### PR TITLE
Events Cleanup

### DIFF
--- a/contracts/bondingcurve/BondingCurve.sol
+++ b/contracts/bondingcurve/BondingCurve.sol
@@ -49,7 +49,6 @@ abstract contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed {
 
 	function setScale(uint _scale) external override onlyGovernor {
 		_setScale(_scale);
-		emit ScaleUpdate(_scale);
 	}
 
 	function setBuffer(uint _buffer) external override onlyGovernor {
@@ -122,6 +121,7 @@ abstract contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed {
 
 	function _setScale(uint _scale) internal {
 		scale = _scale;
+		emit ScaleUpdate(_scale);
 	}
 
 	function _incentivize() internal virtual {

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -22,24 +22,24 @@ contract Core is ICore, Permissions {
 
 	function init() external onlyGovernor {
 		Fei _fei = new Fei(address(this));
-		fei = IFei(address(_fei));
+		_setFei(address(_fei));
 
 		Tribe _tribe = new Tribe(address(this), msg.sender);
-		tribe = IERC20(address(_tribe));
+		_setTribe(address(_tribe));
+
 	}
 
 	function setFei(address token) external override onlyGovernor {
-		fei = IFei(token);
-		emit FeiUpdate(token);
+		_setFei(token);
 	}
 
 	function setTribe(address token) external override onlyGovernor {
-		tribe = IERC20(token);
-		emit TribeUpdate(token);
+		_setTribe(token);
 	}
 
 	function setGenesisGroup(address _genesisGroup) external override onlyGovernor {
 		genesisGroup = _genesisGroup;
+		emit GenesisGroupUpdate(_genesisGroup);
 	}
 
 	function allocateTribe(address to, uint amount) external override onlyGovernor {
@@ -59,6 +59,16 @@ contract Core is ICore, Permissions {
 
 		// solhint-disable-next-line not-rely-on-time
 		emit GenesisPeriodComplete(block.timestamp);
+	}
+
+	function _setFei(address token) internal {
+		fei = IFei(token);
+		emit FeiUpdate(token);
+	}
+
+	function _setTribe(address token) internal {
+		tribe = IERC20(token);
+		emit TribeUpdate(token);
 	}
 }
 

--- a/contracts/core/ICore.sol
+++ b/contracts/core/ICore.sol
@@ -14,6 +14,7 @@ interface ICore is IPermissions {
 
     event FeiUpdate(address indexed _fei);
     event TribeUpdate(address indexed _tribe);
+    event GenesisGroupUpdate(address indexed _genesisGroup);
     event TribeAllocation(address indexed _to, uint _amount);
     event GenesisPeriodComplete(uint _timestamp);
 

--- a/contracts/oracle/BondingCurveOracle.sol
+++ b/contracts/oracle/BondingCurveOracle.sol
@@ -20,8 +20,6 @@ contract BondingCurveOracle is IBondingCurveOracle, CoreRef, Timed {
 	/// @dev this price will "thaw" to the peg price over `duration` window
 	Decimal.D256 public initialPrice;
 
-	event KillSwitchUpdate(bool _killSwitch);
-
 	/// @notice BondingCurveOracle constructor
 	/// @param _core Fei Core to reference
 	/// @param _oracle Uniswap Oracle to report from

--- a/contracts/refs/OracleRef.sol
+++ b/contracts/refs/OracleRef.sol
@@ -20,7 +20,6 @@ abstract contract OracleRef is IOracleRef, CoreRef {
 
 	function setOracle(address _oracle) external override onlyGovernor {
 		_setOracle(_oracle);
-        emit OracleUpdate(_oracle);
 	}
 
     function invert(Decimal.D256 memory price) public override pure returns(Decimal.D256 memory) {
@@ -39,5 +38,6 @@ abstract contract OracleRef is IOracleRef, CoreRef {
 
     function _setOracle(address _oracle) internal {
     	oracle = IOracle(_oracle);
+		emit OracleUpdate(_oracle);
     }
 }

--- a/test/core/Core.test.js
+++ b/test/core/Core.test.js
@@ -92,7 +92,13 @@ describe('Core', function () {
   describe('Genesis', function() {
     describe('Genesis Group', function() {
       it('governor set succeeds', async function() {
-        await this.core.setGenesisGroup(genesisGroup, {from: governorAddress});
+		expectEvent(
+			await this.core.setGenesisGroup(genesisGroup, {from: governorAddress}),
+			'GenesisGroupUpdate',
+			{
+			  _genesisGroup : genesisGroup
+			}
+		);
         expect(await this.core.genesisGroup()).to.be.equal(genesisGroup);
       });
 


### PR DESCRIPTION
Fixes OZ audit report issues N13 and N19.

Elected not to change events to include old update values