### PR TITLE
Set tribe from core

### DIFF
--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -35,6 +35,11 @@ contract Core is ICore, Permissions {
 		emit FeiUpdate(token);
 	}
 
+	function setTribe(address token) external override onlyGovernor {
+		tribe = IERC20(token);
+		emit TribeUpdate(token);
+	}
+
 	function setGenesisGroup(address _genesisGroup) external override onlyGovernor {
 		genesisGroup = _genesisGroup;
 	}

--- a/contracts/core/ICore.sol
+++ b/contracts/core/ICore.sol
@@ -13,6 +13,7 @@ interface ICore is IPermissions {
 	// ----------- Events -----------
 
     event FeiUpdate(address indexed _fei);
+    event TribeUpdate(address indexed _tribe);
     event TribeAllocation(address indexed _to, uint _amount);
     event GenesisPeriodComplete(uint _timestamp);
 
@@ -21,6 +22,10 @@ interface ICore is IPermissions {
     /// @notice sets Fei address to a new address
     /// @param token new fei address
     function setFei(address token) external;
+
+    /// @notice sets Tribe address to a new address
+    /// @param token new tribe address
+    function setTribe(address token) external;
 
     /// @notice sets Genesis Group address
     /// @param _genesisGroup new genesis group address

--- a/test/core/Core.test.js
+++ b/test/core/Core.test.js
@@ -72,6 +72,23 @@ describe('Core', function () {
 	});
   });
 
+  describe('Tribe Update', function() {
+    it('updates', async function() {
+      expectEvent(
+        await this.core.setTribe(userAddress, {from: governorAddress}),
+        'TribeUpdate',
+        {
+          _tribe : userAddress
+        }
+      );
+      expect(await this.core.tribe()).to.be.equal(userAddress);
+	});
+	
+	it('non governor reverts', async function() {
+		await expectRevert(this.core.setTribe(userAddress, {from: userAddress}), "Permissions: Caller is not a governor");
+	});
+  });
+
   describe('Genesis', function() {
     describe('Genesis Group', function() {
       it('governor set succeeds', async function() {


### PR DESCRIPTION
This isn't a bug fix or in scope but if OpenZeppelin has time to take a look at this it is much appreciated!

Similar to FEI, we want to be able to set TRIBE from Core in the event of a governance upgrade.

