### PR TITLE
Consistent block times

### DIFF
--- a/contracts/dao/GovernorAlpha.sol
+++ b/contracts/dao/GovernorAlpha.sol
@@ -18,10 +18,10 @@ contract GovernorAlpha {
     function proposalMaxOperations() public pure returns (uint) { return 10; } // 10 actions
 
     /// @notice The delay before voting on a proposal may take place, once proposed
-    function votingDelay() public pure returns (uint) { return 1; } // 1 block
+    function votingDelay() public pure returns (uint) { return 3333; } // ~0.5 days in blocks (assuming 13s blocks)
 
     /// @notice The duration of voting on a proposal, in blocks
-    function votingPeriod() public pure returns (uint) { return 17280; } // ~3 days in blocks (assuming 15s blocks)
+    function votingPeriod() public pure returns (uint) { return 10000; } // ~1.5 days in blocks (assuming 13s blocks)
 
     /// @notice The address of the Fei Protocol Timelock
     TimelockInterface public timelock;

--- a/contracts/orchestration/CoreOrchestrator.sol
+++ b/contracts/orchestration/CoreOrchestrator.sol
@@ -147,7 +147,7 @@ contract CoreOrchestrator is Ownable {
 	// ----------- Params -----------
 	uint public constant EXCHANGE_RATE_DISCOUNT = 10;
 
-	uint32 public constant INCENTIVE_GROWTH_RATE = 66; // about 1 unit per 5 hours assuming 12s block time
+	uint32 public constant INCENTIVE_GROWTH_RATE = 75; // a bit over 1 unit per 5 hours assuming 13s block time
 
 	uint public constant SCALE = 100_000_000e18;
 	uint public constant BONDING_CURVE_INCENTIVE = 500e18;


### PR DESCRIPTION
Fixes OZ audit issue N05. Uses 13s as expected block time

updates voting delay to 3333 blocks (about 12h)
updates voting period to 10000 blocks (about 36h)