### PR TITLE
Fix Reweight Rounding Errors

### DIFF
--- a/contracts/pcv/EthUniswapPCVController.sol
+++ b/contracts/pcv/EthUniswapPCVController.sol
@@ -86,7 +86,7 @@ contract EthUniswapPCVController is IUniswapPCVController, UniRef {
 	}
 
 	function _reweight() internal {
-		_withdrawAll();
+		_withdraw();
 		_returnToPeg();
 
 		uint balance = address(this).balance;
@@ -125,8 +125,8 @@ contract EthUniswapPCVController is IUniswapPCVController, UniRef {
 		pair.swap(amount0Out, amount1Out, address(this), new bytes(0));
 	}
 
-	function _withdrawAll() internal {
-		uint value = pcvDeposit.totalValue();
+	function _withdraw() internal {
+		uint value = pcvDeposit.totalValue() * 9 / 10; // Only withdraw 90% to prevent rounding errors on Uni LP dust
 		pcvDeposit.withdraw(address(this), value);
 	}
 }

--- a/test/pcv/EthUniswapPCVController.test.js
+++ b/test/pcv/EthUniswapPCVController.test.js
@@ -121,12 +121,12 @@ describe('EthUniswapPCVController', function () {
           await this.pcvController.forceReweight({from: governorAddress});
         });
 
-        it('pair gets all ETH in swap', async function() {
-          expect(await this.token.balanceOf(this.pair.address)).to.be.bignumber.equal(new BN(100000));
+        it('pair gets all withdrawn ETH in swap', async function() {
+          expect(await this.token.balanceOf(this.pair.address)).to.be.bignumber.equal(new BN(90000));
         });
 
-        it('pcvDeposit gets no ETH', async function() {
-          expect(await this.pcvDeposit.totalValue()).to.be.bignumber.equal(new BN(0));
+        it('pcvDeposit only keeps non-withdrawn ETH', async function() {
+          expect(await this.pcvDeposit.totalValue()).to.be.bignumber.equal(new BN(10000));
           expect(await balance.current(this.pcvController.address)).to.be.bignumber.equal(new BN(0));
         });
 


### PR DESCRIPTION
Resolves OpenZeppelin audit issue client reported 02

If a reweight happens when the protocol is the only LP, the dust left in Uniswap prevents accuracy when reweighting the peg. The error can be over 5% at times. 

The proposed solution is to only withdraw 90% of the LP, leaving plenty of room for a granular peg reweighting. The rounding error is now within a few basis points as opposed to large single digit percentages.

