### PR TITLE
Outdated oracle prices

### DIFF
--- a/contracts/bondingcurve/IBondingCurve.sol
+++ b/contracts/bondingcurve/IBondingCurve.sol
@@ -41,16 +41,19 @@ interface IBondingCurve {
 
 	/// @notice return current instantaneous bonding curve price 
 	/// @return price reported as FEI per X with X being the underlying asset
+	/// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
 	function getCurrentPrice() external view returns(Decimal.D256 memory);
 
 	/// @notice return the average price of a transaction along bonding curve
 	/// @param amountIn the amount of underlying used to purchase
 	/// @return price reported as FEI per X with X being the underlying asset
+	/// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
 	function getAveragePrice(uint amountIn) external view returns (Decimal.D256 memory);
 
 	/// @notice return amount of FEI received after a bonding curve purchase
 	/// @param amountIn the amount of underlying used to purchase
 	/// @return amountOut the amount of FEI received
+	/// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
 	function getAmountOut(uint amountIn) external view returns (uint amountOut); 
 
 	/// @notice the Scale target at which bonding curve price fixes

--- a/contracts/mock/MockOracle.sol
+++ b/contracts/mock/MockOracle.sol
@@ -8,9 +8,10 @@ contract MockOracle is IOracle {
     using Decimal for Decimal.D256;
 
     // fixed exchange ratio
-    uint256 _usdPerEth;
+    uint256 public _usdPerEth;
 	bool public override killSwitch;
     bool public updated;
+    bool public outdated;
     bool public valid = true;
 
     constructor(uint256 usdPerEth) public {
@@ -25,6 +26,14 @@ contract MockOracle is IOracle {
     function read() public view override returns (Decimal.D256 memory, bool) {
         Decimal.D256 memory price = Decimal.from(_usdPerEth); 
         return (price, valid);
+    }
+
+    function isOutdated() public view override returns(bool) {
+        return outdated;
+    }
+
+    function setOutdated(bool _outdated) public {
+        outdated = _outdated;
     }
 
     function setValid(bool isValid) public {

--- a/contracts/oracle/BondingCurveOracle.sol
+++ b/contracts/oracle/BondingCurveOracle.sol
@@ -41,6 +41,10 @@ contract BondingCurveOracle is IBondingCurveOracle, CoreRef, Timed {
 		return uniswapOracle.update();
 	}
 
+	function isOutdated() external view override returns(bool) {
+		return uniswapOracle.isOutdated();
+	}
+
     function read() external view override returns (Decimal.D256 memory, bool) {
     	if (killSwitch) {
     		return (Decimal.zero(), false);

--- a/contracts/oracle/IOracle.sol
+++ b/contracts/oracle/IOracle.sol
@@ -30,8 +30,13 @@ interface IOracle {
     /// @notice read the oracle price
     /// @return oracle price
     /// @return true if price is valid
-    /// @dev price is to be denominated in USD per X where X can be ETH, etc.
+    /// @dev price is to be denominated in USD per X where X can be ETH, etc. 
+    /// @dev Can be innacurate if outdated, need to call `isOutdated()` to check
     function read() external view returns (Decimal.D256 memory, bool);
+
+    /// @notice determine if read value is stale
+    /// @return true if read value is stale
+    function isOutdated() external view returns(bool);
 
     /// @notice the kill switch for the oracle feed
     /// @return true if kill switch engaged

--- a/contracts/oracle/UniswapOracle.sol
+++ b/contracts/oracle/UniswapOracle.sol
@@ -68,6 +68,12 @@ contract UniswapOracle is IUniswapOracle, CoreRef {
 		return true;
 	}
 
+	function isOutdated() external view override returns(bool) {
+		(,, uint32 currentTimestamp) = UniswapV2OracleLibrary.currentCumulativePrices(address(pair));
+		uint32 deltaTimestamp = currentTimestamp - priorTimestamp;
+		return deltaTimestamp >= duration;
+	}
+
     function read() external view override returns (Decimal.D256 memory, bool) {
     	bool valid = !(killSwitch || twap.isZero());
     	return (twap, valid);

--- a/contracts/pcv/EthUniswapPCVController.sol
+++ b/contracts/pcv/EthUniswapPCVController.sol
@@ -51,6 +51,7 @@ contract EthUniswapPCVController is IUniswapPCVController, UniRef {
 	receive() external payable {}
 
 	function reweight() external override postGenesis {
+		updateOracle();
 		require(reweightEligible(), "EthUniswapPCVController: Not at incentive parity or not at min distance");
 		_reweight();
 		_incentivize();

--- a/test/oracle/BondingCurveOracle.test.js
+++ b/test/oracle/BondingCurveOracle.test.js
@@ -30,6 +30,14 @@ describe('BondingCurveOracle', function () {
     });
   });
 
+  describe('isOutdated', function() {
+    it('reads uniswapOracle', async function() {
+      expect(await this.oracle.isOutdated()).to.be.equal(false);
+      await this.mockOracle.setOutdated(true);
+      expect(await this.oracle.isOutdated()).to.be.equal(true);
+    });
+  });
+
   describe('Read', function() {
     describe('Uninitialized', function() {
       it('returns invalid', async function() {

--- a/test/oracle/UniswapOracle.test.js
+++ b/test/oracle/UniswapOracle.test.js
@@ -82,6 +82,10 @@ describe('UniswapOracle', function () {
         expect(await this.oracle.priorCumulative()).to.be.bignumber.equal(this.priorCumulativePrice);
         expect(await this.oracle.priorTimestamp()).to.be.bignumber.equal(this.cursor);
       });
+
+      it('not outdated', async function() {
+        expect(await this.oracle.isOutdated()).to.be.equal(false);
+      });
     });
 
     describe('Exceeds duration', function() {
@@ -91,6 +95,10 @@ describe('UniswapOracle', function () {
         await this.pair.set(this.expectedCumulative, 0, this.expectedTime);
         await this.pair.setReserves(100000, 50000000);
         await time.increase(this.delta);
+      });
+
+      it('outdated', async function() {
+        expect(await this.oracle.isOutdated()).to.be.equal(true);
       });
 
       it('updates', async function() {


### PR DESCRIPTION
This is intended to fix OpenZeppelin audit report issue H02.

The idea is to add introspection into whether an oracle has a stale value via new `IOracle` interface method `isOutdated()`. Callers of the public read functions which rely on the oracle can check isOutdated and perform an update call if their flow depends on the accuracy of the info. We flag these methods that rely on the oracle in the dev section of the natspec.

We also add an `updateOracle()` call to the reweight function.

All non-view user flows that rely on the peg should update the oracle at the beginning. The view functions except `isAtMaxPrice()` which is deleted in another PR should all call out the dependency in the natspec