### PR TITLE
Move Incentives to After Transfer

### DIFF
--- a/contracts/token/Fei.sol
+++ b/contracts/token/Fei.sol
@@ -56,11 +56,9 @@ contract Fei is IFei, ERC20, ERC20Burnable, CoreRef {
         emit Burning(account, msg.sender, amount);
     }
 
-    function _beforeTokenTransfer(address from, address to, uint amount) internal override {
-        // If not minting or burning
-        if (from != address(0) && to != address(0)) {
-            _checkAndApplyIncentives(from, to, amount);      
-        }
+    function _transfer(address sender, address recipient, uint256 amount) internal override {
+        super._transfer(sender, recipient, amount);
+        _checkAndApplyIncentives(sender, recipient, amount);
     }
 
     function _checkAndApplyIncentives(address sender, address recipient, uint amount) internal {

--- a/test/token/UniswapIncentive.test.js
+++ b/test/token/UniswapIncentive.test.js
@@ -268,6 +268,7 @@ describe('UniswapIncentive', function () {
     describe('Sell', function() {
       describe('not allowed seller', function() {
         it('reverts', async function() {
+          await this.fei.mint(secondUserAddress, 1000000, {from: minterAddress});
           await expectRevert(this.fei.transfer(this.pair.address, 500000, {from: secondUserAddress}), "UniswapIncentive: Blocked Fei sender or operator");
         });
       });


### PR DESCRIPTION
This is not a bug fix but it is <5 lines and important. If you have time OpenZeppelin please review otherwise let me know and ignore.

This allows us to do "fee on transfer" models more easily in the future as the balance updates of the transfer have already been applied. 

Should strictly increase future feature possibilities without hindering existing functionality