### PR TITLE
split bonding curve purchase to optimize gas

### DIFF
--- a/contracts/bondingcurve/EthBondingCurve.sol
+++ b/contracts/bondingcurve/EthBondingCurve.sol
@@ -13,9 +13,18 @@ contract EthBondingCurve is BondingCurve {
 		address core, 
 		address[] memory pcvDeposits, 
 		uint[] memory ratios, 
-		address oracle
-	) public
-		BondingCurve(scale, core, pcvDeposits, ratios, oracle) {}
+		address oracle,
+		uint32 duration,
+		uint incentive
+	) public BondingCurve(
+			scale, 
+			core, 
+			pcvDeposits, 
+			ratios, 
+			oracle, 
+			duration,
+			incentive
+	) {}
 
 	function purchase(address to, uint amountIn) external override payable postGenesis returns (uint amountOut) {
 		require(msg.value == amountIn, "Bonding Curve: Sent value does not equal input");
@@ -36,5 +45,8 @@ contract EthBondingCurve is BondingCurve {
 		IPCVDeposit(pcvDeposit).deposit{value : amount}(amount);
 	}
 
+	function getTotalPCVHeld() public view override returns(uint) {
+		return address(this).balance;
+	}
 }
 

--- a/contracts/bondingcurve/IBondingCurve.sol
+++ b/contracts/bondingcurve/IBondingCurve.sol
@@ -13,6 +13,8 @@ interface IBondingCurve {
 
     event Purchase(address indexed _to, uint _amountIn, uint _amountOut);
 
+	event Allocate(address indexed _caller, uint amount);
+
 	// ----------- State changing Api -----------
 
 	/// @notice purchase FEI for underlying tokens
@@ -21,6 +23,9 @@ interface IBondingCurve {
 	/// @return amountOut amount of FEI received
 	function purchase(address to, uint amountIn) external payable returns (uint amountOut);
 	
+	/// @notice batch allocate held PCV
+	function allocate() external;
+
 	// ----------- Governor only state changing api -----------
 
 	/// @notice sets the bonding curve price buffer
@@ -60,5 +65,10 @@ interface IBondingCurve {
 	/// @notice the total amount of FEI purchased on bonding curve. FEI_b from the whitepaper
 	function totalPurchased() external view returns(uint);
 
+	/// @notice the amount of PCV held in contract and ready to be allocated
+	function getTotalPCVHeld() external view returns(uint);
+
+	/// @notice amount of FEI paid for allocation when incentivized
+	function incentiveAmount() external view returns(uint);
 }
 

--- a/contracts/genesis/GenesisGroup.sol
+++ b/contracts/genesis/GenesisGroup.sol
@@ -113,6 +113,7 @@ contract GenesisGroup is IGenesisGroup, CoreRef, ERC20, ERC20Burnable, Timed {
 		bondingCurveOracle.init(bondingcurve.getAveragePrice(balance));
 
 		bondingcurve.purchase{value: balance}(genesisGroup, balance);
+		bondingcurve.allocate();
 
 		pool.init();
 

--- a/contracts/mock/MockBondingCurve.sol
+++ b/contracts/mock/MockBondingCurve.sol
@@ -6,6 +6,7 @@ import "../external/Decimal.sol";
 contract MockBondingCurve {
 
 	bool public atScale;
+	bool public allocated;
 	Decimal.D256 public getCurrentPrice;
 
 	constructor(bool _atScale, uint256 price) public {
@@ -19,6 +20,10 @@ contract MockBondingCurve {
 
 	function setCurrentPrice(uint256 price) public {
 		getCurrentPrice = Decimal.ratio(price, 100);
+	}
+
+	function allocate() public payable {
+		allocated = true;
 	}
 
 	function purchase(address to, uint amount) public payable returns (uint256 amountOut) {

--- a/contracts/orchestration/BondingCurveOrchestrator.sol
+++ b/contracts/orchestration/BondingCurveOrchestrator.sol
@@ -13,7 +13,9 @@ contract BondingCurveOrchestrator is Ownable {
 		address pair, 
 		address router, 
 		uint scale,
-		uint32 thawingDuration
+		uint32 thawingDuration,
+		uint32 bondingCurveIncentiveDuration,
+		uint bondingCurveIncentiveAmount
 	) public onlyOwner returns(
 		address ethUniswapPCVDeposit,
 		address ethBondingCurve,
@@ -24,8 +26,21 @@ contract BondingCurveOrchestrator is Ownable {
 		ratios[0] = 10000;
 		address[] memory allocations = new address[](1);
 		allocations[0] = address(ethUniswapPCVDeposit);
-		ethBondingCurve = address(new EthBondingCurve(scale, core, allocations, ratios, uniswapOracle));
-		bondingCurveOracle = address(new BondingCurveOracle(core, uniswapOracle, address(ethBondingCurve), thawingDuration));
+		ethBondingCurve = address(new EthBondingCurve(
+			scale, 
+			core, 
+			allocations, 
+			ratios, 
+			uniswapOracle, 
+			bondingCurveIncentiveDuration, 
+			bondingCurveIncentiveAmount
+		));
+		bondingCurveOracle = address(new BondingCurveOracle(
+			core, 
+			uniswapOracle, 
+			ethBondingCurve, 
+			thawingDuration
+		));
 		return (
 			ethUniswapPCVDeposit,
 			ethBondingCurve,

--- a/contracts/orchestration/CoreOrchestrator.sol
+++ b/contracts/orchestration/CoreOrchestrator.sol
@@ -16,7 +16,9 @@ interface IBondingCurveOrchestrator {
 		address pair, 
 		address router, 
 		uint scale,
-		uint32 thawingDuration
+		uint32 thawingDuration,
+		uint32 bondingCurveIncentiveDuration,
+		uint bondingCurveIncentiveAmount
 	) external returns(
 		address ethUniswapPCVDeposit,
 		address ethBondingCurve,
@@ -115,6 +117,8 @@ contract CoreOrchestrator is Ownable {
 
 	uint32 public constant UNI_ORACLE_TWAP_DURATION = TEST_MODE ? 1 : 10 minutes; // 10 min twap
 
+	uint32 public constant BONDING_CURVE_INCENTIVE_DURATION = TEST_MODE ? 1 : 1 days; // 1 day duration
+
 	// ----------- Params -----------
 	uint public constant MAX_GENESIS_PRICE_BPS = 9000;
 	uint public constant EXCHANGE_RATE_DISCOUNT = 10;
@@ -122,8 +126,9 @@ contract CoreOrchestrator is Ownable {
 	uint32 public constant INCENTIVE_GROWTH_RATE = TEST_MODE ? 1_000_000 : 333; // about 1 unit per hour assuming 12s block time
 
 	uint public constant SCALE = 250_000_000e18;
+	uint public constant BONDING_CURVE_INCENTIVE = 500e18;
 
-	uint public constant REWEIGHT_INCENTIVE = 100e18;
+	uint public constant REWEIGHT_INCENTIVE = 500e18;
 	uint public constant MIN_REWEIGHT_DISTANCE_BPS = 100;
 
 	bool public constant USDC_PER_ETH_IS_PRICE_0 = true;
@@ -208,7 +213,17 @@ contract CoreOrchestrator is Ownable {
 	function initBondingCurve() public onlyOwner {
 		(ethUniswapPCVDeposit,
 		 ethBondingCurve,
-		 bondingCurveOracle) = bcOrchestrator.init(address(core), uniswapOracle, ethFeiPair, ROUTER, SCALE, THAWING_DURATION);
+		 bondingCurveOracle) = bcOrchestrator.init(
+			 address(core), 
+			 uniswapOracle, 
+			 ethFeiPair, 
+			 ROUTER, 
+			 SCALE, 
+			 THAWING_DURATION,
+			 BONDING_CURVE_INCENTIVE_DURATION,
+			 BONDING_CURVE_INCENTIVE
+		);
+
 		core.grantMinter(ethUniswapPCVDeposit);
 		core.grantMinter(ethBondingCurve);
 		IOracleRef(ethUniswapPCVDeposit).setOracle(bondingCurveOracle);

--- a/test/genesis/GenesisGroup.test.js
+++ b/test/genesis/GenesisGroup.test.js
@@ -144,6 +144,10 @@ describe('GenesisGroup', function () {
           expect(await balance.current(this.bc.address)).to.be.bignumber.equal(new BN(1000));
         });
 
+        it('allocates bonding curve', async function() {
+          expect(await this.bc.allocated()).to.be.equal(true);
+        });
+
         it('deploys IDO', async function() {
           expect(await this.ido.ratio()).to.be.bignumber.equal(new BN('5000000000000000000').div(new BN(10)));
         });
@@ -191,6 +195,10 @@ describe('GenesisGroup', function () {
       it('purchases on bondingCurve', async function() {
         expect(await balance.current(this.genesisGroup.address)).to.be.bignumber.equal(new BN(0));
         expect(await balance.current(this.bc.address)).to.be.bignumber.equal(new BN(1000));
+      });
+
+      it('allocates bonding curve', async function() {
+        expect(await this.bc.allocated()).to.be.equal(true);
       });
 
       it('deploys IDO', async function() {


### PR DESCRIPTION
Splits up the bonding curve purchase flow into "purchase" and "allocate". This saves the average purchaser from incurring the allocation gas costs and batches them.

Purchase gas before 300k

Purchase gas after 100k
Allocate gas after 230k

Allocation is incentivized over a time window that resets each period but it can be called any time.