### PR TITLE
Assert Invariants

### DIFF
--- a/contracts/genesis/GenesisGroup.sol
+++ b/contracts/genesis/GenesisGroup.sol
@@ -181,8 +181,8 @@ contract GenesisGroup is IGenesisGroup, CoreRef, ERC20, Timed {
 		uint total = heldFGEN.add(committed);
 
 		require(total != 0, "GenesisGroup: No FGEN or committed balance");
-		require(address(this).balance >= total, "GenesisGroup: Not enough ETH to redeem");
 		require(msg.sender == from || allowance(from, msg.sender) >= total, "GenesisGroup: Not approved for emergency withdrawal");
+		assert(address(this).balance >= total); // ETH can only be removed by launch which blocks this method or this method in event of launch failure
 
 		_burnFrom(from, heldFGEN);
 		committedFGEN[from] = 0;

--- a/test/genesis/GenesisGroup.test.js
+++ b/test/genesis/GenesisGroup.test.js
@@ -544,6 +544,13 @@ describe('GenesisGroup', function () {
               expect(await this.genesisGroup.totalCommittedTribe()).to.be.bignumber.equal(new BN('0'));
               expect(await this.genesisGroup.totalCommittedFGEN()).to.be.bignumber.equal(new BN('0'));
             });
+
+            it('nothing left to redeem', async function() {
+              let remaining = await this.genesisGroup.getAmountsToRedeem(userAddress);
+              expect(remaining.feiAmount).to.be.bignumber.equal(new BN('0'));
+              expect(remaining.genesisTribe).to.be.bignumber.equal(new BN('0'));
+              expect(remaining.idoTribe).to.be.bignumber.equal(new BN('0'));
+            });
           });
         });
       });

--- a/test/genesis/IDO.test.js
+++ b/test/genesis/IDO.test.js
@@ -48,6 +48,12 @@ describe('IDO', function () {
       });
     });
 
+    describe('Bad Beneficiary', function() {
+      it('reverts', async function() {
+        await expectRevert(IDO.new(this.core.address, ZERO_ADDRESS, this.window, this.pair.address, this.router.address), "LinearTokenTimelock: Beneficiary must not be 0 address");
+      });
+    });
+
     it('pair', async function() {
       expect(await this.ido.pair()).to.be.equal(this.pair.address);
     });


### PR DESCRIPTION
Fixes OZ audit issue N04

In the report they cited methods in Pool.sol which now use SafeMath so no longer "require" on an invariant.

I re-ran solidity coverage and checked branch coverage to find require statements I hadn't hit in tests to see if any could be an invariant. I added tests for two uncovered branches that were not invariants and found only one invariant in `GenesisGroup`