### PR TITLE
Style Cleanup

### DIFF
--- a/contracts/bondingcurve/BondingCurve.sol
+++ b/contracts/bondingcurve/BondingCurve.sol
@@ -12,135 +12,176 @@ import "../utils/Timed.sol";
 /// @author Fei Protocol
 abstract contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed {
     using Decimal for Decimal.D256;
-    using Roots for uint;
+    using Roots for uint256;
 
-	uint public override scale;
-	uint public override totalPurchased; // FEI_b for this curve
+    uint256 public override scale;
+    uint256 public override totalPurchased; // FEI_b for this curve
 
-	uint public override buffer = 100;
-	uint public constant BUFFER_GRANULARITY = 10_000;
+    uint256 public override buffer = 100;
+    uint256 public constant BUFFER_GRANULARITY = 10_000;
 
-	uint public override incentiveAmount;
+    uint256 public override incentiveAmount;
 
-	/// @notice constructor
-	/// @param _scale the Scale target where peg fixes
-	/// @param _core Fei Core to reference
-	/// @param _pcvDeposits the PCV Deposits for the PCVSplitter
-	/// @param _ratios the ratios for the PCVSplitter
-	/// @param _oracle the UniswapOracle to reference
-	/// @param _duration the duration between incentivizing allocations
-	/// @param _incentive the amount rewarded to the caller of an allocation
-	constructor(
-		uint _scale, 
-		address _core, 
-		address[] memory _pcvDeposits, 
-		uint[] memory _ratios, 
-		address _oracle,
-		uint _duration,
-		uint _incentive
-	) public
-		OracleRef(_core, _oracle)
-		PCVSplitter(_pcvDeposits, _ratios)
-		Timed(_duration)
-	{
-		_setScale(_scale);
-		incentiveAmount = _incentive;
-	}
+    /// @notice constructor
+    /// @param _scale the Scale target where peg fixes
+    /// @param _core Fei Core to reference
+    /// @param _pcvDeposits the PCV Deposits for the PCVSplitter
+    /// @param _ratios the ratios for the PCVSplitter
+    /// @param _oracle the UniswapOracle to reference
+    /// @param _duration the duration between incentivizing allocations
+    /// @param _incentive the amount rewarded to the caller of an allocation
+    constructor(
+        uint256 _scale,
+        address _core,
+        address[] memory _pcvDeposits,
+        uint256[] memory _ratios,
+        address _oracle,
+        uint256 _duration,
+        uint256 _incentive
+    )
+        public
+        OracleRef(_core, _oracle)
+        PCVSplitter(_pcvDeposits, _ratios)
+        Timed(_duration)
+    {
+        _setScale(_scale);
+        incentiveAmount = _incentive;
+    }
 
-	function setScale(uint _scale) external override onlyGovernor {
-		_setScale(_scale);
-	}
+    function setScale(uint256 _scale) external override onlyGovernor {
+        _setScale(_scale);
+    }
 
-	function setBuffer(uint _buffer) external override onlyGovernor {
-		require(_buffer < BUFFER_GRANULARITY, "BondingCurve: Buffer exceeds or matches granularity");
-		buffer = _buffer;
-		emit BufferUpdate(_buffer);
-	}
+    function setBuffer(uint256 _buffer) external override onlyGovernor {
+        require(
+            _buffer < BUFFER_GRANULARITY,
+            "BondingCurve: Buffer exceeds or matches granularity"
+        );
+        buffer = _buffer;
+        emit BufferUpdate(_buffer);
+    }
 
-	function setAllocation(address[] calldata allocations, uint[] calldata ratios) external override onlyGovernor {
-		_setAllocation(allocations, ratios);
-	}
+    function setAllocation(
+        address[] calldata allocations,
+        uint256[] calldata ratios
+    ) external override onlyGovernor {
+        _setAllocation(allocations, ratios);
+    }
 
-	function allocate() external override {
-		uint amount = getTotalPCVHeld();
-		require(amount != 0, "BondingCurve: No PCV held");
+    function allocate() external override {
+        uint256 amount = getTotalPCVHeld();
+        require(amount != 0, "BondingCurve: No PCV held");
 
-		_allocate(amount);
-		_incentivize();
-		
-		emit Allocate(msg.sender, amount);
-	}
+        _allocate(amount);
+        _incentivize();
 
-	function atScale() public override view returns (bool) {
-		return totalPurchased >= scale;
-	}
+        emit Allocate(msg.sender, amount);
+    }
 
-	function getCurrentPrice() public view override returns(Decimal.D256 memory) {
-		if (atScale()) {
-			return peg().mul(_getBuffer());
-		}
-		return peg().div(_getBondingCurvePriceMultiplier());
-	}
+    function atScale() public view override returns (bool) {
+        return totalPurchased >= scale;
+    }
 
-	function getAmountOut(uint amountIn) public view override returns (uint amountOut) {
-		uint adjustedAmount = getAdjustedAmount(amountIn);
-		amountOut = _getBufferAdjustedAmount(adjustedAmount);
-		if (atScale()) {
-			return amountOut;
-		}
-		return Math.max(amountOut, _getBondingCurveAmountOut(adjustedAmount)); // Cap price at buffer adjusted
-	}
+    function getCurrentPrice()
+        public
+        view
+        override
+        returns (Decimal.D256 memory)
+    {
+        if (atScale()) {
+            return peg().mul(_getBuffer());
+        }
+        return peg().div(_getBondingCurvePriceMultiplier());
+    }
 
-	function getAveragePrice(uint amountIn) public view override returns (Decimal.D256 memory) {
-		uint adjustedAmount = getAdjustedAmount(amountIn);
-		uint amountOut = getAmountOut(amountIn);
-		return Decimal.ratio(adjustedAmount, amountOut);
-	}
+    function getAmountOut(uint256 amountIn)
+        public
+        view
+        override
+        returns (uint256 amountOut)
+    {
+        uint256 adjustedAmount = _getAdjustedAmount(amountIn);
+        amountOut = _getBufferAdjustedAmount(adjustedAmount);
+        if (atScale()) {
+            return amountOut;
+        }
+        return Math.max(amountOut, _getBondingCurveAmountOut(adjustedAmount)); // Cap price at buffer adjusted
+    }
 
-	function getAdjustedAmount(uint amountIn) internal view returns (uint) {
-		return peg().mul(amountIn).asUint256();
-	}
+    function getAveragePrice(uint256 amountIn)
+        public
+        view
+        override
+        returns (Decimal.D256 memory)
+    {
+        uint256 adjustedAmount = _getAdjustedAmount(amountIn);
+        uint256 amountOut = getAmountOut(amountIn);
+        return Decimal.ratio(adjustedAmount, amountOut);
+    }
 
-	function getTotalPCVHeld() public view override virtual returns(uint);
+    function getTotalPCVHeld() public view virtual override returns (uint256);
 
-	function _purchase(uint amountIn, address to) internal returns (uint amountOut) {
-	 	updateOracle();
-		
-	 	amountOut = getAmountOut(amountIn);
-	 	incrementTotalPurchased(amountOut);
-		fei().mint(to, amountOut);
+    function _getAdjustedAmount(uint256 amountIn)
+        internal
+        view
+        returns (uint256)
+    {
+        return peg().mul(amountIn).asUint256();
+    }
 
-		emit Purchase(to, amountIn, amountOut);
+    function _purchase(uint256 amountIn, address to)
+        internal
+        returns (uint256 amountOut)
+    {
+        updateOracle();
 
-		return amountOut;
-	}
+        amountOut = getAmountOut(amountIn);
+        _incrementTotalPurchased(amountOut);
+        fei().mint(to, amountOut);
 
-	function incrementTotalPurchased(uint amount) internal {
-		totalPurchased = totalPurchased.add(amount);
-	}
+        emit Purchase(to, amountIn, amountOut);
 
-	function _setScale(uint _scale) internal {
-		scale = _scale;
-		emit ScaleUpdate(_scale);
-	}
+        return amountOut;
+    }
 
-	function _incentivize() internal virtual {
-		if (isTimeEnded()) {
-			_initTimed();
-			fei().mint(msg.sender, incentiveAmount);
-		}
-	}
+    function _incrementTotalPurchased(uint256 amount) internal {
+        totalPurchased = totalPurchased.add(amount);
+    }
 
-	function _getBondingCurvePriceMultiplier() internal view virtual returns(Decimal.D256 memory);
+    function _setScale(uint256 _scale) internal {
+        scale = _scale;
+        emit ScaleUpdate(_scale);
+    }
 
-	function _getBondingCurveAmountOut(uint adjustedAmountIn) internal view virtual returns(uint);
+    function _incentivize() internal virtual {
+        if (isTimeEnded()) {
+            _initTimed();
+            fei().mint(msg.sender, incentiveAmount);
+        }
+    }
 
-	function _getBuffer() internal view returns(Decimal.D256 memory) {
-		uint granularity = BUFFER_GRANULARITY;
-		return Decimal.ratio(granularity - buffer, granularity);
-	} 
+    function _getBondingCurvePriceMultiplier()
+        internal
+        view
+        virtual
+        returns (Decimal.D256 memory);
 
-	function _getBufferAdjustedAmount(uint amountIn) internal view returns(uint) {
-		return _getBuffer().mul(amountIn).asUint256();
-	}
+    function _getBondingCurveAmountOut(uint256 adjustedAmountIn)
+        internal
+        view
+        virtual
+        returns (uint256);
+
+    function _getBuffer() internal view returns (Decimal.D256 memory) {
+        uint256 granularity = BUFFER_GRANULARITY;
+        return Decimal.ratio(granularity - buffer, granularity);
+    }
+
+    function _getBufferAdjustedAmount(uint256 amountIn)
+        internal
+        view
+        returns (uint256)
+    {
+        return _getBuffer().mul(amountIn).asUint256();
+    }
 }

--- a/contracts/bondingcurve/EthBondingCurve.sol
+++ b/contracts/bondingcurve/EthBondingCurve.sol
@@ -7,56 +7,84 @@ import "../pcv/IPCVDeposit.sol";
 /// @title a square root growth bonding curve for purchasing FEI with ETH
 /// @author Fei Protocol
 contract EthBondingCurve is BondingCurve {
+    // solhint-disable-next-line var-name-mixedcase
+    uint256 internal immutable SHIFT; // k shift
 
-	uint internal immutable SHIFT; // k shift
+    constructor(
+        uint256 scale,
+        address core,
+        address[] memory pcvDeposits,
+        uint256[] memory ratios,
+        address oracle,
+        uint256 duration,
+        uint256 incentive
+    )
+        public
+        BondingCurve(
+            scale,
+            core,
+            pcvDeposits,
+            ratios,
+            oracle,
+            duration,
+            incentive
+        )
+    {
+        SHIFT = scale / 3; // Enforces a .50c starting price per bonding curve formula
+    }
 
-	constructor(
-		uint scale, 
-		address core, 
-		address[] memory pcvDeposits, 
-		uint[] memory ratios, 
-		address oracle,
-		uint duration,
-		uint incentive
-	) public BondingCurve(
-			scale, 
-			core, 
-			pcvDeposits, 
-			ratios, 
-			oracle, 
-			duration,
-			incentive
-	) {
-		SHIFT = scale / 3; // Enforces a .50c starting price per bonding curve formula
-	}
+    function purchase(address to, uint256 amountIn)
+        external
+        payable
+        override
+        postGenesis
+        returns (uint256 amountOut)
+    {
+        require(
+            msg.value == amountIn,
+            "Bonding Curve: Sent value does not equal input"
+        );
+        return _purchase(amountIn, to);
+    }
 
-	function purchase(address to, uint amountIn) external override payable postGenesis returns (uint amountOut) {
-		require(msg.value == amountIn, "Bonding Curve: Sent value does not equal input");
-		return _purchase(amountIn, to);
-	}
+    function getTotalPCVHeld() public view override returns (uint256) {
+        return address(this).balance;
+    }
 
-	function getTotalPCVHeld() public view override returns(uint) {
-		return address(this).balance;
-	}
+    // Represents the integral solved for upper bound of P(x) = ((k+X)/(k+S))^1/2 * O. Subtracting starting point C
+    function _getBondingCurveAmountOut(uint256 adjustedAmountIn)
+        internal
+        view
+        override
+        returns (uint256 amountOut)
+    {
+        uint256 shiftTotal = _shift(totalPurchased); // k + C
+        uint256 shiftTotalCubed = shiftTotal.mul(shiftTotal.mul(shiftTotal));
+        uint256 radicand =
+            (adjustedAmountIn.mul(3).mul(_shift(scale).sqrt()) / 2).add(
+                shiftTotalCubed.sqrt()
+            );
+        return (radicand.mul(radicand)).cubeRoot() - shiftTotal; // result - (k + C)
+    }
 
-	// Represents the integral solved for upper bound of P(x) = ((k+X)/(k+S))^1/2 * O. Subtracting starting point C
-	function _getBondingCurveAmountOut(uint adjustedAmountIn) internal view override returns (uint amountOut) {
-		uint shiftTotal = _shift(totalPurchased); // k + C
-		uint shiftTotalCubed = shiftTotal.mul(shiftTotal.mul(shiftTotal));
-		uint radicand = (adjustedAmountIn.mul(3).mul(_shift(scale).sqrt()) / 2).add(shiftTotalCubed.sqrt());
-		return (radicand.mul(radicand)).cubeRoot() - shiftTotal; // result - (k + C)
-	}
+    function _getBondingCurvePriceMultiplier()
+        internal
+        view
+        override
+        returns (Decimal.D256 memory)
+    {
+        return
+            Decimal.ratio(_shift(totalPurchased).sqrt(), _shift(scale).sqrt());
+    }
 
-	function _getBondingCurvePriceMultiplier() internal view override returns(Decimal.D256 memory) {
-		return Decimal.ratio(_shift(totalPurchased).sqrt(), _shift(scale).sqrt());
-	}
+    function _allocateSingle(uint256 amount, address pcvDeposit)
+        internal
+        override
+    {
+        IPCVDeposit(pcvDeposit).deposit{value: amount}(amount);
+    }
 
-	function _allocateSingle(uint amount, address pcvDeposit) internal override {
-		IPCVDeposit(pcvDeposit).deposit{value : amount}(amount);
-	}
-
-	function _shift(uint x) internal view returns(uint) {
-		return SHIFT.add(x);
-	}
+    function _shift(uint256 x) internal view returns (uint256) {
+        return SHIFT.add(x);
+    }
 }
-

--- a/contracts/bondingcurve/IBondingCurve.sol
+++ b/contracts/bondingcurve/IBondingCurve.sol
@@ -4,74 +4,84 @@ pragma experimental ABIEncoderV2;
 import "../external/Decimal.sol";
 
 interface IBondingCurve {
+    // ----------- Events -----------
 
-	// ----------- Events -----------
+    event ScaleUpdate(uint256 _scale);
 
-    event ScaleUpdate(uint _scale);
+    event BufferUpdate(uint256 _buffer);
 
-    event BufferUpdate(uint _buffer);
+    event Purchase(address indexed _to, uint256 _amountIn, uint256 _amountOut);
 
-    event Purchase(address indexed _to, uint _amountIn, uint _amountOut);
+    event Allocate(address indexed _caller, uint256 _amount);
 
-	event Allocate(address indexed _caller, uint _amount);
+    // ----------- State changing Api -----------
 
-	// ----------- State changing Api -----------
+    /// @notice purchase FEI for underlying tokens
+    /// @param to address to receive FEI
+    /// @param amountIn amount of underlying tokens input
+    /// @return amountOut amount of FEI received
+    function purchase(address to, uint256 amountIn)
+        external
+        payable
+        returns (uint256 amountOut);
 
-	/// @notice purchase FEI for underlying tokens
-	/// @param to address to receive FEI
-	/// @param amountIn amount of underlying tokens input
-	/// @return amountOut amount of FEI received
-	function purchase(address to, uint amountIn) external payable returns (uint amountOut);
-	
-	/// @notice batch allocate held PCV
-	function allocate() external;
+    /// @notice batch allocate held PCV
+    function allocate() external;
 
-	// ----------- Governor only state changing api -----------
+    // ----------- Governor only state changing api -----------
 
-	/// @notice sets the bonding curve price buffer
-	function setBuffer(uint _buffer) external;
+    /// @notice sets the bonding curve price buffer
+    function setBuffer(uint256 _buffer) external;
 
-	/// @notice sets the bonding curve Scale target
-	function setScale(uint _scale) external;
+    /// @notice sets the bonding curve Scale target
+    function setScale(uint256 _scale) external;
 
-	/// @notice sets the allocation of incoming PCV
-	function setAllocation(address[] calldata pcvDeposits, uint[] calldata ratios) external;
+    /// @notice sets the allocation of incoming PCV
+    function setAllocation(
+        address[] calldata pcvDeposits,
+        uint256[] calldata ratios
+    ) external;
 
-	// ----------- Getters -----------
+    // ----------- Getters -----------
 
-	/// @notice return current instantaneous bonding curve price 
-	/// @return price reported as FEI per X with X being the underlying asset
-	/// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
-	function getCurrentPrice() external view returns(Decimal.D256 memory);
+    /// @notice return current instantaneous bonding curve price
+    /// @return price reported as FEI per X with X being the underlying asset
+    /// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
+    function getCurrentPrice() external view returns (Decimal.D256 memory);
 
-	/// @notice return the average price of a transaction along bonding curve
-	/// @param amountIn the amount of underlying used to purchase
-	/// @return price reported as USD per FEI
-	/// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
-	function getAveragePrice(uint amountIn) external view returns (Decimal.D256 memory);
+    /// @notice return the average price of a transaction along bonding curve
+    /// @param amountIn the amount of underlying used to purchase
+    /// @return price reported as USD per FEI
+    /// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
+    function getAveragePrice(uint256 amountIn)
+        external
+        view
+        returns (Decimal.D256 memory);
 
-	/// @notice return amount of FEI received after a bonding curve purchase
-	/// @param amountIn the amount of underlying used to purchase
-	/// @return amountOut the amount of FEI received
-	/// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
-	function getAmountOut(uint amountIn) external view returns (uint amountOut); 
+    /// @notice return amount of FEI received after a bonding curve purchase
+    /// @param amountIn the amount of underlying used to purchase
+    /// @return amountOut the amount of FEI received
+    /// @dev Can be innacurate if outdated, need to call `oracle().isOutdated()` to check
+    function getAmountOut(uint256 amountIn)
+        external
+        view
+        returns (uint256 amountOut);
 
-	/// @notice the Scale target at which bonding curve price fixes
-	function scale() external view returns (uint);
+    /// @notice the Scale target at which bonding curve price fixes
+    function scale() external view returns (uint256);
 
-	/// @notice a boolean signalling whether Scale has been reached
-	function atScale() external view returns (bool);
+    /// @notice a boolean signalling whether Scale has been reached
+    function atScale() external view returns (bool);
 
-	/// @notice the buffer applied on top of the peg purchase price once at Scale
-	function buffer() external view returns(uint);
+    /// @notice the buffer applied on top of the peg purchase price once at Scale
+    function buffer() external view returns (uint256);
 
-	/// @notice the total amount of FEI purchased on bonding curve. FEI_b from the whitepaper
-	function totalPurchased() external view returns(uint);
+    /// @notice the total amount of FEI purchased on bonding curve. FEI_b from the whitepaper
+    function totalPurchased() external view returns (uint256);
 
-	/// @notice the amount of PCV held in contract and ready to be allocated
-	function getTotalPCVHeld() external view returns(uint);
+    /// @notice the amount of PCV held in contract and ready to be allocated
+    function getTotalPCVHeld() external view returns (uint256);
 
-	/// @notice amount of FEI paid for allocation when incentivized
-	function incentiveAmount() external view returns(uint);
+    /// @notice amount of FEI paid for allocation when incentivized
+    function incentiveAmount() external view returns (uint256);
 }
-

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -9,66 +9,80 @@ import "../dao/Tribe.sol";
 /// @title ICore implementation
 /// @author Fei Protocol
 contract Core is ICore, Permissions {
+    IFei public override fei;
+    IERC20 public override tribe;
 
-	IFei public override fei;
-	IERC20 public override tribe;
+    address public override genesisGroup;
+    bool public override hasGenesisGroupCompleted;
 
-	address public override genesisGroup;
-	bool public override hasGenesisGroupCompleted;
+    constructor() public {
+        _setupGovernor(msg.sender);
+    }
 
-	constructor() public {
-		_setupGovernor(msg.sender);
-	}
+    function init() external onlyGovernor {
+        Fei _fei = new Fei(address(this));
+        _setFei(address(_fei));
 
-	function init() external onlyGovernor {
-		Fei _fei = new Fei(address(this));
-		_setFei(address(_fei));
+        Tribe _tribe = new Tribe(address(this), msg.sender);
+        _setTribe(address(_tribe));
+    }
 
-		Tribe _tribe = new Tribe(address(this), msg.sender);
-		_setTribe(address(_tribe));
+    function setFei(address token) external override onlyGovernor {
+        _setFei(token);
+    }
 
-	}
+    function setTribe(address token) external override onlyGovernor {
+        _setTribe(token);
+    }
 
-	function setFei(address token) external override onlyGovernor {
-		_setFei(token);
-	}
+    function setGenesisGroup(address _genesisGroup)
+        external
+        override
+        onlyGovernor
+    {
+        genesisGroup = _genesisGroup;
+        emit GenesisGroupUpdate(_genesisGroup);
+    }
 
-	function setTribe(address token) external override onlyGovernor {
-		_setTribe(token);
-	}
+    function allocateTribe(address to, uint256 amount)
+        external
+        override
+        onlyGovernor
+    {
+        IERC20 _tribe = tribe;
+        require(
+            _tribe.balanceOf(address(this)) >= amount,
+            "Core: Not enough Tribe"
+        );
 
-	function setGenesisGroup(address _genesisGroup) external override onlyGovernor {
-		genesisGroup = _genesisGroup;
-		emit GenesisGroupUpdate(_genesisGroup);
-	}
+        _tribe.transfer(to, amount);
 
-	function allocateTribe(address to, uint amount) external override onlyGovernor {
-		IERC20 _tribe = tribe;
-		require(_tribe.balanceOf(address(this)) >= amount, "Core: Not enough Tribe");
+        emit TribeAllocation(to, amount);
+    }
 
-		_tribe.transfer(to, amount);
+    function completeGenesisGroup() external override {
+        require(
+            !hasGenesisGroupCompleted,
+            "Core: Genesis Group already complete"
+        );
+        require(
+            msg.sender == genesisGroup,
+            "Core: Caller is not Genesis Group"
+        );
 
-		emit TribeAllocation(to, amount);
-	}
+        hasGenesisGroupCompleted = true;
 
-	function completeGenesisGroup() external override {
-		require(!hasGenesisGroupCompleted, "Core: Genesis Group already complete");
-		require(msg.sender == genesisGroup, "Core: Caller is not Genesis Group");
+        // solhint-disable-next-line not-rely-on-time
+        emit GenesisPeriodComplete(block.timestamp);
+    }
 
-		hasGenesisGroupCompleted = true;
+    function _setFei(address token) internal {
+        fei = IFei(token);
+        emit FeiUpdate(token);
+    }
 
-		// solhint-disable-next-line not-rely-on-time
-		emit GenesisPeriodComplete(block.timestamp);
-	}
-
-	function _setFei(address token) internal {
-		fei = IFei(token);
-		emit FeiUpdate(token);
-	}
-
-	function _setTribe(address token) internal {
-		tribe = IERC20(token);
-		emit TribeUpdate(token);
-	}
+    function _setTribe(address token) internal {
+        tribe = IERC20(token);
+        emit TribeUpdate(token);
+    }
 }
-

--- a/contracts/core/ICore.sol
+++ b/contracts/core/ICore.sol
@@ -9,14 +9,13 @@ import "../token/IFei.sol";
 /// @author Fei Protocol
 /// @notice maintains roles, access control, fei, tribe, genesisGroup, and the TRIBE treasury
 interface ICore is IPermissions {
-
-	// ----------- Events -----------
+    // ----------- Events -----------
 
     event FeiUpdate(address indexed _fei);
     event TribeUpdate(address indexed _tribe);
     event GenesisGroupUpdate(address indexed _genesisGroup);
-    event TribeAllocation(address indexed _to, uint _amount);
-    event GenesisPeriodComplete(uint _timestamp);
+    event TribeAllocation(address indexed _to, uint256 _amount);
+    event GenesisPeriodComplete(uint256 _timestamp);
 
     // ----------- Governor only state changing api -----------
 
@@ -35,29 +34,29 @@ interface ICore is IPermissions {
     /// @notice sends TRIBE tokens from treasury to an address
     /// @param to the address to send TRIBE to
     /// @param amount the amount of TRIBE to send
-    function allocateTribe(address to, uint amount) external;
+    function allocateTribe(address to, uint256 amount) external;
 
     // ----------- Genesis Group only state changing api -----------
 
     /// @notice marks the end of the genesis period
     /// @dev can only be called once
-	function completeGenesisGroup() external;
+    function completeGenesisGroup() external;
 
     // ----------- Getters -----------
 
     /// @notice the address of the FEI contract
     /// @return fei contract
-	function fei() external view returns (IFei);
+    function fei() external view returns (IFei);
 
     /// @notice the address of the TRIBE contract
     /// @return tribe contract
-	function tribe() external view returns (IERC20);
+    function tribe() external view returns (IERC20);
 
     /// @notice the address of the GenesisGroup contract
     /// @return genesis group contract
-    function genesisGroup() external view returns(address);
+    function genesisGroup() external view returns (address);
 
     /// @notice determines whether in genesis period or not
     /// @return true if in genesis period
-	function hasGenesisGroupCompleted() external view returns(bool);
+    function hasGenesisGroupCompleted() external view returns (bool);
 }

--- a/contracts/core/IPermissions.sol
+++ b/contracts/core/IPermissions.sol
@@ -13,27 +13,27 @@ interface IPermissions {
     /// @param role the new role id
     /// @param adminRole the admin role id for `role`
     /// @dev can also be used to update admin of existing role
-	function createRole(bytes32 role, bytes32 adminRole) external;
+    function createRole(bytes32 role, bytes32 adminRole) external;
 
     /// @notice grants minter role to address
     /// @param minter new minter
-	function grantMinter(address minter) external;
+    function grantMinter(address minter) external;
 
     /// @notice grants burner role to address
     /// @param burner new burner
-	function grantBurner(address burner) external;
+    function grantBurner(address burner) external;
 
     /// @notice grants controller role to address
     /// @param pcvController new controller
-	function grantPCVController(address pcvController) external;
+    function grantPCVController(address pcvController) external;
 
     /// @notice grants governor role to address
     /// @param governor new governor
-	function grantGovernor(address governor) external;
+    function grantGovernor(address governor) external;
 
     /// @notice grants revoker role to address
     /// @param revoker new revoker
-	function grantRevoker(address revoker) external;
+    function grantRevoker(address revoker) external;
 
     /// @notice revokes minter role from address
     /// @param minter ex minter
@@ -67,17 +67,17 @@ interface IPermissions {
     /// @notice checks if address is a burner
     /// @param _address address to check
     /// @return true _address is a burner
-	function isBurner(address _address) external view returns (bool);
+    function isBurner(address _address) external view returns (bool);
 
     /// @notice checks if address is a minter
     /// @param _address address to check
     /// @return true _address is a minter
-	function isMinter(address _address) external view returns (bool);
+    function isMinter(address _address) external view returns (bool);
 
     /// @notice checks if address is a governor
     /// @param _address address to check
     /// @return true _address is a governor
-	function isGovernor(address _address) external view returns (bool);
+    function isGovernor(address _address) external view returns (bool);
 
     /// @notice checks if address is a revoker
     /// @param _address address to check
@@ -87,5 +87,5 @@ interface IPermissions {
     /// @notice checks if address is a controller
     /// @param _address address to check
     /// @return true _address is a controller
-	function isPCVController(address _address) external view returns (bool);
+    function isPCVController(address _address) external view returns (bool);
 }

--- a/contracts/core/Permissions.sol
+++ b/contracts/core/Permissions.sol
@@ -7,101 +7,131 @@ import "./IPermissions.sol";
 /// @title IPermissions implementation
 /// @author Fei Protocol
 contract Permissions is IPermissions, AccessControl {
-	bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
-	bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-	bytes32 public constant PCV_CONTROLLER_ROLE = keccak256("PCV_CONTROLLER_ROLE");
-	bytes32 public constant GOVERN_ROLE = keccak256("GOVERN_ROLE");
-	bytes32 public constant REVOKE_ROLE = keccak256("REVOKE_ROLE");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant PCV_CONTROLLER_ROLE = keccak256("PCV_CONTROLLER_ROLE");
+    bytes32 public constant GOVERN_ROLE = keccak256("GOVERN_ROLE");
+    bytes32 public constant REVOKE_ROLE = keccak256("REVOKE_ROLE");
 
-	constructor() public {
-		_setupGovernor(address(this));
-		_setRoleAdmin(MINTER_ROLE, GOVERN_ROLE);
-		_setRoleAdmin(BURNER_ROLE, GOVERN_ROLE);
-		_setRoleAdmin(PCV_CONTROLLER_ROLE, GOVERN_ROLE);
-		_setRoleAdmin(GOVERN_ROLE, GOVERN_ROLE);
-		_setRoleAdmin(REVOKE_ROLE, GOVERN_ROLE);
-	}
+    constructor() public {
+        _setupGovernor(address(this));
+        _setRoleAdmin(MINTER_ROLE, GOVERN_ROLE);
+        _setRoleAdmin(BURNER_ROLE, GOVERN_ROLE);
+        _setRoleAdmin(PCV_CONTROLLER_ROLE, GOVERN_ROLE);
+        _setRoleAdmin(GOVERN_ROLE, GOVERN_ROLE);
+        _setRoleAdmin(REVOKE_ROLE, GOVERN_ROLE);
+    }
 
-	modifier onlyGovernor() {
-		require(isGovernor(msg.sender), "Permissions: Caller is not a governor");
-		_;
-	}
+    modifier onlyGovernor() {
+        require(
+            isGovernor(msg.sender),
+            "Permissions: Caller is not a governor"
+        );
+        _;
+    }
 
-	modifier onlyRevoker() {
-		require(isRevoker(msg.sender), "Permissions: Caller is not a revoker");
-		_;
-	}
+    modifier onlyRevoker() {
+        require(isRevoker(msg.sender), "Permissions: Caller is not a revoker");
+        _;
+    }
 
-	function createRole(bytes32 role, bytes32 adminRole) external override onlyGovernor {
-		_setRoleAdmin(role, adminRole);
-	}
+    function createRole(bytes32 role, bytes32 adminRole)
+        external
+        override
+        onlyGovernor
+    {
+        _setRoleAdmin(role, adminRole);
+    }
 
-	function grantMinter(address minter) external override onlyGovernor {
-		grantRole(MINTER_ROLE, minter);
-	} 
+    function grantMinter(address minter) external override onlyGovernor {
+        grantRole(MINTER_ROLE, minter);
+    }
 
-	function grantBurner(address burner) external override onlyGovernor {
-		grantRole(BURNER_ROLE, burner);
-	} 
+    function grantBurner(address burner) external override onlyGovernor {
+        grantRole(BURNER_ROLE, burner);
+    }
 
-	function grantPCVController(address pcvController) external override onlyGovernor {
-		grantRole(PCV_CONTROLLER_ROLE, pcvController);
-	}
+    function grantPCVController(address pcvController)
+        external
+        override
+        onlyGovernor
+    {
+        grantRole(PCV_CONTROLLER_ROLE, pcvController);
+    }
 
-	function grantGovernor(address governor) external override onlyGovernor {
-		grantRole(GOVERN_ROLE, governor);
-	}
+    function grantGovernor(address governor) external override onlyGovernor {
+        grantRole(GOVERN_ROLE, governor);
+    }
 
-	function grantRevoker(address revoker) external override onlyGovernor {
-		grantRole(REVOKE_ROLE, revoker);
-	}
+    function grantRevoker(address revoker) external override onlyGovernor {
+        grantRole(REVOKE_ROLE, revoker);
+    }
 
-	function revokeMinter(address minter) external override onlyGovernor {
-		revokeRole(MINTER_ROLE, minter);
-	} 
+    function revokeMinter(address minter) external override onlyGovernor {
+        revokeRole(MINTER_ROLE, minter);
+    }
 
-	function revokeBurner(address burner) external override onlyGovernor {
-		revokeRole(BURNER_ROLE, burner);
-	} 
+    function revokeBurner(address burner) external override onlyGovernor {
+        revokeRole(BURNER_ROLE, burner);
+    }
 
-	function revokePCVController(address pcvController) external override onlyGovernor {
-		revokeRole(PCV_CONTROLLER_ROLE, pcvController);
-	}
+    function revokePCVController(address pcvController)
+        external
+        override
+        onlyGovernor
+    {
+        revokeRole(PCV_CONTROLLER_ROLE, pcvController);
+    }
 
-	function revokeGovernor(address governor) external override onlyGovernor {
-		revokeRole(GOVERN_ROLE, governor);
-	}
+    function revokeGovernor(address governor) external override onlyGovernor {
+        revokeRole(GOVERN_ROLE, governor);
+    }
 
-	function revokeRevoker(address revoker) external override onlyGovernor {
-		revokeRole(REVOKE_ROLE, revoker);
-	}
+    function revokeRevoker(address revoker) external override onlyGovernor {
+        revokeRole(REVOKE_ROLE, revoker);
+    }
 
-	function revokeOverride(bytes32 role, address account) external override onlyRevoker {
-		this.revokeRole(role, account);
-	}
+    function revokeOverride(bytes32 role, address account)
+        external
+        override
+        onlyRevoker
+    {
+        this.revokeRole(role, account);
+    }
 
-	function isMinter(address _address) external override view returns (bool) {
-		return hasRole(MINTER_ROLE, _address);
-	}
+    function isMinter(address _address) external view override returns (bool) {
+        return hasRole(MINTER_ROLE, _address);
+    }
 
-	function isBurner(address _address) external override view returns (bool) {
-		return hasRole(BURNER_ROLE, _address);
-	}
+    function isBurner(address _address) external view override returns (bool) {
+        return hasRole(BURNER_ROLE, _address);
+    }
 
-	function isPCVController(address _address) external override view returns (bool) {
-		return hasRole(PCV_CONTROLLER_ROLE, _address);
-	}
+    function isPCVController(address _address)
+        external
+        view
+        override
+        returns (bool)
+    {
+        return hasRole(PCV_CONTROLLER_ROLE, _address);
+    }
 
-	// only virtual for testing mock override
-	function isGovernor(address _address) public override view virtual returns (bool) {
-		return hasRole(GOVERN_ROLE, _address);
-	}
+    // only virtual for testing mock override
+    function isGovernor(address _address)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return hasRole(GOVERN_ROLE, _address);
+    }
 
-	function isRevoker(address _address) public override view returns (bool) {
-		return hasRole(REVOKE_ROLE, _address);
-	}
+    function isRevoker(address _address) public view override returns (bool) {
+        return hasRole(REVOKE_ROLE, _address);
+    }
 
-	function _setupGovernor(address governor) internal {
-		_setupRole(GOVERN_ROLE, governor);
-	}
+    function _setupGovernor(address governor) internal {
+        _setupRole(GOVERN_ROLE, governor);
+    }
 }

--- a/contracts/dao/ITimelockedDelegator.sol
+++ b/contracts/dao/ITimelockedDelegator.sol
@@ -5,49 +5,50 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../token/IFei.sol";
 
 interface ITribe is IERC20 {
-	function delegate(address delegatee) external;
+    function delegate(address delegatee) external;
 }
 
 /// @title a timelock for TRIBE allowing for sub-delegation
 /// @author Fei Protocol
 /// @notice allows the timelocked TRIBE to be delegated by the beneficiary while locked
 interface ITimelockedDelegator {
+    // ----------- Events -----------
 
-	// ----------- Events -----------
+    event Delegate(address indexed _delegatee, uint256 _amount);
 
-    event Delegate(address indexed _delegatee, uint _amount);
-
-    event Undelegate(address indexed _delegatee, uint _amount);
+    event Undelegate(address indexed _delegatee, uint256 _amount);
 
     // ----------- Beneficiary only state changing api -----------
 
-	/// @notice delegate locked TRIBE to a delegatee
-	/// @param delegatee the target address to delegate to
-	/// @param amount the amount of TRIBE to delegate. Will increment existing delegated TRIBE
-    function delegate(address delegatee, uint amount) external;
+    /// @notice delegate locked TRIBE to a delegatee
+    /// @param delegatee the target address to delegate to
+    /// @param amount the amount of TRIBE to delegate. Will increment existing delegated TRIBE
+    function delegate(address delegatee, uint256 amount) external;
 
-	/// @notice return delegated TRIBE to the timelock
-	/// @param delegatee the target address to undelegate from
-	/// @return the amount of TRIBE returned
-    function undelegate(address delegatee) external returns(uint);
+    /// @notice return delegated TRIBE to the timelock
+    /// @param delegatee the target address to undelegate from
+    /// @return the amount of TRIBE returned
+    function undelegate(address delegatee) external returns (uint256);
 
     // ----------- Getters -----------
 
-	/// @notice associated delegate proxy contract for a delegatee
-	/// @param delegatee The delegatee
-	/// @return the corresponding delegate proxy contract
-    function delegateContract(address delegatee) external view returns(address);
+    /// @notice associated delegate proxy contract for a delegatee
+    /// @param delegatee The delegatee
+    /// @return the corresponding delegate proxy contract
+    function delegateContract(address delegatee)
+        external
+        view
+        returns (address);
 
-	/// @notice associated delegated amount for a delegatee
-	/// @param delegatee The delegatee
-	/// @return uint amount of TRIBE delegated
+    /// @notice associated delegated amount for a delegatee
+    /// @param delegatee The delegatee
+    /// @return uint amount of TRIBE delegated
     /// @dev Using as source of truth to prevent accounting errors by transferring to Delegate contracts
-    function delegateAmount(address delegatee) external view returns(uint);
+    function delegateAmount(address delegatee) external view returns (uint256);
 
-	/// @notice the total delegated amount of TRIBE
-    function totalDelegated() external view returns(uint);
+    /// @notice the total delegated amount of TRIBE
+    function totalDelegated() external view returns (uint256);
 
-	/// @notice the TRIBE token contract
-    function tribe() external view returns(ITribe);
-
+    /// @notice the TRIBE token contract
+    function tribe() external view returns (ITribe);
 }

--- a/contracts/dao/TimelockedDelegator.sol
+++ b/contracts/dao/TimelockedDelegator.sol
@@ -8,97 +8,112 @@ import "../utils/LinearTokenTimelock.sol";
 /// @title a proxy delegate contract for TRIBE
 /// @author Fei Protocol
 contract Delegatee is Ownable {
+    ITribe public tribe;
 
-	ITribe public tribe;
+    /// @notice Delegatee constructor
+    /// @param _delegatee the address to delegate TRIBE to
+    /// @param _tribe the TRIBE token address
+    constructor(address _delegatee, address _tribe) public {
+        tribe = ITribe(_tribe);
+        tribe.delegate(_delegatee);
+    }
 
-	/// @notice Delegatee constructor
-	/// @param _delegatee the address to delegate TRIBE to
-	/// @param _tribe the TRIBE token address
-	constructor(address _delegatee, address _tribe) public {
-		tribe = ITribe(_tribe);
-		tribe.delegate(_delegatee);
-	}
-
-	/// @notice send TRIBE back to timelock and selfdestruct
-	function withdraw() public onlyOwner {
-		ITribe _tribe = tribe;
-		uint balance = _tribe.balanceOf(address(this));
-		_tribe.transfer(owner(), balance);
-		selfdestruct(payable(owner()));
-	}
+    /// @notice send TRIBE back to timelock and selfdestruct
+    function withdraw() public onlyOwner {
+        ITribe _tribe = tribe;
+        uint256 balance = _tribe.balanceOf(address(this));
+        _tribe.transfer(owner(), balance);
+        selfdestruct(payable(owner()));
+    }
 }
 
 /// @title ITimelockedDelegator implementation
 /// @author Fei Protocol
 contract TimelockedDelegator is ITimelockedDelegator, LinearTokenTimelock {
+    mapping(address => address) public override delegateContract;
 
-    mapping (address => address) public override delegateContract;
-
-    mapping (address => uint) public override delegateAmount;
+    mapping(address => uint256) public override delegateAmount;
 
     ITribe public override tribe;
 
-    uint public override totalDelegated;
+    uint256 public override totalDelegated;
 
-	/// @notice Delegatee constructor
-	/// @param _tribe the TRIBE token address
-	/// @param _beneficiary default delegate, admin, and timelock beneficiary
-	/// @param _duration duration of the token timelock window
-	constructor(address _tribe, address _beneficiary, uint _duration) public
-		LinearTokenTimelock(_beneficiary, _duration, _tribe)
-	{
-		tribe = ITribe(_tribe);
-		tribe.delegate(_beneficiary);
-	}
-
-	function delegate(address delegatee, uint amount) public override onlyBeneficiary {
-		require(amount <= tribeBalance(), "TimelockedDelegator: Not enough Tribe");
-
-		if (delegateContract[delegatee] != address(0)) {
-			amount = amount.add(undelegate(delegatee));
-		}
-		ITribe _tribe = tribe;
-		address _delegateContract = address(new Delegatee(delegatee, address(_tribe)));
-		delegateContract[delegatee] = _delegateContract;
-
-		delegateAmount[delegatee] = amount;
-		totalDelegated = totalDelegated.add(amount);
-
-		_tribe.transfer(_delegateContract, amount);
-
-		emit Delegate(delegatee, amount);
-	}
-
-	function undelegate(address delegatee) public override onlyBeneficiary returns(uint) {
-		address _delegateContract = delegateContract[delegatee];
-		require(_delegateContract != address(0), "TimelockedDelegator: Delegate contract nonexistent");
-
-		Delegatee(_delegateContract).withdraw();
-
-		uint amount = delegateAmount[delegatee];
-		totalDelegated = totalDelegated.sub(amount);
-
-		delegateContract[delegatee] = address(0);
-		delegateAmount[delegatee] = 0;
-
-		emit Undelegate(delegatee, amount);
-
-		return amount;
-	}
-
-	/// @notice calculate total TRIBE held plus delegated
-	/// @dev used by LinearTokenTimelock to determine the released amount
-	function totalToken() public view override returns(uint256) {
-        return tribeBalance().add(totalDelegated);
+    /// @notice Delegatee constructor
+    /// @param _tribe the TRIBE token address
+    /// @param _beneficiary default delegate, admin, and timelock beneficiary
+    /// @param _duration duration of the token timelock window
+    constructor(
+        address _tribe,
+        address _beneficiary,
+        uint256 _duration
+    ) public LinearTokenTimelock(_beneficiary, _duration, _tribe) {
+        tribe = ITribe(_tribe);
+        tribe.delegate(_beneficiary);
     }
 
-	/// @notice accept beneficiary role over timelocked TRIBE. Delegates all held (non-subdelegated) tribe to beneficiary
-	function acceptBeneficiary() public override {
+    function delegate(address delegatee, uint256 amount)
+        public
+        override
+        onlyBeneficiary
+    {
+        require(
+            amount <= _tribeBalance(),
+            "TimelockedDelegator: Not enough Tribe"
+        );
+
+        if (delegateContract[delegatee] != address(0)) {
+            amount = amount.add(undelegate(delegatee));
+        }
+        ITribe _tribe = tribe;
+        address _delegateContract = address(new Delegatee(delegatee, address(_tribe)));
+        delegateContract[delegatee] = _delegateContract;
+
+        delegateAmount[delegatee] = amount;
+        totalDelegated = totalDelegated.add(amount);
+
+        _tribe.transfer(_delegateContract, amount);
+
+        emit Delegate(delegatee, amount);
+    }
+
+    function undelegate(address delegatee)
+        public
+        override
+        onlyBeneficiary
+        returns (uint256)
+    {
+        address _delegateContract = delegateContract[delegatee];
+        require(
+            _delegateContract != address(0),
+            "TimelockedDelegator: Delegate contract nonexistent"
+        );
+
+        Delegatee(_delegateContract).withdraw();
+
+        uint256 amount = delegateAmount[delegatee];
+        totalDelegated = totalDelegated.sub(amount);
+
+        delegateContract[delegatee] = address(0);
+        delegateAmount[delegatee] = 0;
+
+        emit Undelegate(delegatee, amount);
+
+        return amount;
+    }
+
+    /// @notice calculate total TRIBE held plus delegated
+    /// @dev used by LinearTokenTimelock to determine the released amount
+    function totalToken() public view override returns (uint256) {
+        return _tribeBalance().add(totalDelegated);
+    }
+
+    /// @notice accept beneficiary role over timelocked TRIBE. Delegates all held (non-subdelegated) tribe to beneficiary
+    function acceptBeneficiary() public override {
         _setBeneficiary(msg.sender);
         tribe.delegate(msg.sender);
     }
 
-    function tribeBalance() internal view returns (uint256) {
-    	return tribe.balanceOf(address(this));
+    function _tribeBalance() internal view returns (uint256) {
+        return tribe.balanceOf(address(this));
     }
 }

--- a/contracts/genesis/GenesisGroup.sol
+++ b/contracts/genesis/GenesisGroup.sol
@@ -13,210 +13,269 @@ import "../bondingcurve/IBondingCurve.sol";
 /// @title IGenesisGroup implementation
 /// @author Fei Protocol
 contract GenesisGroup is IGenesisGroup, CoreRef, ERC20, Timed {
-	using Decimal for Decimal.D256;
+    using Decimal for Decimal.D256;
 
-	IBondingCurve private bondingcurve;
+    IBondingCurve private bondingcurve;
 
-	IBondingCurveOracle private bondingCurveOracle;
+    IBondingCurveOracle private bondingCurveOracle;
 
-	IPool private pool;
+    IPool private pool;
 
-	IDOInterface private ido;
-	uint private exchangeRateDiscount;
+    IDOInterface private ido;
+    uint256 private exchangeRateDiscount;
 
-	mapping(address => uint) public committedFGEN;
-	uint public totalCommittedFGEN;
+    mapping(address => uint256) public committedFGEN;
+    uint256 public totalCommittedFGEN;
 
-	uint public totalCommittedTribe;
+    uint256 public totalCommittedTribe;
 
-	uint public constant ORACLE_LISTING_PERCENT = 90;
-	uint public launchBlock;
+    uint256 public constant ORACLE_LISTING_PERCENT = 90;
+    uint256 public launchBlock;
 
-	/// @notice GenesisGroup constructor
-	/// @param _core Fei Core address to reference
-	/// @param _bondingcurve Bonding curve address for purchase
-	/// @param _ido IDO contract to deploy
-	/// @param _oracle Bonding curve oracle
-	/// @param _pool Staking Pool
-	/// @param _duration duration of the Genesis Period
-	/// @param _exchangeRateDiscount a divisor on the FEI/TRIBE ratio at Genesis to deploy to the IDO
-	constructor(
-		address _core, 
-		address _bondingcurve,
-		address _ido,
-		address _oracle,
-		address _pool,
-		uint _duration,
-		uint _exchangeRateDiscount
-	) public
-		CoreRef(_core)
-		ERC20("Fei Genesis Group", "FGEN")
-		Timed(_duration)
-	{
-		bondingcurve = IBondingCurve(_bondingcurve);
+    /// @notice GenesisGroup constructor
+    /// @param _core Fei Core address to reference
+    /// @param _bondingcurve Bonding curve address for purchase
+    /// @param _ido IDO contract to deploy
+    /// @param _oracle Bonding curve oracle
+    /// @param _pool Staking Pool
+    /// @param _duration duration of the Genesis Period
+    /// @param _exchangeRateDiscount a divisor on the FEI/TRIBE ratio at Genesis to deploy to the IDO
+    constructor(
+        address _core,
+        address _bondingcurve,
+        address _ido,
+        address _oracle,
+        address _pool,
+        uint256 _duration,
+        uint256 _exchangeRateDiscount
+    )
+        public
+        CoreRef(_core)
+        ERC20("Fei Genesis Group", "FGEN")
+        Timed(_duration)
+    {
+        bondingcurve = IBondingCurve(_bondingcurve);
 
-		exchangeRateDiscount = _exchangeRateDiscount;
-		ido = IDOInterface(_ido);
+        exchangeRateDiscount = _exchangeRateDiscount;
+        ido = IDOInterface(_ido);
 
-		uint maxTokens = uint(-1);
-		fei().approve(_ido, maxTokens);
+        uint256 maxTokens = uint256(-1);
+        fei().approve(_ido, maxTokens);
 
-		pool = IPool(_pool);
-		bondingCurveOracle = IBondingCurveOracle(_oracle);
+        pool = IPool(_pool);
+        bondingCurveOracle = IBondingCurveOracle(_oracle);
 
-		_initTimed();
-	}
+        _initTimed();
+    }
 
-	modifier onlyGenesisPeriod() {
-		require(!isTimeEnded() && !core().hasGenesisGroupCompleted(), "GenesisGroup: Not in Genesis Period");
-		_;
-	}
+    modifier onlyGenesisPeriod() {
+        require(
+            !isTimeEnded() && !core().hasGenesisGroupCompleted(),
+            "GenesisGroup: Not in Genesis Period"
+        );
+        _;
+    }
 
-	function purchase(address to, uint value) external override payable onlyGenesisPeriod {
-		require(msg.value == value, "GenesisGroup: value mismatch");
-		require(value != 0, "GenesisGroup: no value sent");
+    function purchase(address to, uint256 value)
+        external
+        payable
+        override
+        onlyGenesisPeriod
+    {
+        require(msg.value == value, "GenesisGroup: value mismatch");
+        require(value != 0, "GenesisGroup: no value sent");
 
-		_mint(to, value);
+        _mint(to, value);
 
-		emit Purchase(to, value);
-	}
+        emit Purchase(to, value);
+    }
 
-	function commit(address from, address to, uint amount) external override onlyGenesisPeriod {
-		_burnFrom(from, amount);
+    function commit(
+        address from,
+        address to,
+        uint256 amount
+    ) external override onlyGenesisPeriod {
+        _burnFrom(from, amount);
 
-		committedFGEN[to] = committedFGEN[to].add(amount);
-		totalCommittedFGEN = totalCommittedFGEN.add(amount);
+        committedFGEN[to] = committedFGEN[to].add(amount);
+        totalCommittedFGEN = totalCommittedFGEN.add(amount);
 
-		emit Commit(from, to, amount);
-	}
+        emit Commit(from, to, amount);
+    }
 
-	function redeem(address to) external override {
-		(uint feiAmount, uint genesisTribe, uint idoTribe) = getAmountsToRedeem(to); 
-		require(block.number > launchBlock, "GenesisGroup: No redeeming in launch block");
+    function redeem(address to) external override {
+        (uint256 feiAmount, uint256 genesisTribe, uint256 idoTribe) =
+            getAmountsToRedeem(to);
+        require(
+            block.number > launchBlock,
+            "GenesisGroup: No redeeming in launch block"
+        );
 
-		uint tribeAmount = genesisTribe.add(idoTribe);
+        uint256 tribeAmount = genesisTribe.add(idoTribe);
 
-		require(tribeAmount != 0, "GenesisGroup: No redeemable TRIBE");
+        require(tribeAmount != 0, "GenesisGroup: No redeemable TRIBE");
 
-		uint amountIn = balanceOf(to);
-		_burnFrom(to, amountIn);
+        uint256 amountIn = balanceOf(to);
+        _burnFrom(to, amountIn);
 
-		uint committed = committedFGEN[to];
-		committedFGEN[to] = 0;
-		totalCommittedFGEN = totalCommittedFGEN.sub(committed);
+        uint256 committed = committedFGEN[to];
+        committedFGEN[to] = 0;
+        totalCommittedFGEN = totalCommittedFGEN.sub(committed);
 
-		totalCommittedTribe = totalCommittedTribe.sub(idoTribe);
+        totalCommittedTribe = totalCommittedTribe.sub(idoTribe);
 
+        if (feiAmount != 0) {
+            fei().transfer(to, feiAmount);
+        }
 
-		if (feiAmount != 0) {
-			fei().transfer(to, feiAmount);
-		}
-		
-		tribe().transfer(to, tribeAmount);
+        tribe().transfer(to, tribeAmount);
 
-		emit Redeem(to, amountIn, feiAmount, tribeAmount);
-	}
+        emit Redeem(to, amountIn, feiAmount, tribeAmount);
+    }
 
-	function getAmountsToRedeem(address to) public view postGenesis returns (uint feiAmount, uint genesisTribe, uint idoTribe) {
-		
-		uint userFGEN = balanceOf(to);
-		uint userCommittedFGEN = committedFGEN[to];
+    function launch() external override {
+        require(isTimeEnded(), "GenesisGroup: Still in Genesis Period");
 
-		uint circulatingFGEN = totalSupply();
-		uint totalFGEN = circulatingFGEN.add(totalCommittedFGEN);
+        core().completeGenesisGroup();
+        launchBlock = block.number;
 
-		// subtract purchased TRIBE amount
-		uint totalGenesisTribe = tribeBalance().sub(totalCommittedTribe);
+        address genesisGroup = address(this);
+        uint256 balance = genesisGroup.balance;
 
-		if (circulatingFGEN != 0) {
-			feiAmount = feiBalance().mul(userFGEN) / circulatingFGEN;
-		}
+        Decimal.D256 memory oraclePrice =
+            bondingcurve
+                .getAveragePrice(balance)
+                .mul(ORACLE_LISTING_PERCENT)
+                .div(100);
+        bondingCurveOracle.init(oraclePrice);
 
-		if (totalFGEN != 0) {
-			genesisTribe = totalGenesisTribe.mul(userFGEN.add(userCommittedFGEN)) / totalFGEN;
-		}
+        bondingcurve.purchase{value: balance}(genesisGroup, balance);
+        bondingcurve.allocate();
 
-		if (totalCommittedFGEN != 0) {
-			idoTribe = totalCommittedTribe.mul(userCommittedFGEN) / totalCommittedFGEN;
-		}
+        pool.init();
 
-		return (feiAmount, genesisTribe, idoTribe);
-	}
+        ido.deploy(_feiTribeExchangeRate());
 
-	function launch() external override {
-		require(isTimeEnded(), "GenesisGroup: Still in Genesis Period");
+        uint256 amountFei =
+            feiBalance().mul(totalCommittedFGEN) /
+                (totalSupply().add(totalCommittedFGEN));
+        if (amountFei != 0) {
+            totalCommittedTribe = ido.swapFei(amountFei);
+        }
 
-		core().completeGenesisGroup();
-		launchBlock = block.number;
+        // solhint-disable-next-line not-rely-on-time
+        emit Launch(block.timestamp);
+    }
 
-		address genesisGroup = address(this);
-		uint balance = genesisGroup.balance;
+    // Add a backdoor out of Genesis in case of brick
+    function emergencyExit(address from, address payable to) external {
+        require(
+            // solhint-disable-next-line not-rely-on-time
+            block.timestamp > (startTime + duration + 3 days),
+            "GenesisGroup: Not in exit window"
+        );
+        require(
+            !core().hasGenesisGroupCompleted(),
+            "GenesisGroup: Launch already happened"
+        );
 
-		Decimal.D256 memory oraclePrice = bondingcurve.getAveragePrice(balance).mul(ORACLE_LISTING_PERCENT).div(100);
-		bondingCurveOracle.init(oraclePrice);
+        uint256 heldFGEN = balanceOf(from);
+        uint256 committed = committedFGEN[from];
+        uint256 total = heldFGEN.add(committed);
 
-		bondingcurve.purchase{value: balance}(genesisGroup, balance);
-		bondingcurve.allocate();
+        require(total != 0, "GenesisGroup: No FGEN or committed balance");
+        require(
+            msg.sender == from || allowance(from, msg.sender) >= total,
+            "GenesisGroup: Not approved for emergency withdrawal"
+        );
+        assert(address(this).balance >= total); // ETH can only be removed by launch which blocks this method or this method in event of launch failure
 
-		pool.init();
+        _burnFrom(from, heldFGEN);
+        committedFGEN[from] = 0;
+        totalCommittedFGEN = totalCommittedFGEN.sub(committed);
 
-		ido.deploy(_feiTribeExchangeRate());
+        to.transfer(total);
+    }
 
-		uint amountFei = feiBalance().mul(totalCommittedFGEN) / (totalSupply().add(totalCommittedFGEN));
-		if (amountFei != 0) {
-			totalCommittedTribe = ido.swapFei(amountFei);
-		}
+    function getAmountsToRedeem(address to)
+        public
+        view
+        postGenesis
+        returns (
+            uint256 feiAmount,
+            uint256 genesisTribe,
+            uint256 idoTribe
+        )
+    {
+        uint256 userFGEN = balanceOf(to);
+        uint256 userCommittedFGEN = committedFGEN[to];
 
-		// solhint-disable-next-line not-rely-on-time
-		emit Launch(block.timestamp);
-	}
+        uint256 circulatingFGEN = totalSupply();
+        uint256 totalFGEN = circulatingFGEN.add(totalCommittedFGEN);
 
-	// Add a backdoor out of Genesis in case of brick
-	function emergencyExit(address from, address payable to) external {
-		require(block.timestamp > (startTime + duration + 3 days), "GenesisGroup: Not in exit window");
-		require(!core().hasGenesisGroupCompleted(), "GenesisGroup: Launch already happened");
+        // subtract purchased TRIBE amount
+        uint256 totalGenesisTribe = tribeBalance().sub(totalCommittedTribe);
 
-		uint heldFGEN = balanceOf(from);
-		uint committed = committedFGEN[from];
-		uint total = heldFGEN.add(committed);
+        if (circulatingFGEN != 0) {
+            feiAmount = feiBalance().mul(userFGEN) / circulatingFGEN;
+        }
 
-		require(total != 0, "GenesisGroup: No FGEN or committed balance");
-		require(msg.sender == from || allowance(from, msg.sender) >= total, "GenesisGroup: Not approved for emergency withdrawal");
-		assert(address(this).balance >= total); // ETH can only be removed by launch which blocks this method or this method in event of launch failure
+        if (totalFGEN != 0) {
+            genesisTribe =
+                totalGenesisTribe.mul(userFGEN.add(userCommittedFGEN)) /
+                totalFGEN;
+        }
 
-		_burnFrom(from, heldFGEN);
-		committedFGEN[from] = 0;
-		totalCommittedFGEN = totalCommittedFGEN.sub(committed);
+        if (totalCommittedFGEN != 0) {
+            idoTribe =
+                totalCommittedTribe.mul(userCommittedFGEN) /
+                totalCommittedFGEN;
+        }
 
-		to.transfer(total);
-	}
+        return (feiAmount, genesisTribe, idoTribe);
+    }
 
-	function getAmountOut(
-		uint amountIn, 
-		bool inclusive
-	) public view override returns (uint feiAmount, uint tribeAmount) {
-		uint totalIn = totalSupply();
-		if (!inclusive) {
-			totalIn = totalIn.add(amountIn);
-		}
-		require(amountIn <= totalIn, "GenesisGroup: Not enough supply");
+    function getAmountOut(uint256 amountIn, bool inclusive)
+        public
+        view
+        override
+        returns (uint256 feiAmount, uint256 tribeAmount)
+    {
+        uint256 totalIn = totalSupply();
+        if (!inclusive) {
+            totalIn = totalIn.add(amountIn);
+        }
+        require(amountIn <= totalIn, "GenesisGroup: Not enough supply");
 
-		uint totalFei = bondingcurve.getAmountOut(totalIn);
-		uint totalTribe = tribeBalance();
+        uint256 totalFei = bondingcurve.getAmountOut(totalIn);
+        uint256 totalTribe = tribeBalance();
 
-		return (totalFei.mul(amountIn) / totalIn, totalTribe.mul(amountIn) / totalIn);
-	}
+        return (
+            totalFei.mul(amountIn) / totalIn,
+            totalTribe.mul(amountIn) / totalIn
+        );
+    }
 
-
-	function _burnFrom(address account, uint amount) internal {
-		if (msg.sender != account) {
-			uint256 decreasedAllowance = allowance(account, _msgSender()).sub(amount, "GenesisGroup: burn amount exceeds allowance");
-			_approve(account, _msgSender(), decreasedAllowance);
-		}
+    function _burnFrom(address account, uint256 amount) internal {
+        if (msg.sender != account) {
+            uint256 decreasedAllowance =
+                allowance(account, _msgSender()).sub(
+                    amount,
+                    "GenesisGroup: burn amount exceeds allowance"
+                );
+            _approve(account, _msgSender(), decreasedAllowance);
+        }
         _burn(account, amount);
-	}
+    }
 
-	function _feiTribeExchangeRate() public view returns (Decimal.D256 memory) {
-		return Decimal.ratio(feiBalance(), tribeBalance()).div(exchangeRateDiscount);
-	}
+    function _feiTribeExchangeRate()
+        internal
+        view
+        returns (Decimal.D256 memory)
+    {
+        return
+            Decimal.ratio(feiBalance(), tribeBalance()).div(
+                exchangeRateDiscount
+            );
+    }
 }

--- a/contracts/genesis/IDO.sol
+++ b/contracts/genesis/IDO.sol
@@ -9,56 +9,72 @@ import "../refs/UniRef.sol";
 /// @title IDOInterface implementation
 /// @author Fei Protocol
 contract IDO is IDOInterface, UniRef, LinearTokenTimelock {
+    /// @notice IDO constructor
+    /// @param _core Fei Core address to reference
+    /// @param _beneficiary the beneficiary to vest LP shares
+    /// @param _duration the duration of LP share vesting
+    /// @param _pair the Uniswap pair contract of the IDO
+    /// @param _router the Uniswap router contract
+    constructor(
+        address _core,
+        address _beneficiary,
+        uint256 _duration,
+        address _pair,
+        address _router
+    )
+        public
+        UniRef(_core, _pair, _router, address(0)) // no oracle needed
+        LinearTokenTimelock(_beneficiary, _duration, _pair)
+    {}
 
-	/// @notice IDO constructor
-	/// @param _core Fei Core address to reference
-	/// @param _beneficiary the beneficiary to vest LP shares
-	/// @param _duration the duration of LP share vesting
-	/// @param _pair the Uniswap pair contract of the IDO
-	/// @param _router the Uniswap router contract
-	constructor(
-		address _core, 
-		address _beneficiary, 
-		uint _duration, 
-		address _pair, 
-		address _router
-	) public
-		UniRef(_core, _pair, _router, address(0)) // no oracle needed
-		LinearTokenTimelock(_beneficiary, _duration, _pair)
-	{}
+    function deploy(Decimal.D256 calldata feiRatio)
+        external
+        override
+        onlyGenesisGroup
+    {
+        uint256 tribeAmount = tribeBalance();
 
-	function deploy(Decimal.D256 calldata feiRatio) external override onlyGenesisGroup {
-		uint tribeAmount = tribeBalance();
+        uint256 feiAmount = feiRatio.mul(tribeAmount).asUint256();
+        _mintFei(feiAmount);
 
-		uint feiAmount = feiRatio.mul(tribeAmount).asUint256();
-		_mintFei(feiAmount);
+        uint256 endOfTime = uint256(-1);
+        router.addLiquidity(
+            address(tribe()),
+            address(fei()),
+            tribeAmount,
+            feiAmount,
+            tribeAmount,
+            feiAmount,
+            address(this),
+            endOfTime
+        );
 
-		uint endOfTime = uint(-1);
-		router.addLiquidity(
-	        address(tribe()),
-	        address(fei()),
-	        tribeAmount,
-	        feiAmount,
-	        tribeAmount,
-	        feiAmount,
-	        address(this),
-	        endOfTime
-	    );
+        emit Deploy(feiAmount, tribeAmount);
+    }
 
-	    emit Deploy(feiAmount, tribeAmount);
-	} 
+    function swapFei(uint256 amountFei)
+        external
+        override
+        onlyGenesisGroup
+        returns (uint256)
+    {
+        (uint256 feiReserves, uint256 tribeReserves) = getReserves();
 
-	function swapFei(uint amountFei) external override onlyGenesisGroup returns(uint) {
+        uint256 amountOut =
+            UniswapV2Library.getAmountOut(
+                amountFei,
+                feiReserves,
+                tribeReserves
+            );
 
-		(uint feiReserves, uint tribeReserves) = getReserves();
+        fei().transferFrom(msg.sender, address(pair), amountFei);
 
-		uint amountOut = UniswapV2Library.getAmountOut(amountFei, feiReserves, tribeReserves);
+        (uint256 amount0Out, uint256 amount1Out) =
+            pair.token0() == address(fei())
+                ? (uint256(0), amountOut)
+                : (amountOut, uint256(0));
+        pair.swap(amount0Out, amount1Out, msg.sender, new bytes(0));
 
-		fei().transferFrom(msg.sender, address(pair), amountFei);
-
-		(uint amount0Out, uint amount1Out) = pair.token0() == address(fei()) ? (uint(0), amountOut) : (amountOut, uint(0));
-		pair.swap(amount0Out, amount1Out, msg.sender, new bytes(0));
-
-		return amountOut;
-	}
+        return amountOut;
+    }
 }

--- a/contracts/genesis/IDOInterface.sol
+++ b/contracts/genesis/IDOInterface.sol
@@ -6,20 +6,19 @@ import "../external/Decimal.sol";
 /// @title an initial DeFi offering for the TRIBE token
 /// @author Fei Protocol
 interface IDOInterface {
+    // ----------- Events -----------
 
-	// ----------- Events -----------
+    event Deploy(uint256 _amountFei, uint256 _amountTribe);
 
-	event Deploy(uint _amountFei, uint _amountTribe);
-
-	// ----------- Genesis Group only state changing API -----------
+    // ----------- Genesis Group only state changing API -----------
 
     /// @notice deploys all held TRIBE on Uniswap at the given ratio
     /// @param feiRatio the exchange rate for FEI/TRIBE
     /// @dev the contract will mint any FEI necessary to do the listing. Assumes no existing LP
-	function deploy(Decimal.D256 calldata feiRatio) external;
+    function deploy(Decimal.D256 calldata feiRatio) external;
 
-	/// @notice swaps Genesis Group FEI on Uniswap For TRIBE
-	/// @param amountFei the amount of FEI to swap
-	/// @return uint amount of TRIBE sent to Genesis Group
-	function swapFei(uint amountFei) external returns(uint);
+    /// @notice swaps Genesis Group FEI on Uniswap For TRIBE
+    /// @param amountFei the amount of FEI to swap
+    /// @return uint amount of TRIBE sent to Genesis Group
+    function swapFei(uint256 amountFei) external returns (uint256);
 }

--- a/contracts/genesis/IGenesisGroup.sol
+++ b/contracts/genesis/IGenesisGroup.sol
@@ -7,22 +7,27 @@ import "../external/Decimal.sol";
 /// @title Equal access to the first bonding curve transaction
 /// @author Fei Protocol
 interface IGenesisGroup {
-	// ----------- Events -----------
+    // ----------- Events -----------
 
-	event Purchase(address indexed _to, uint _value);
+    event Purchase(address indexed _to, uint256 _value);
 
-	event Redeem(address indexed _to, uint _amountIn, uint _amountFei, uint _amountTribe);
+    event Redeem(
+        address indexed _to,
+        uint256 _amountIn,
+        uint256 _amountFei,
+        uint256 _amountTribe
+    );
 
-    event Commit(address indexed _from, address indexed _to, uint _amount);
+    event Commit(address indexed _from, address indexed _to, uint256 _amount);
 
-	event Launch(uint _timestamp);
+    event Launch(uint256 _timestamp);
 
     // ----------- State changing API -----------
 
     /// @notice allows for entry into the Genesis Group via ETH. Only callable during Genesis Period.
     /// @param to address to send FGEN Genesis tokens to
     /// @param value amount of ETH to deposit
-    function purchase(address to, uint value) external payable;
+    function purchase(address to, uint256 value) external payable;
 
     /// @notice redeem FGEN genesis tokens for FEI and TRIBE. Only callable post launch
     /// @param to address to send redeemed FEI and TRIBE to.
@@ -32,11 +37,14 @@ interface IGenesisGroup {
     /// @param from address to source FGEN Genesis shares from
     /// @param to address to earn TRIBE and redeem post launch
     /// @param amount of FGEN Genesis shares to commit
-    function commit(address from, address to, uint amount) external;
+    function commit(
+        address from,
+        address to,
+        uint256 amount
+    ) external;
 
     /// @notice launch Fei Protocol. Callable once Genesis Period has ended or the max price has been reached
     function launch() external;
-
 
     // ----------- Getters -----------
 
@@ -45,6 +53,8 @@ interface IGenesisGroup {
     /// @param inclusive if true, assumes the `amountIn` is part of the existing FGEN supply. Set to false to simulate a new purchase.
     /// @return feiAmount the amount of FEI received by the user
     /// @return tribeAmount the amount of TRIBE received by the user
-    function getAmountOut(uint amountIn, bool inclusive) external view returns (uint feiAmount, uint tribeAmount);
-    
+    function getAmountOut(uint256 amountIn, bool inclusive)
+        external
+        view
+        returns (uint256 feiAmount, uint256 tribeAmount);
 }

--- a/contracts/oracle/BondingCurveOracle.sol
+++ b/contracts/oracle/BondingCurveOracle.sol
@@ -9,81 +9,94 @@ import "../utils/Timed.sol";
 /// @author Fei Protocol
 /// @notice includes "thawing" on the initial purchase price at genesis. Time weights price from initial to true peg over a window.
 contract BondingCurveOracle is IBondingCurveOracle, CoreRef, Timed {
-	using Decimal for Decimal.D256;
+    using Decimal for Decimal.D256;
 
-	IOracle public override uniswapOracle;
-	IBondingCurve public override bondingCurve;
+    IOracle public override uniswapOracle;
+    IBondingCurve public override bondingCurve;
 
-	bool public override killSwitch = true;
+    bool public override killSwitch = true;
 
-	Decimal.D256 internal _initialPrice;
+    Decimal.D256 internal _initialPrice;
 
-	/// @notice BondingCurveOracle constructor
-	/// @param _core Fei Core to reference
-	/// @param _oracle Uniswap Oracle to report from
-	/// @param _bondingCurve Bonding curve to report from
-	/// @param _duration price thawing duration
-	constructor(
-		address _core, 
-		address _oracle, 
-		address _bondingCurve, 
-		uint _duration
-	) public CoreRef(_core) Timed(_duration) {
-		uniswapOracle = IOracle(_oracle);
-		bondingCurve = IBondingCurve(_bondingCurve);
-	}
+    /// @notice BondingCurveOracle constructor
+    /// @param _core Fei Core to reference
+    /// @param _oracle Uniswap Oracle to report from
+    /// @param _bondingCurve Bonding curve to report from
+    /// @param _duration price thawing duration
+    constructor(
+        address _core,
+        address _oracle,
+        address _bondingCurve,
+        uint256 _duration
+    ) public CoreRef(_core) Timed(_duration) {
+        uniswapOracle = IOracle(_oracle);
+        bondingCurve = IBondingCurve(_bondingCurve);
+    }
 
-	function update() external override returns (bool) {
-		return uniswapOracle.update();
-	}
+    function setKillSwitch(bool _killSwitch) external override onlyGovernor {
+        killSwitch = _killSwitch;
+        emit KillSwitchUpdate(_killSwitch);
+    }
 
-	function isOutdated() external view override returns(bool) {
-		return uniswapOracle.isOutdated();
-	}
+    function update() external override returns (bool) {
+        return uniswapOracle.update();
+    }
+
+    function isOutdated() external view override returns (bool) {
+        return uniswapOracle.isOutdated();
+    }
 
     function read() external view override returns (Decimal.D256 memory, bool) {
-    	if (killSwitch) {
-    		return (Decimal.zero(), false);
-    	}
-    	(Decimal.D256 memory peg, bool valid) = getOracleValue();
-    	return (thaw(peg), valid);
+        if (killSwitch) {
+            return (Decimal.zero(), false);
+        }
+        (Decimal.D256 memory peg, bool valid) = _getOracleValue();
+        return (_thaw(peg), valid);
     }
 
-	function setKillSwitch(bool _killSwitch) external override onlyGovernor {
-		killSwitch = _killSwitch;
-		emit KillSwitchUpdate(_killSwitch);
-	}
-
-	function init(Decimal.D256 memory initialPrice) public override onlyGenesisGroup {
-    	killSwitch = false;
-
-    	_initialPrice = initialPrice;
-
-		_initTimed();
+    function initialPrice() external override returns (Decimal.D256 memory) {
+        return _initialPrice;
     }
 
-	function initialPrice() external override returns(Decimal.D256 memory) {
-		return _initialPrice;
-	}
+    function init(Decimal.D256 memory initPrice)
+        public
+        override
+        onlyGenesisGroup
+    {
+        killSwitch = false;
 
-    function thaw(Decimal.D256 memory peg) internal view returns (Decimal.D256 memory) {
-    	if (isTimeEnded()) {
-    		return peg;
-    	}
-		uint elapsed = timeSinceStart();
-		uint remaining = remainingTime();
+        _initialPrice = initPrice;
 
-    	(Decimal.D256 memory uniswapPeg,) = uniswapOracle.read();
-    	Decimal.D256 memory price = uniswapPeg.div(peg);
-
-    	Decimal.D256 memory weightedPrice = _initialPrice.mul(remaining).add(price.mul(elapsed)).div(duration);
-    	return uniswapPeg.div(weightedPrice);
+        _initTimed();
     }
 
-    function getOracleValue() internal view returns(Decimal.D256 memory, bool) {
-    	if (bondingCurve.atScale()) {
-    		return uniswapOracle.read();
-    	}
-    	return (bondingCurve.getCurrentPrice(), true);
+    function _thaw(Decimal.D256 memory peg)
+        internal
+        view
+        returns (Decimal.D256 memory)
+    {
+        if (isTimeEnded()) {
+            return peg;
+        }
+        uint256 elapsed = timeSinceStart();
+        uint256 remaining = remainingTime();
+
+        (Decimal.D256 memory uniswapPeg, ) = uniswapOracle.read();
+        Decimal.D256 memory price = uniswapPeg.div(peg);
+
+        Decimal.D256 memory weightedPrice =
+            _initialPrice.mul(remaining).add(price.mul(elapsed)).div(duration);
+        return uniswapPeg.div(weightedPrice);
+    }
+
+    function _getOracleValue()
+        internal
+        view
+        returns (Decimal.D256 memory, bool)
+    {
+        if (bondingCurve.atScale()) {
+            return uniswapOracle.read();
+        }
+        return (bondingCurve.getCurrentPrice(), true);
     }
 }

--- a/contracts/oracle/IBondingCurveOracle.sol
+++ b/contracts/oracle/IBondingCurveOracle.sol
@@ -19,11 +19,11 @@ interface IBondingCurveOracle is IOracle {
     // ----------- Getters -----------
 
     /// @notice the referenced uniswap oracle price
-    function uniswapOracle() external returns(IOracle);
+    function uniswapOracle() external returns (IOracle);
 
     /// @notice the referenced bonding curve
-    function bondingCurve() external returns(IBondingCurve);
+    function bondingCurve() external returns (IBondingCurve);
 
     /// @notice the initial price denominated in USD per FEI to thaw from
-    function initialPrice() external returns(Decimal.D256 memory);
+    function initialPrice() external returns (Decimal.D256 memory);
 }

--- a/contracts/oracle/IOracle.sol
+++ b/contracts/oracle/IOracle.sol
@@ -6,12 +6,11 @@ import "../external/Decimal.sol";
 /// @title generic oracle interface for Fei Protocol
 /// @author Fei Protocol
 interface IOracle {
-	
     // ----------- Events -----------
 
-	event KillSwitchUpdate(bool _killSwitch);
+    event KillSwitchUpdate(bool _killSwitch);
 
-	event Update(uint _peg);
+    event Update(uint256 _peg);
 
     // ----------- State changing API -----------
 
@@ -30,13 +29,13 @@ interface IOracle {
     /// @notice read the oracle price
     /// @return oracle price
     /// @return true if price is valid
-    /// @dev price is to be denominated in USD per X where X can be ETH, etc. 
+    /// @dev price is to be denominated in USD per X where X can be ETH, etc.
     /// @dev Can be innacurate if outdated, need to call `isOutdated()` to check
     function read() external view returns (Decimal.D256 memory, bool);
 
     /// @notice determine if read value is stale
     /// @return true if read value is stale
-    function isOutdated() external view returns(bool);
+    function isOutdated() external view returns (bool);
 
     /// @notice the kill switch for the oracle feed
     /// @return true if kill switch engaged

--- a/contracts/oracle/IUniswapOracle.sol
+++ b/contracts/oracle/IUniswapOracle.sol
@@ -8,26 +8,25 @@ import "./IOracle.sol";
 /// @author Fei Protocol
 /// @notice maintains the TWAP of a uniswap pair contract over a specified duration
 interface IUniswapOracle is IOracle {
-
-	// ----------- Events -----------
-    event DurationUpdate(uint _duration);
+    // ----------- Events -----------
+    event DurationUpdate(uint256 _duration);
 
     // ----------- Governor only state changing API -----------
 
     /// @notice set a new duration for the TWAP window
-    function setDuration(uint _duration) external;
+    function setDuration(uint256 _duration) external;
 
     // ----------- Getters -----------
 
     /// @notice the previous timestamp of the oracle snapshot
-    function priorTimestamp() external returns(uint32);
+    function priorTimestamp() external returns (uint32);
 
     /// @notice the previous cumulative price of the oracle snapshot
-    function priorCumulative() external returns(uint);
+    function priorCumulative() external returns (uint256);
 
     /// @notice the window over which the initial price will "thaw" to the true peg price
-    function duration() external returns(uint);
+    function duration() external returns (uint256);
 
     /// @notice the referenced uniswap pair contract
-    function pair() external returns(IUniswapV2Pair);
+    function pair() external returns (IUniswapV2Pair);
 }

--- a/contracts/oracle/UniswapOracle.sol
+++ b/contracts/oracle/UniswapOracle.sol
@@ -1,4 +1,3 @@
-
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
@@ -13,97 +12,113 @@ import "../external/SafeMathCopy.sol";
 /// @title IUniswapOracle implementation contract
 /// @author Fei Protocol
 contract UniswapOracle is IUniswapOracle, CoreRef {
-	using Decimal for Decimal.D256;
-	using SafeMathCopy for uint;
+    using Decimal for Decimal.D256;
+    using SafeMathCopy for uint256;
 
-	IUniswapV2Pair public override pair;
-	bool private isPrice0;
+    IUniswapV2Pair public override pair;
+    bool private isPrice0;
 
-	uint public override priorCumulative; 
-	uint32 public override priorTimestamp;
+    uint256 public override priorCumulative;
+    uint32 public override priorTimestamp;
 
-	Decimal.D256 private twap = Decimal.zero();
-	uint public override duration;
+    Decimal.D256 private twap = Decimal.zero();
+    uint256 public override duration;
 
-	bool public override killSwitch;
+    bool public override killSwitch;
 
-	uint private constant FIXED_POINT_GRANULARITY = 2**112;
-	uint private constant USDC_DECIMALS_MULTIPLIER = 1e12; // to normalize USDC and ETH wei units
+    uint256 private constant FIXED_POINT_GRANULARITY = 2**112;
+    uint256 private constant USDC_DECIMALS_MULTIPLIER = 1e12; // to normalize USDC and ETH wei units
 
-	/// @notice UniswapOracle constructor
-	/// @param _core Fei Core for reference
-	/// @param _pair Uniswap Pair to provide TWAP
-	/// @param _duration TWAP duration
-	/// @param _isPrice0 flag for using token0 or token1 for cumulative on Uniswap
-	constructor(
-		address _core, 
-		address _pair, 
-		uint _duration,
-		bool _isPrice0
-	) public CoreRef(_core) {
-		pair = IUniswapV2Pair(_pair);
-		// Relative to USD per ETH price
-		isPrice0 = _isPrice0;
+    /// @notice UniswapOracle constructor
+    /// @param _core Fei Core for reference
+    /// @param _pair Uniswap Pair to provide TWAP
+    /// @param _duration TWAP duration
+    /// @param _isPrice0 flag for using token0 or token1 for cumulative on Uniswap
+    constructor(
+        address _core,
+        address _pair,
+        uint256 _duration,
+        bool _isPrice0
+    ) public CoreRef(_core) {
+        pair = IUniswapV2Pair(_pair);
+        // Relative to USD per ETH price
+        isPrice0 = _isPrice0;
 
-		duration = _duration;
+        duration = _duration;
 
-		_init();
-	}
-
-	function update() external override returns (bool) {
-		(uint price0Cumulative, uint price1Cumulative, uint32 currentTimestamp) =
-            UniswapV2OracleLibrary.currentCumulativePrices(address(pair));
-
-		uint32 deltaTimestamp = currentTimestamp - priorTimestamp; // allowing underflow per Uniswap Oracle spec
-		if(deltaTimestamp < duration) {
-			return false;
-		}
-
-		uint currentCumulative = _getCumulative(price0Cumulative, price1Cumulative);
-		uint deltaCumulative = (currentCumulative - priorCumulative).mul(USDC_DECIMALS_MULTIPLIER); // allowing underflow per Uniswap Oracle spec
-
-		// Uniswap stores cumulative price variables as a fixed point 112x112 so we need to divide out the granularity
-		Decimal.D256 memory _twap = Decimal.ratio(deltaCumulative / deltaTimestamp, FIXED_POINT_GRANULARITY);
-		twap = _twap;
-
-		priorTimestamp = currentTimestamp;
-		priorCumulative = currentCumulative;
-
-		emit Update(_twap.asUint256());
-
-		return true;
-	}
-
-	function isOutdated() external view override returns(bool) {
-		(,, uint32 currentTimestamp) = UniswapV2OracleLibrary.currentCumulativePrices(address(pair));
-		uint32 deltaTimestamp = currentTimestamp - priorTimestamp; // allowing underflow per Uniswap Oracle spec
-		return deltaTimestamp >= duration;
-	}
-
-    function read() external view override returns (Decimal.D256 memory, bool) {
-    	bool valid = !(killSwitch || twap.isZero());
-    	return (twap, valid);
+        _init();
     }
- 
-	function setKillSwitch(bool _killSwitch) external override onlyGovernor {
-		killSwitch = _killSwitch;
-		emit KillSwitchUpdate(_killSwitch);
-	}
 
-	function setDuration(uint _duration) external override onlyGovernor {
-		duration = _duration;
-		emit DurationUpdate(_duration);
-	}
+    function update() external override returns (bool) {
+        (
+            uint256 price0Cumulative,
+            uint256 price1Cumulative,
+            uint32 currentTimestamp
+        ) = UniswapV2OracleLibrary.currentCumulativePrices(address(pair));
 
-	function _init() internal {
-		(uint price0Cumulative, uint price1Cumulative, uint32 currentTimestamp) =
-            UniswapV2OracleLibrary.currentCumulativePrices(address(pair));
+        uint32 deltaTimestamp = currentTimestamp - priorTimestamp; // allowing underflow per Uniswap Oracle spec
+        if (deltaTimestamp < duration) {
+            return false;
+        }
+
+        uint256 currentCumulative = _getCumulative(price0Cumulative, price1Cumulative);
+        uint256 deltaCumulative =
+            (currentCumulative - priorCumulative).mul(USDC_DECIMALS_MULTIPLIER); // allowing underflow per Uniswap Oracle spec
+
+        // Uniswap stores cumulative price variables as a fixed point 112x112 so we need to divide out the granularity
+        Decimal.D256 memory _twap =
+            Decimal.ratio(
+                deltaCumulative / deltaTimestamp,
+                FIXED_POINT_GRANULARITY
+            );
+        twap = _twap;
 
         priorTimestamp = currentTimestamp;
-		priorCumulative = _getCumulative(price0Cumulative, price1Cumulative);
-	}
+        priorCumulative = currentCumulative;
 
-    function _getCumulative(uint price0Cumulative, uint price1Cumulative) internal view returns (uint) {
-		return isPrice0 ? price0Cumulative : price1Cumulative;
-	}
+        emit Update(_twap.asUint256());
+
+        return true;
+    }
+
+    function isOutdated() external view override returns (bool) {
+        (, , uint32 currentTimestamp) =
+            UniswapV2OracleLibrary.currentCumulativePrices(address(pair));
+        uint32 deltaTimestamp = currentTimestamp - priorTimestamp; // allowing underflow per Uniswap Oracle spec
+        return deltaTimestamp >= duration;
+    }
+
+    function read() external view override returns (Decimal.D256 memory, bool) {
+        bool valid = !(killSwitch || twap.isZero());
+        return (twap, valid);
+    }
+
+    function setKillSwitch(bool _killSwitch) external override onlyGovernor {
+        killSwitch = _killSwitch;
+        emit KillSwitchUpdate(_killSwitch);
+    }
+
+    function setDuration(uint256 _duration) external override onlyGovernor {
+        duration = _duration;
+        emit DurationUpdate(_duration);
+    }
+
+    function _init() internal {
+        (
+            uint256 price0Cumulative,
+            uint256 price1Cumulative,
+            uint32 currentTimestamp
+        ) = UniswapV2OracleLibrary.currentCumulativePrices(address(pair));
+
+        priorTimestamp = currentTimestamp;
+        priorCumulative = _getCumulative(price0Cumulative, price1Cumulative);
+    }
+
+    function _getCumulative(uint256 price0Cumulative, uint256 price1Cumulative)
+        internal
+        view
+        returns (uint256)
+    {
+        return isPrice0 ? price0Cumulative : price1Cumulative;
+    }
 }

--- a/contracts/orchestration/BondingCurveOrchestrator.sol
+++ b/contracts/orchestration/BondingCurveOrchestrator.sol
@@ -6,47 +6,49 @@ import "../bondingcurve/EthBondingCurve.sol";
 import "./IOrchestrator.sol";
 
 contract BondingCurveOrchestrator is IBondingCurveOrchestrator, Ownable {
+    uint256 private constant SPLITTER_GRANULARITY = 10000;
 
-	uint private constant SPLITTER_GRANULARITY = 10000;
+    function init(
+        address core,
+        address uniswapOracle,
+        address ethUniswapPCVDeposit,
+        uint256 scale,
+        uint256 thawingDuration,
+        uint256 bondingCurveIncentiveDuration,
+        uint256 bondingCurveIncentiveAmount
+    )
+        public
+        override
+        onlyOwner
+        returns (address ethBondingCurve, address bondingCurveOracle)
+    {
+        uint256[] memory ratios = new uint256[](1);
+        ratios[0] = SPLITTER_GRANULARITY; // 100% to the ethUniswapPCVDeposit
+        address[] memory allocations = new address[](1);
+        allocations[0] = address(ethUniswapPCVDeposit);
+        ethBondingCurve = address(
+            new EthBondingCurve(
+                scale,
+                core,
+                allocations,
+                ratios,
+                uniswapOracle,
+                bondingCurveIncentiveDuration,
+                bondingCurveIncentiveAmount
+            )
+        );
+        bondingCurveOracle = address(
+            new BondingCurveOracle(
+                core,
+                uniswapOracle,
+                ethBondingCurve,
+                thawingDuration
+            )
+        );
+        return (ethBondingCurve, bondingCurveOracle);
+    }
 
-	function init(
-		address core, 
-		address uniswapOracle, 
-		address ethUniswapPCVDeposit, 
-		uint scale,
-		uint thawingDuration,
-		uint bondingCurveIncentiveDuration,
-		uint bondingCurveIncentiveAmount
-	) public override onlyOwner returns(
-		address ethBondingCurve,
-		address bondingCurveOracle
-	) {
-		uint[] memory ratios = new uint[](1);
-		ratios[0] = SPLITTER_GRANULARITY; // 100% to the ethUniswapPCVDeposit
-		address[] memory allocations = new address[](1);
-		allocations[0] = address(ethUniswapPCVDeposit);
-		ethBondingCurve = address(new EthBondingCurve(
-			scale, 
-			core, 
-			allocations, 
-			ratios, 
-			uniswapOracle, 
-			bondingCurveIncentiveDuration, 
-			bondingCurveIncentiveAmount
-		));
-		bondingCurveOracle = address(new BondingCurveOracle(
-			core, 
-			uniswapOracle, 
-			ethBondingCurve, 
-			thawingDuration
-		));
-		return (
-			ethBondingCurve,
-			bondingCurveOracle
-		);
-	}
-
-	function detonate() public override onlyOwner {
-		selfdestruct(payable(owner()));
-	}
+    function detonate() public override onlyOwner {
+        selfdestruct(payable(owner()));
+    }
 }

--- a/contracts/orchestration/ControllerOrchestrator.sol
+++ b/contracts/orchestration/ControllerOrchestrator.sol
@@ -5,30 +5,32 @@ import "../pcv/EthUniswapPCVController.sol";
 import "./IOrchestrator.sol";
 
 contract ControllerOrchestrator is IControllerOrchestrator, Ownable {
+    function init(
+        address core,
+        address bondingCurveOracle,
+        address uniswapIncentive,
+        address ethUniswapPCVDeposit,
+        address pair,
+        address router,
+        uint256 reweightIncentive,
+        uint256 reweightMinDistanceBPs
+    ) public override onlyOwner returns (address) {
+        return
+            address(
+                new EthUniswapPCVController(
+                    core,
+                    ethUniswapPCVDeposit,
+                    bondingCurveOracle,
+                    uniswapIncentive,
+                    reweightIncentive,
+                    reweightMinDistanceBPs,
+                    pair,
+                    router
+                )
+            );
+    }
 
-	function init(
-		address core,
-		address bondingCurveOracle, 
-		address uniswapIncentive, 
-		address ethUniswapPCVDeposit,
-		address pair, 
-		address router,
-		uint reweightIncentive,
-		uint reweightMinDistanceBPs
-	) public override onlyOwner returns(address) {
-		return address(new EthUniswapPCVController(
-				core, 
-				ethUniswapPCVDeposit, 
-				bondingCurveOracle, 
-				uniswapIncentive,
-				reweightIncentive,
-				reweightMinDistanceBPs,
-				pair, 
-				router
-			));
-	}
-
-	function detonate() public override onlyOwner {
-		selfdestruct(payable(owner()));
-	}
+    function detonate() public override onlyOwner {
+        selfdestruct(payable(owner()));
+    }
 }

--- a/contracts/orchestration/CoreOrchestrator.sol
+++ b/contracts/orchestration/CoreOrchestrator.sol
@@ -10,239 +10,273 @@ import "../core/Core.sol";
 import "./IOrchestrator.sol";
 
 interface ITribe {
-	function setMinter(address minter_) external;
+    function setMinter(address minter_) external;
 }
 
 // solhint-disable-next-line max-states-count
 contract CoreOrchestrator is Ownable {
-	address public admin;
+    address public admin;
 
-	// ----------- Uniswap Addresses -----------
-	address public constant ETH_USDC_UNI_PAIR = address(0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc);
-	address public constant ROUTER = address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
+    // ----------- Uniswap Addresses -----------
+    address public constant ETH_USDC_UNI_PAIR =
+        address(0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc);
+    address public constant ROUTER =
+        address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
 
-	address public constant WETH = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-	IUniswapV2Factory public constant UNISWAP_FACTORY = IUniswapV2Factory(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
+    address public constant WETH =
+        address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    IUniswapV2Factory public constant UNISWAP_FACTORY =
+        IUniswapV2Factory(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
 
-	address public ethFeiPair;
-	address public tribeFeiPair;
+    address public ethFeiPair;
+    address public tribeFeiPair;
 
-	// ----------- Time periods -----------
-	uint constant public RELEASE_WINDOW = 4 * 365 days;
+    // ----------- Time periods -----------
+    uint256 public constant RELEASE_WINDOW = 4 * 365 days;
 
-	uint public constant TIMELOCK_DELAY = 2 days;
-	uint public constant GENESIS_DURATION = 3 days;
+    uint256 public constant TIMELOCK_DELAY = 2 days;
+    uint256 public constant GENESIS_DURATION = 3 days;
 
-	uint public constant POOL_DURATION = 2 * 365 days;
-	uint public constant THAWING_DURATION = 4 weeks;
+    uint256 public constant POOL_DURATION = 2 * 365 days;
+    uint256 public constant THAWING_DURATION = 4 weeks;
 
-	uint public constant UNI_ORACLE_TWAP_DURATION = 10 minutes; // 10 min twap
+    uint256 public constant UNI_ORACLE_TWAP_DURATION = 10 minutes; // 10 min twap
 
-	uint public constant BONDING_CURVE_INCENTIVE_DURATION = 1 days; // 1 day duration
+    uint256 public constant BONDING_CURVE_INCENTIVE_DURATION = 1 days; // 1 day duration
 
-	// ----------- Params -----------
-	uint public constant EXCHANGE_RATE_DISCOUNT = 10;
+    // ----------- Params -----------
+    uint256 public constant EXCHANGE_RATE_DISCOUNT = 10;
 
-	uint32 public constant INCENTIVE_GROWTH_RATE = 75; // a bit over 1 unit per 5 hours assuming 13s block time
+    uint32 public constant INCENTIVE_GROWTH_RATE = 75; // a bit over 1 unit per 5 hours assuming 13s block time
 
-	uint public constant SCALE = 100_000_000e18;
-	uint public constant BONDING_CURVE_INCENTIVE = 500e18;
+    uint256 public constant SCALE = 100_000_000e18;
+    uint256 public constant BONDING_CURVE_INCENTIVE = 500e18;
 
-	uint public constant REWEIGHT_INCENTIVE = 500e18;
-	uint public constant MIN_REWEIGHT_DISTANCE_BPS = 100;
+    uint256 public constant REWEIGHT_INCENTIVE = 500e18;
+    uint256 public constant MIN_REWEIGHT_DISTANCE_BPS = 100;
 
-	bool public constant USDC_PER_ETH_IS_PRICE_0 = false;
+    bool public constant USDC_PER_ETH_IS_PRICE_0 = false;
 
+    uint256 public tribeSupply;
+    uint256 public constant IDO_TRIBE_PERCENTAGE = 20;
+    uint256 public constant GENESIS_TRIBE_PERCENTAGE = 10;
+    uint256 public constant DEV_TRIBE_PERCENTAGE = 20;
+    uint256 public constant STAKING_TRIBE_PERCENTAGE = 10;
 
-	uint public tribeSupply;
-	uint public constant IDO_TRIBE_PERCENTAGE = 20;
-	uint public constant GENESIS_TRIBE_PERCENTAGE = 10;
-	uint public constant DEV_TRIBE_PERCENTAGE = 20;
-	uint public constant STAKING_TRIBE_PERCENTAGE = 10;
+    // ----------- Orchestrators -----------
+    IPCVDepositOrchestrator private pcvDepositOrchestrator;
+    IBondingCurveOrchestrator private bcOrchestrator;
+    IIncentiveOrchestrator private incentiveOrchestrator;
+    IControllerOrchestrator private controllerOrchestrator;
+    IIDOOrchestrator private idoOrchestrator;
+    IGenesisOrchestrator private genesisOrchestrator;
+    IGovernanceOrchestrator private governanceOrchestrator;
+    IRouterOrchestrator private routerOrchestrator;
 
-	// ----------- Orchestrators -----------
-	IPCVDepositOrchestrator private pcvDepositOrchestrator;
-	IBondingCurveOrchestrator private bcOrchestrator;
-	IIncentiveOrchestrator private incentiveOrchestrator;
-	IControllerOrchestrator private controllerOrchestrator;
-	IIDOOrchestrator private idoOrchestrator;
-	IGenesisOrchestrator private genesisOrchestrator;
-	IGovernanceOrchestrator private governanceOrchestrator;
-	IRouterOrchestrator private routerOrchestrator;
+    // ----------- Deployed Contracts -----------
+    Core public core;
+    address public fei;
+    address public tribe;
+    address public feiRouter;
 
-	// ----------- Deployed Contracts -----------
-	Core public core;
-	address public fei;
-	address public tribe;
-	address public feiRouter;
+    address public ethUniswapPCVDeposit;
+    address public ethBondingCurve;
 
-	address public ethUniswapPCVDeposit;
-	address public ethBondingCurve;
-		
-	address public uniswapOracle;
-	address public bondingCurveOracle;
+    address public uniswapOracle;
+    address public bondingCurveOracle;
 
-	address public uniswapIncentive;
+    address public uniswapIncentive;
 
-	address public ethUniswapPCVController;
+    address public ethUniswapPCVController;
 
-	address public ido;
-	address public timelockedDelegator;
+    address public ido;
+    address public timelockedDelegator;
 
-	address public genesisGroup;
-	address public pool;
+    address public genesisGroup;
+    address public pool;
 
-	address public governorAlpha;
-	address public timelock;
+    address public governorAlpha;
+    address public timelock;
 
-	constructor(
-		address _pcvDepositOrchestrator,
-		address _bcOrchestrator, 
-		address _incentiveOrchestrator, 
-		address _controllerOrchestrator,
-		address _idoOrchestrator,
-		address _genesisOrchestrator, 
-		address _governanceOrchestrator,
-		address _routerOrchestrator,
-		address _admin
-	) public {
-		core = new Core();
+    constructor(
+        address _pcvDepositOrchestrator,
+        address _bcOrchestrator,
+        address _incentiveOrchestrator,
+        address _controllerOrchestrator,
+        address _idoOrchestrator,
+        address _genesisOrchestrator,
+        address _governanceOrchestrator,
+        address _routerOrchestrator,
+        address _admin
+    ) public {
+        core = new Core();
 
-		require(_admin != address(0), "CoreOrchestrator: no admin");
+        require(_admin != address(0), "CoreOrchestrator: no admin");
 
-		core.grantRevoker(_admin);
+        core.grantRevoker(_admin);
 
-		pcvDepositOrchestrator = IPCVDepositOrchestrator(_pcvDepositOrchestrator);
-		bcOrchestrator = IBondingCurveOrchestrator(_bcOrchestrator);
-		incentiveOrchestrator = IIncentiveOrchestrator(_incentiveOrchestrator);
-		idoOrchestrator = IIDOOrchestrator(_idoOrchestrator);
-		controllerOrchestrator = IControllerOrchestrator(_controllerOrchestrator);
-		genesisOrchestrator = IGenesisOrchestrator(_genesisOrchestrator);
-		governanceOrchestrator = IGovernanceOrchestrator(_governanceOrchestrator);
-		routerOrchestrator = IRouterOrchestrator(_routerOrchestrator);
+        pcvDepositOrchestrator = IPCVDepositOrchestrator(
+            _pcvDepositOrchestrator
+        );
+        bcOrchestrator = IBondingCurveOrchestrator(_bcOrchestrator);
+        incentiveOrchestrator = IIncentiveOrchestrator(_incentiveOrchestrator);
+        idoOrchestrator = IIDOOrchestrator(_idoOrchestrator);
+        controllerOrchestrator = IControllerOrchestrator(
+            _controllerOrchestrator
+        );
+        genesisOrchestrator = IGenesisOrchestrator(_genesisOrchestrator);
+        governanceOrchestrator = IGovernanceOrchestrator(
+            _governanceOrchestrator
+        );
+        routerOrchestrator = IRouterOrchestrator(_routerOrchestrator);
 
-		admin = _admin;
-	}
+        admin = _admin;
+    }
 
-	function initCore() public onlyOwner {
-		core.init();
+    function initCore() public onlyOwner {
+        core.init();
 
-		tribe = address(core.tribe());
-		fei = address(core.fei());
-		tribeSupply = IERC20(tribe).totalSupply();
-	}
+        tribe = address(core.tribe());
+        fei = address(core.fei());
+        tribeSupply = IERC20(tribe).totalSupply();
+    }
 
+    function initPairs() public onlyOwner {
+        ethFeiPair = UNISWAP_FACTORY.createPair(fei, WETH);
+        tribeFeiPair = UNISWAP_FACTORY.createPair(tribe, fei);
+    }
 
-	function initPairs() public onlyOwner {
-		ethFeiPair = UNISWAP_FACTORY.createPair(fei, WETH);
-		tribeFeiPair = UNISWAP_FACTORY.createPair(tribe, fei);
-	}
+    function initPCVDeposit() public onlyOwner() {
+        (ethUniswapPCVDeposit, uniswapOracle) = pcvDepositOrchestrator.init(
+            address(core),
+            ethFeiPair,
+            ROUTER,
+            ETH_USDC_UNI_PAIR,
+            UNI_ORACLE_TWAP_DURATION,
+            USDC_PER_ETH_IS_PRICE_0
+        );
+        core.grantMinter(ethUniswapPCVDeposit);
+        pcvDepositOrchestrator.detonate();
+    }
 
-	function initPCVDeposit() public onlyOwner() {
-		(ethUniswapPCVDeposit, uniswapOracle) = pcvDepositOrchestrator.init(
-			address(core),
-			ethFeiPair,
-			ROUTER,
-			ETH_USDC_UNI_PAIR,
-			UNI_ORACLE_TWAP_DURATION,
-			USDC_PER_ETH_IS_PRICE_0
-		);
-		core.grantMinter(ethUniswapPCVDeposit);
-		pcvDepositOrchestrator.detonate();
-	}
+    function initBondingCurve() public onlyOwner {
+        (ethBondingCurve, bondingCurveOracle) = bcOrchestrator.init(
+            address(core),
+            uniswapOracle,
+            ethUniswapPCVDeposit,
+            SCALE,
+            THAWING_DURATION,
+            BONDING_CURVE_INCENTIVE_DURATION,
+            BONDING_CURVE_INCENTIVE
+        );
+        core.grantMinter(ethBondingCurve);
+        IOracleRef(ethUniswapPCVDeposit).setOracle(bondingCurveOracle);
+        bcOrchestrator.detonate();
+    }
 
-	function initBondingCurve() public onlyOwner {
-		(ethBondingCurve,
-		 bondingCurveOracle) = bcOrchestrator.init(
-			 address(core), 
-			 uniswapOracle, 
-			 ethUniswapPCVDeposit, 
-			 SCALE, 
-			 THAWING_DURATION,
-			 BONDING_CURVE_INCENTIVE_DURATION,
-			 BONDING_CURVE_INCENTIVE
-		);
-		core.grantMinter(ethBondingCurve);
-		IOracleRef(ethUniswapPCVDeposit).setOracle(bondingCurveOracle);
-		bcOrchestrator.detonate();
-	}
+    function initIncentive() public onlyOwner {
+        uniswapIncentive = incentiveOrchestrator.init(
+            address(core),
+            bondingCurveOracle,
+            ethFeiPair,
+            ROUTER,
+            INCENTIVE_GROWTH_RATE
+        );
+        core.grantMinter(uniswapIncentive);
+        core.grantBurner(uniswapIncentive);
+        IFei(fei).setIncentiveContract(ethFeiPair, uniswapIncentive);
+        incentiveOrchestrator.detonate();
+    }
 
-	function initIncentive() public onlyOwner {
-		uniswapIncentive = incentiveOrchestrator.init(
-			address(core), 
-			bondingCurveOracle, 
-			ethFeiPair,
-			ROUTER,
-			INCENTIVE_GROWTH_RATE
-		);
-		core.grantMinter(uniswapIncentive);
-		core.grantBurner(uniswapIncentive);
-		IFei(fei).setIncentiveContract(ethFeiPair, uniswapIncentive);
-		incentiveOrchestrator.detonate();
-	}
+    function initRouter() public onlyOwner {
+        feiRouter = routerOrchestrator.init(ethFeiPair, WETH, uniswapIncentive);
 
-	function initRouter() public onlyOwner {
-		feiRouter = routerOrchestrator.init(ethFeiPair, WETH, uniswapIncentive);
-		
-		IUniswapIncentive(uniswapIncentive).setSellAllowlisted(feiRouter, true);
-		IUniswapIncentive(uniswapIncentive).setSellAllowlisted(ethUniswapPCVDeposit, true);
-		IUniswapIncentive(uniswapIncentive).setSellAllowlisted(ethUniswapPCVController, true);
+        IUniswapIncentive(uniswapIncentive).setSellAllowlisted(feiRouter, true);
+        IUniswapIncentive(uniswapIncentive).setSellAllowlisted(
+            ethUniswapPCVDeposit,
+            true
+        );
+        IUniswapIncentive(uniswapIncentive).setSellAllowlisted(
+            ethUniswapPCVController,
+            true
+        );
+    }
 
-	}
+    function initController() public onlyOwner {
+        ethUniswapPCVController = controllerOrchestrator.init(
+            address(core),
+            bondingCurveOracle,
+            uniswapIncentive,
+            ethUniswapPCVDeposit,
+            ethFeiPair,
+            ROUTER,
+            REWEIGHT_INCENTIVE,
+            MIN_REWEIGHT_DISTANCE_BPS
+        );
+        core.grantMinter(ethUniswapPCVController);
+        core.grantPCVController(ethUniswapPCVController);
 
-	function initController() public onlyOwner {
-		ethUniswapPCVController = controllerOrchestrator.init(
-			address(core), 
-			bondingCurveOracle, 
-			uniswapIncentive, 
-			ethUniswapPCVDeposit, 
-			ethFeiPair,
-			ROUTER,
-			REWEIGHT_INCENTIVE,
-			MIN_REWEIGHT_DISTANCE_BPS
-		);
-		core.grantMinter(ethUniswapPCVController);
-		core.grantPCVController(ethUniswapPCVController);
-		
-		IUniswapIncentive(uniswapIncentive).setExemptAddress(ethUniswapPCVDeposit, true);
-		IUniswapIncentive(uniswapIncentive).setExemptAddress(ethUniswapPCVController, true);
+        IUniswapIncentive(uniswapIncentive).setExemptAddress(
+            ethUniswapPCVDeposit,
+            true
+        );
+        IUniswapIncentive(uniswapIncentive).setExemptAddress(
+            ethUniswapPCVController,
+            true
+        );
 
-		controllerOrchestrator.detonate();
-	}
+        controllerOrchestrator.detonate();
+    }
 
-	function initIDO() public onlyOwner {
-		(ido, timelockedDelegator) = idoOrchestrator.init(address(core), admin, tribe, tribeFeiPair, ROUTER, RELEASE_WINDOW);
-		core.grantMinter(ido);
-		core.allocateTribe(ido, tribeSupply * IDO_TRIBE_PERCENTAGE / 100);
-		core.allocateTribe(timelockedDelegator, tribeSupply * DEV_TRIBE_PERCENTAGE / 100);
-		idoOrchestrator.detonate();
-	}
+    function initIDO() public onlyOwner {
+        (ido, timelockedDelegator) = idoOrchestrator.init(
+            address(core),
+            admin,
+            tribe,
+            tribeFeiPair,
+            ROUTER,
+            RELEASE_WINDOW
+        );
+        core.grantMinter(ido);
+        core.allocateTribe(ido, (tribeSupply * IDO_TRIBE_PERCENTAGE) / 100);
+        core.allocateTribe(
+            timelockedDelegator,
+            (tribeSupply * DEV_TRIBE_PERCENTAGE) / 100
+        );
+        idoOrchestrator.detonate();
+    }
 
-	function initGenesis() public onlyOwner {
-		(genesisGroup, pool) = genesisOrchestrator.init(
-			address(core), 
-			ethBondingCurve, 
-			ido,
-			tribeFeiPair,
-			bondingCurveOracle,
-			GENESIS_DURATION,
-			EXCHANGE_RATE_DISCOUNT,
-			POOL_DURATION
-		);
-		core.setGenesisGroup(genesisGroup);
-		core.allocateTribe(genesisGroup, tribeSupply * GENESIS_TRIBE_PERCENTAGE / 100);
-		core.allocateTribe(pool, tribeSupply * STAKING_TRIBE_PERCENTAGE / 100);
-		genesisOrchestrator.detonate();
-	}
+    function initGenesis() public onlyOwner {
+        (genesisGroup, pool) = genesisOrchestrator.init(
+            address(core),
+            ethBondingCurve,
+            ido,
+            tribeFeiPair,
+            bondingCurveOracle,
+            GENESIS_DURATION,
+            EXCHANGE_RATE_DISCOUNT,
+            POOL_DURATION
+        );
+        core.setGenesisGroup(genesisGroup);
+        core.allocateTribe(
+            genesisGroup,
+            (tribeSupply * GENESIS_TRIBE_PERCENTAGE) / 100
+        );
+        core.allocateTribe(
+            pool,
+            (tribeSupply * STAKING_TRIBE_PERCENTAGE) / 100
+        );
+        genesisOrchestrator.detonate();
+    }
 
-	function initGovernance() public onlyOwner {
-		(governorAlpha, timelock) = governanceOrchestrator.init(
-			admin, 
-			tribe,
-			TIMELOCK_DELAY
-		);
-		governanceOrchestrator.detonate();
-		core.grantGovernor(timelock);
-		ITribe(tribe).setMinter(timelock);
-	}
+    function initGovernance() public onlyOwner {
+        (governorAlpha, timelock) = governanceOrchestrator.init(
+            admin,
+            tribe,
+            TIMELOCK_DELAY
+        );
+        governanceOrchestrator.detonate();
+        core.grantGovernor(timelock);
+        ITribe(tribe).setMinter(timelock);
+    }
 }

--- a/contracts/orchestration/GenesisOrchestrator.sol
+++ b/contracts/orchestration/GenesisOrchestrator.sol
@@ -6,31 +6,32 @@ import "../genesis/GenesisGroup.sol";
 import "./IOrchestrator.sol";
 
 contract GenesisOrchestrator is IGenesisOrchestrator, Ownable {
+    function init(
+        address core,
+        address ethBondingCurve,
+        address ido,
+        address tribeFeiPair,
+        address oracle,
+        uint256 genesisDuration,
+        uint256 exhangeRateDiscount,
+        uint256 poolDuration
+    ) public override onlyOwner returns (address genesisGroup, address pool) {
+        pool = address(new FeiPool(core, tribeFeiPair, poolDuration));
+        genesisGroup = address(
+            new GenesisGroup(
+                core,
+                ethBondingCurve,
+                ido,
+                oracle,
+                pool,
+                genesisDuration,
+                exhangeRateDiscount
+            )
+        );
+        return (genesisGroup, pool);
+    }
 
-	function init(
-		address core, 
-		address ethBondingCurve, 
-		address ido, 
-		address tribeFeiPair,
-		address oracle,
-		uint genesisDuration,
-		uint exhangeRateDiscount,
-		uint poolDuration
-	) public override onlyOwner returns (address genesisGroup, address pool) {
-		pool = address(new FeiPool(core, tribeFeiPair, poolDuration));
-		genesisGroup = address(new GenesisGroup(
-			core, 
-			ethBondingCurve, 
-			ido,
-			oracle,
-			pool, 
-			genesisDuration, 
-			exhangeRateDiscount
-		));
-		return (genesisGroup, pool);
-	}
-
-	function detonate() public override onlyOwner {
-		selfdestruct(payable(owner()));
-	}
+    function detonate() public override onlyOwner {
+        selfdestruct(payable(owner()));
+    }
 }

--- a/contracts/orchestration/GovernanceOrchestrator.sol
+++ b/contracts/orchestration/GovernanceOrchestrator.sol
@@ -6,16 +6,24 @@ import "../dao/GovernorAlpha.sol";
 import "./IOrchestrator.sol";
 
 contract GovernanceOrchestrator is IGovernanceOrchestrator, Ownable {
+    function init(
+        address admin,
+        address tribe,
+        uint256 timelockDelay
+    )
+        public
+        override
+        onlyOwner
+        returns (address governorAlpha, address timelock)
+    {
+        timelock = address(new Timelock(admin, timelockDelay));
+        governorAlpha = address(
+            new GovernorAlpha(address(timelock), tribe, admin)
+        );
+        return (governorAlpha, timelock);
+    }
 
-	function init(address admin, address tribe, uint timelockDelay) public override onlyOwner returns (
-		address governorAlpha, address timelock
-	) {
-		timelock = address(new Timelock(admin, timelockDelay));
-		governorAlpha = address(new GovernorAlpha(address(timelock), tribe, admin));
-		return (governorAlpha, timelock);
-	}
-
-	function detonate() public override onlyOwner {
-		selfdestruct(payable(owner()));
-	}
+    function detonate() public override onlyOwner {
+        selfdestruct(payable(owner()));
+    }
 }

--- a/contracts/orchestration/IDOOrchestrator.sol
+++ b/contracts/orchestration/IDOOrchestrator.sol
@@ -6,23 +6,28 @@ import "../dao/TimelockedDelegator.sol";
 import "./IOrchestrator.sol";
 
 contract IDOOrchestrator is IIDOOrchestrator, Ownable {
+    function init(
+        address core,
+        address admin,
+        address tribe,
+        address pair,
+        address router,
+        uint256 releaseWindowDuration
+    )
+        public
+        override
+        onlyOwner
+        returns (address ido, address timelockedDelegator)
+    {
+        ido = address(
+            new IDO(core, admin, releaseWindowDuration, pair, router)
+        );
+        timelockedDelegator = address(
+            new TimelockedDelegator(tribe, admin, releaseWindowDuration)
+        );
+    }
 
-	function init(
-		address core, 
-		address admin, 
-		address tribe, 
-		address pair, 
-		address router,
-		uint releaseWindowDuration
-	) public override onlyOwner returns (
-		address ido,
-		address timelockedDelegator
-	) {
-		ido = address(new IDO(core, admin, releaseWindowDuration, pair, router));
-		timelockedDelegator = address(new TimelockedDelegator(tribe, admin, releaseWindowDuration));
-	}
-
-	function detonate() public override onlyOwner {
-		selfdestruct(payable(owner()));
-	}
+    function detonate() public override onlyOwner {
+        selfdestruct(payable(owner()));
+    }
 }

--- a/contracts/orchestration/IOrchestrator.sol
+++ b/contracts/orchestration/IOrchestrator.sol
@@ -5,95 +5,87 @@ interface IOrchestrator {
 }
 
 interface IPCVDepositOrchestrator is IOrchestrator {
-	function init(
-		address core, 
-		address pair, 
-		address router,
-		address oraclePair,
-		uint twapDuration,
-		bool isPrice0
-	) external returns(
-		address ethUniswapPCVDeposit,
-		address uniswapOracle
-	);
+    function init(
+        address core,
+        address pair,
+        address router,
+        address oraclePair,
+        uint256 twapDuration,
+        bool isPrice0
+    ) external returns (address ethUniswapPCVDeposit, address uniswapOracle);
 }
 
-interface IBondingCurveOrchestrator is IOrchestrator  {
-	function init(
-		address core, 
-		address uniswapOracle, 
-		address ethUniswapPCVDeposit, 
-		uint scale,
-		uint thawingDuration,
-		uint bondingCurveIncentiveDuration,
-		uint bondingCurveIncentiveAmount
-	) external returns(
-		address ethBondingCurve,
-		address bondingCurveOracle
-	);
+interface IBondingCurveOrchestrator is IOrchestrator {
+    function init(
+        address core,
+        address uniswapOracle,
+        address ethUniswapPCVDeposit,
+        uint256 scale,
+        uint256 thawingDuration,
+        uint256 bondingCurveIncentiveDuration,
+        uint256 bondingCurveIncentiveAmount
+    ) external returns (address ethBondingCurve, address bondingCurveOracle);
 }
 
 interface IIncentiveOrchestrator is IOrchestrator {
-	function init(
-		address core, 
-		address bondingCurveOracle, 
-		address fei, 
-		address router,
-		uint32 growthRate
-	) external returns(address uniswapIncentive);
+    function init(
+        address core,
+        address bondingCurveOracle,
+        address fei,
+        address router,
+        uint32 growthRate
+    ) external returns (address uniswapIncentive);
 }
 
 interface IRouterOrchestrator is IOrchestrator {
-	function init(
-		address pair, 
-		address weth,
-		address incentive
-	) external returns(address ethRouter);
+    function init(
+        address pair,
+        address weth,
+        address incentive
+    ) external returns (address ethRouter);
 }
 
 interface IControllerOrchestrator is IOrchestrator {
-	function init(
-		address core, 
-		address bondingCurveOracle, 
-		address uniswapIncentive, 
-		address ethUniswapPCVDeposit, 
-		address fei, 
-		address router,
-		uint reweightIncentive,
-		uint reweightMinDistanceBPs
-	) external returns(address ethUniswapPCVController);
+    function init(
+        address core,
+        address bondingCurveOracle,
+        address uniswapIncentive,
+        address ethUniswapPCVDeposit,
+        address fei,
+        address router,
+        uint256 reweightIncentive,
+        uint256 reweightMinDistanceBPs
+    ) external returns (address ethUniswapPCVController);
 }
 
 interface IIDOOrchestrator is IOrchestrator {
-	function init(
-		address core, 
-		address admin, 
-		address tribe, 
-		address pair, 
-		address router,
-		uint releaseWindowDuration
-	) external returns (
-		address ido,
-		address timelockedDelegator
-	);
+    function init(
+        address core,
+        address admin,
+        address tribe,
+        address pair,
+        address router,
+        uint256 releaseWindowDuration
+    ) external returns (address ido, address timelockedDelegator);
 }
 
-interface IGenesisOrchestrator is IOrchestrator  {
-	function init(
-		address core, 
-		address ethBondingCurve, 
-		address ido,
-		address tribeFeiPair,
-		address oracle,
-		uint genesisDuration,
-		uint exhangeRateDiscount,
-		uint poolDuration
-	) external returns (address genesisGroup, address pool);
+interface IGenesisOrchestrator is IOrchestrator {
+    function init(
+        address core,
+        address ethBondingCurve,
+        address ido,
+        address tribeFeiPair,
+        address oracle,
+        uint256 genesisDuration,
+        uint256 exhangeRateDiscount,
+        uint256 poolDuration
+    ) external returns (address genesisGroup, address pool);
 }
 
 interface IGovernanceOrchestrator is IOrchestrator {
-	function init(address admin, address tribe, uint timelockDelay) external returns (
-		address governorAlpha, 
-		address timelock
-	);
+    function init(
+        address admin,
+        address tribe,
+        uint256 timelockDelay
+    ) external returns (address governorAlpha, address timelock);
 }

--- a/contracts/orchestration/PCVDepositOrchestrator.sol
+++ b/contracts/orchestration/PCVDepositOrchestrator.sol
@@ -6,32 +6,30 @@ import "../oracle/UniswapOracle.sol";
 import "./IOrchestrator.sol";
 
 contract PCVDepositOrchestrator is IPCVDepositOrchestrator, Ownable {
+    function init(
+        address core,
+        address pair,
+        address router,
+        address oraclePair,
+        uint256 twapDuration,
+        bool isPrice0
+    )
+        public
+        override
+        onlyOwner
+        returns (address ethUniswapPCVDeposit, address uniswapOracle)
+    {
+        uniswapOracle = address(
+            new UniswapOracle(core, oraclePair, twapDuration, isPrice0)
+        );
+        ethUniswapPCVDeposit = address(
+            new EthUniswapPCVDeposit(core, pair, router, uniswapOracle)
+        );
 
-	function init(
-		address core, 
-		address pair, 
-		address router,
-		address oraclePair,
-		uint twapDuration,
-		bool isPrice0
-	) public override onlyOwner returns(
-		address ethUniswapPCVDeposit,
-		address uniswapOracle
-	) {
-		uniswapOracle = address(new UniswapOracle(core, 
-			oraclePair, 
-			twapDuration, 
-			isPrice0
-		));
-		ethUniswapPCVDeposit = address(new EthUniswapPCVDeposit(core, pair, router, uniswapOracle));
+        return (ethUniswapPCVDeposit, uniswapOracle);
+    }
 
-		return (
-			ethUniswapPCVDeposit,
-			uniswapOracle
-		);
-	}
-
-	function detonate() public override onlyOwner {
-		selfdestruct(payable(owner()));
-	}
+    function detonate() public override onlyOwner {
+        selfdestruct(payable(owner()));
+    }
 }

--- a/contracts/orchestration/RouterOrchestrator.sol
+++ b/contracts/orchestration/RouterOrchestrator.sol
@@ -5,22 +5,17 @@ import "../router/FeiRouter.sol";
 import "./IOrchestrator.sol";
 
 contract RouterOrchestrator is IRouterOrchestrator, Ownable {
+    function init(
+        address pair,
+        address weth,
+        address incentive
+    ) public override onlyOwner returns (address ethRouter) {
+        ethRouter = address(new FeiRouter(pair, weth, incentive));
 
-	function init(
-		address pair, 
-		address weth,
-		address incentive
-	) public override onlyOwner returns(address ethRouter) {
-		
-		ethRouter = address(new FeiRouter(pair, 
-			weth, 
-			incentive
-		));
+        return ethRouter;
+    }
 
-		return ethRouter;
-	}
-
-	function detonate() public override onlyOwner {
-		selfdestruct(payable(owner()));
-	}
+    function detonate() public override onlyOwner {
+        selfdestruct(payable(owner()));
+    }
 }

--- a/contracts/pcv/EthUniswapPCVController.sol
+++ b/contracts/pcv/EthUniswapPCVController.sol
@@ -12,132 +12,166 @@ import "../external/SafeMathCopy.sol";
 /// @title a IUniswapPCVController implementation for ETH
 /// @author Fei Protocol
 contract EthUniswapPCVController is IUniswapPCVController, UniRef {
-	using Decimal for Decimal.D256;
-	using SafeMathCopy for uint;
+    using Decimal for Decimal.D256;
+    using SafeMathCopy for uint256;
 
-	uint internal constant WITHDRAW_AMOUNT_BPS = 9000;
+    uint256 internal constant WITHDRAW_AMOUNT_BPS = 9000;
 
-	uint internal constant BASIS_POINTS_GRANULARITY = 10000;
+    uint256 internal constant BASIS_POINTS_GRANULARITY = 10000;
 
-	IPCVDeposit public override pcvDeposit;
-	IUniswapIncentive public override incentiveContract;
+    IPCVDeposit public override pcvDeposit;
+    IUniswapIncentive public override incentiveContract;
 
-	uint public override reweightIncentiveAmount;
-	Decimal.D256 internal _minDistanceForReweight;
+    uint256 public override reweightIncentiveAmount;
+    Decimal.D256 internal _minDistanceForReweight;
 
-	/// @notice EthUniswapPCVController constructor
-	/// @param _core Fei Core for reference
-	/// @param _pcvDeposit PCV Deposit to reweight
-	/// @param _oracle oracle for reference
-	/// @param _incentiveContract incentive contract for reference
-	/// @param _incentiveAmount amount of FEI for triggering a reweight
-	/// @param _minDistanceForReweightBPs minimum distance from peg to reweight in basis points
-	/// @param _pair Uniswap pair contract to reweight
-	/// @param _router Uniswap Router
-	constructor (
-		address _core, 
-		address _pcvDeposit, 
-		address _oracle, 
-		address _incentiveContract,
-		uint _incentiveAmount,
-		uint _minDistanceForReweightBPs,
-		address _pair,
-		address _router
-	) public
-		UniRef(_core, _pair, _router, _oracle)
-	{
-		pcvDeposit = IPCVDeposit(_pcvDeposit);
-		incentiveContract = IUniswapIncentive(_incentiveContract);
+    /// @notice EthUniswapPCVController constructor
+    /// @param _core Fei Core for reference
+    /// @param _pcvDeposit PCV Deposit to reweight
+    /// @param _oracle oracle for reference
+    /// @param _incentiveContract incentive contract for reference
+    /// @param _incentiveAmount amount of FEI for triggering a reweight
+    /// @param _minDistanceForReweightBPs minimum distance from peg to reweight in basis points
+    /// @param _pair Uniswap pair contract to reweight
+    /// @param _router Uniswap Router
+    constructor(
+        address _core,
+        address _pcvDeposit,
+        address _oracle,
+        address _incentiveContract,
+        uint256 _incentiveAmount,
+        uint256 _minDistanceForReweightBPs,
+        address _pair,
+        address _router
+    ) public UniRef(_core, _pair, _router, _oracle) {
+        pcvDeposit = IPCVDeposit(_pcvDeposit);
+        incentiveContract = IUniswapIncentive(_incentiveContract);
 
-		reweightIncentiveAmount = _incentiveAmount;
-		_minDistanceForReweight = Decimal.ratio(_minDistanceForReweightBPs, BASIS_POINTS_GRANULARITY);
-	}
+        reweightIncentiveAmount = _incentiveAmount;
+        _minDistanceForReweight = Decimal.ratio(
+            _minDistanceForReweightBPs,
+            BASIS_POINTS_GRANULARITY
+        );
+    }
 
-	receive() external payable {}
+    receive() external payable {}
 
-	function reweight() external override postGenesis {
-		updateOracle();
-		require(reweightEligible(), "EthUniswapPCVController: Not at incentive parity or not at min distance");
-		_reweight();
-		_incentivize();
-	}
+    function reweight() external override postGenesis {
+        updateOracle();
+        require(
+            reweightEligible(),
+            "EthUniswapPCVController: Not at incentive parity or not at min distance"
+        );
+        _reweight();
+        _incentivize();
+    }
 
-	function forceReweight() external override onlyGovernor {
-		_reweight();
-	}
+    function forceReweight() external override onlyGovernor {
+        _reweight();
+    }
 
-	function setPCVDeposit(address _pcvDeposit) external override onlyGovernor {
-		pcvDeposit = IPCVDeposit(_pcvDeposit);
-		emit PCVDepositUpdate(_pcvDeposit);
-	}
+    function setPCVDeposit(address _pcvDeposit) external override onlyGovernor {
+        pcvDeposit = IPCVDeposit(_pcvDeposit);
+        emit PCVDepositUpdate(_pcvDeposit);
+    }
 
-	function setReweightIncentive(uint amount) external override onlyGovernor {
-		reweightIncentiveAmount = amount;
-		emit ReweightIncentiveUpdate(amount);
-	}
+    function setReweightIncentive(uint256 amount)
+        external
+        override
+        onlyGovernor
+    {
+        reweightIncentiveAmount = amount;
+        emit ReweightIncentiveUpdate(amount);
+    }
 
-	function setReweightMinDistance(uint basisPoints) external override onlyGovernor {
-		_minDistanceForReweight = Decimal.ratio(basisPoints, BASIS_POINTS_GRANULARITY);
-		emit ReweightMinDistanceUpdate(basisPoints);
-	}
+    function setReweightMinDistance(uint256 basisPoints)
+        external
+        override
+        onlyGovernor
+    {
+        _minDistanceForReweight = Decimal.ratio(
+            basisPoints,
+            BASIS_POINTS_GRANULARITY
+        );
+        emit ReweightMinDistanceUpdate(basisPoints);
+    }
 
-	function reweightEligible() public view override returns(bool) {
-		bool magnitude = getDistanceToPeg().greaterThan(_minDistanceForReweight);
-		bool time = incentiveContract.isIncentiveParity();
-		return magnitude && time;
-	}
+    function reweightEligible() public view override returns (bool) {
+        bool magnitude =
+            _getDistanceToPeg().greaterThan(_minDistanceForReweight);
+        bool time = incentiveContract.isIncentiveParity();
+        return magnitude && time;
+    }
 
-	function minDistanceForReweight() external view override returns(Decimal.D256 memory) {
-		return _minDistanceForReweight;
-	}
+    function minDistanceForReweight()
+        external
+        view
+        override
+        returns (Decimal.D256 memory)
+    {
+        return _minDistanceForReweight;
+    }
 
-	function _incentivize() internal ifMinterSelf {
-		fei().mint(msg.sender, reweightIncentiveAmount);
-	}
+    function _incentivize() internal ifMinterSelf {
+        fei().mint(msg.sender, reweightIncentiveAmount);
+    }
 
-	function _reweight() internal {
-		_withdraw();
-		_returnToPeg();
+    function _reweight() internal {
+        _withdraw();
+        _returnToPeg();
 
-		uint balance = address(this).balance;
-		pcvDeposit.deposit{value: balance}(balance);
+        uint256 balance = address(this).balance;
+        pcvDeposit.deposit{value: balance}(balance);
 
-		_burnFeiHeld();
+        _burnFeiHeld();
 
-		emit Reweight(msg.sender);
-	}
+        emit Reweight(msg.sender);
+    }
 
-	function _returnToPeg() internal {
-		(uint feiReserves, uint ethReserves) = getReserves();
-		if (feiReserves == 0 || ethReserves == 0) {
-			return;
-		}
+    function _returnToPeg() internal {
+        (uint256 feiReserves, uint256 ethReserves) = getReserves();
+        if (feiReserves == 0 || ethReserves == 0) {
+            return;
+        }
 
-		updateOracle();
+        updateOracle();
 
-    	require(isBelowPeg(peg()), "EthUniswapPCVController: already at or above peg");
-    	
-		uint amountEth = getAmountToPegOther();
-    	_swapEth(amountEth, ethReserves, feiReserves);
-	}
+        require(
+            _isBelowPeg(peg()),
+            "EthUniswapPCVController: already at or above peg"
+        );
 
-	function _swapEth(uint amountEth, uint ethReserves, uint feiReserves) internal {
-		uint balance = address(this).balance;
-		uint amount = Math.min(amountEth, balance);
-		
-		uint amountOut = UniswapV2Library.getAmountOut(amount, ethReserves, feiReserves);
-		
-		IWETH weth = IWETH(router.WETH());
-		weth.deposit{value: amount}();
-		assert(weth.transfer(address(pair), amount));
+        uint256 amountEth = _getAmountToPegOther();
+        _swapEth(amountEth, ethReserves, feiReserves);
+    }
 
-		(uint amount0Out, uint amount1Out) = pair.token0() == address(weth) ? (uint(0), amountOut) : (amountOut, uint(0));
-		pair.swap(amount0Out, amount1Out, address(this), new bytes(0));
-	}
+    function _swapEth(
+        uint256 amountEth,
+        uint256 ethReserves,
+        uint256 feiReserves
+    ) internal {
+        uint256 balance = address(this).balance;
+        uint256 amount = Math.min(amountEth, balance);
 
-	function _withdraw() internal {
-		// Only withdraw a portion to prevent rounding errors on Uni LP dust
-		uint value = pcvDeposit.totalValue().mul(WITHDRAW_AMOUNT_BPS) / BASIS_POINTS_GRANULARITY;
-		pcvDeposit.withdraw(address(this), value);
-	}
+        uint256 amountOut =
+            UniswapV2Library.getAmountOut(amount, ethReserves, feiReserves);
+
+        IWETH weth = IWETH(router.WETH());
+        weth.deposit{value: amount}();
+        assert(weth.transfer(address(pair), amount));
+
+        (uint256 amount0Out, uint256 amount1Out) =
+            pair.token0() == address(weth)
+                ? (uint256(0), amountOut)
+                : (amountOut, uint256(0));
+        pair.swap(amount0Out, amount1Out, address(this), new bytes(0));
+    }
+
+    function _withdraw() internal {
+        // Only withdraw a portion to prevent rounding errors on Uni LP dust
+        uint256 value =
+            pcvDeposit.totalValue().mul(WITHDRAW_AMOUNT_BPS) /
+                BASIS_POINTS_GRANULARITY;
+        pcvDeposit.withdraw(address(this), value);
+    }
 }

--- a/contracts/pcv/EthUniswapPCVDeposit.sol
+++ b/contracts/pcv/EthUniswapPCVDeposit.sol
@@ -9,26 +9,29 @@ import "./UniswapPCVDeposit.sol";
 contract EthUniswapPCVDeposit is UniswapPCVDeposit {
     using Address for address payable;
 
-	/// @notice ETH Uniswap PCV Deposit constructor
-	/// @param _core Fei Core for reference
-	/// @param _pair Uniswap Pair to deposit to
-	/// @param _router Uniswap Router
-	/// @param _oracle oracle for reference
+    /// @notice ETH Uniswap PCV Deposit constructor
+    /// @param _core Fei Core for reference
+    /// @param _pair Uniswap Pair to deposit to
+    /// @param _router Uniswap Router
+    /// @param _oracle oracle for reference
     constructor(
-        address _core, 
-        address _pair, 
-        address _router, 
+        address _core,
+        address _pair,
+        address _router,
         address _oracle
     ) public UniswapPCVDeposit(_core, _pair, _router, _oracle) {}
 
     receive() external payable {}
 
-    function deposit(uint ethAmount) external override payable postGenesis {
-    	require(ethAmount == msg.value, "Bonding Curve: Sent value does not equal input");
-        
+    function deposit(uint256 ethAmount) external payable override postGenesis {
+        require(
+            ethAmount == msg.value,
+            "Bonding Curve: Sent value does not equal input"
+        );
+
         ethAmount = address(this).balance; // include any ETH dust from prior LP
 
-        uint feiAmount = _getAmountFeiToDeposit(ethAmount);
+        uint256 feiAmount = _getAmountFeiToDeposit(ethAmount);
 
         _addLiquidity(ethAmount, feiAmount);
 
@@ -37,28 +40,34 @@ contract EthUniswapPCVDeposit is UniswapPCVDeposit {
         emit Deposit(msg.sender, ethAmount);
     }
 
-    function _removeLiquidity(uint liquidity) internal override returns (uint) {
-        uint endOfTime = uint(-1);
-        (, uint amountWithdrawn) = router.removeLiquidityETH(
-            address(fei()),
-            liquidity,
-            0,
-            0,
-            address(this),
-            endOfTime
-        );
+    function _removeLiquidity(uint256 liquidity)
+        internal
+        override
+        returns (uint256)
+    {
+        uint256 endOfTime = uint256(-1);
+        (, uint256 amountWithdrawn) =
+            router.removeLiquidityETH(
+                address(fei()),
+                liquidity,
+                0,
+                0,
+                address(this),
+                endOfTime
+            );
         return amountWithdrawn;
     }
 
-    function _transferWithdrawn(address to, uint amount) internal override {
+    function _transferWithdrawn(address to, uint256 amount) internal override {
         payable(to).sendValue(amount);
     }
 
-    function _addLiquidity(uint ethAmount, uint feiAmount) internal {
+    function _addLiquidity(uint256 ethAmount, uint256 feiAmount) internal {
         _mintFei(feiAmount);
-        
-        uint endOfTime = uint(-1);
-        router.addLiquidityETH{value : ethAmount}(address(fei()),
+
+        uint256 endOfTime = uint256(-1);
+        router.addLiquidityETH{value: ethAmount}(
+            address(fei()),
             feiAmount,
             0,
             0,

--- a/contracts/pcv/IPCVDeposit.sol
+++ b/contracts/pcv/IPCVDeposit.sol
@@ -3,27 +3,30 @@ pragma solidity ^0.6.2;
 /// @title a PCV Deposit interface
 /// @author Fei Protocol
 interface IPCVDeposit {
+    // ----------- Events -----------
+    event Deposit(address indexed _from, uint256 _amount);
 
-	// ----------- Events -----------
-    event Deposit(address indexed _from, uint _amount);
-
-    event Withdrawal(address indexed _caller, address indexed _to, uint _amount);
+    event Withdrawal(
+        address indexed _caller,
+        address indexed _to,
+        uint256 _amount
+    );
 
     // ----------- State changing api -----------
 
     /// @notice deposit tokens into the PCV allocation
     /// @param amount of tokens deposited
-    function deposit(uint amount) external payable;
+    function deposit(uint256 amount) external payable;
 
     // ----------- PCV Controller only state changing api -----------
 
     /// @notice withdraw tokens from the PCV allocation
     /// @param amount of tokens withdrawn
     /// @param to the address to send PCV to
-    function withdraw(address to, uint amount) external;
+    function withdraw(address to, uint256 amount) external;
 
     // ----------- Getters -----------
-    
+
     /// @notice returns total value of PCV in the Deposit
-    function totalValue() external view returns(uint);
+    function totalValue() external view returns (uint256);
 }

--- a/contracts/pcv/IUniswapPCVController.sol
+++ b/contracts/pcv/IUniswapPCVController.sol
@@ -7,21 +7,20 @@ import "../token/IUniswapIncentive.sol";
 /// @title a Uniswap PCV Controller interface
 /// @author Fei Protocol
 interface IUniswapPCVController {
-    
     // ----------- Events -----------
 
     event Reweight(address indexed _caller);
 
-	event PCVDepositUpdate(address indexed _pcvDeposit);
+    event PCVDepositUpdate(address indexed _pcvDeposit);
 
-	event ReweightIncentiveUpdate(uint _amount);
+    event ReweightIncentiveUpdate(uint256 _amount);
 
-	event ReweightMinDistanceUpdate(uint _basisPoints);
+    event ReweightMinDistanceUpdate(uint256 _basisPoints);
 
     // ----------- State changing API -----------
 
     /// @notice reweights the linked PCV Deposit to the peg price. Needs to be reweight eligible
-	function reweight() external;
+    function reweight() external;
 
     // ----------- Governor only state changing API -----------
 
@@ -29,28 +28,31 @@ interface IUniswapPCVController {
     function forceReweight() external;
 
     /// @notice sets the target PCV Deposit address
-	function setPCVDeposit(address _pcvDeposit) external;
+    function setPCVDeposit(address _pcvDeposit) external;
 
     /// @notice sets the reweight incentive amount
-	function setReweightIncentive(uint amount) external;
+    function setReweightIncentive(uint256 amount) external;
 
     /// @notice sets the reweight min distance in basis points
-	function setReweightMinDistance(uint basisPoints) external;
+    function setReweightMinDistance(uint256 basisPoints) external;
 
     // ----------- Getters -----------
 
     /// @notice returns the linked pcv deposit contract
-	function pcvDeposit() external returns(IPCVDeposit);
+    function pcvDeposit() external returns (IPCVDeposit);
 
     /// @notice returns the linked Uniswap incentive contract
-    function incentiveContract() external returns(IUniswapIncentive);
+    function incentiveContract() external returns (IUniswapIncentive);
 
     /// @notice gets the FEI reward incentive for reweighting
-    function reweightIncentiveAmount() external returns(uint);
+    function reweightIncentiveAmount() external returns (uint256);
 
     /// @notice signal whether the reweight is available. Must have incentive parity and minimum distance from peg
-	function reweightEligible() external view returns(bool);
+    function reweightEligible() external view returns (bool);
 
     /// @notice minimum distance as a percentage from the peg for a reweight to be eligible
-    function minDistanceForReweight() external view returns(Decimal.D256 memory);
+    function minDistanceForReweight()
+        external
+        view
+        returns (Decimal.D256 memory);
 }

--- a/contracts/pcv/PCVSplitter.sol
+++ b/contracts/pcv/PCVSplitter.sol
@@ -7,69 +7,89 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @title abstract contract for splitting PCV into different deposits
 /// @author Fei Protocol
 abstract contract PCVSplitter {
-    using SafeMathCopy for uint;
+    using SafeMathCopy for uint256;
 
-	/// @notice total allocation allowed representing 100%
-	uint public constant ALLOCATION_GRANULARITY = 10_000; 
+    /// @notice total allocation allowed representing 100%
+    uint256 public constant ALLOCATION_GRANULARITY = 10_000;
 
-	uint[] private ratios;
-	address[] private pcvDeposits;
+    uint256[] private ratios;
+    address[] private pcvDeposits;
 
-	event AllocationUpdate(address[] _pcvDeposits, uint[] _ratios);
+    event AllocationUpdate(address[] _pcvDeposits, uint256[] _ratios);
 
-	/// @notice PCVSplitter constructor
-	/// @param _pcvDeposits list of PCV Deposits to split to
-	/// @param _ratios ratios for splitting PCV Deposit allocations
-	constructor(address[] memory _pcvDeposits, uint[] memory _ratios) public {
-		_setAllocation(_pcvDeposits, _ratios);
-	}
+    /// @notice PCVSplitter constructor
+    /// @param _pcvDeposits list of PCV Deposits to split to
+    /// @param _ratios ratios for splitting PCV Deposit allocations
+    constructor(address[] memory _pcvDeposits, uint256[] memory _ratios)
+        public
+    {
+        _setAllocation(_pcvDeposits, _ratios);
+    }
 
-	/// @notice make sure an allocation has matching lengths and totals the ALLOCATION_GRANULARITY
-	/// @param _pcvDeposits new list of pcv deposits to send to
-	/// @param _ratios new ratios corresponding to the PCV deposits
-	/// @return true if it is a valid allocation
-	function checkAllocation(address[] memory _pcvDeposits, uint[] memory _ratios) public pure returns (bool) {
-		require(_pcvDeposits.length == _ratios.length, "PCVSplitter: PCV Deposits and ratios are different lengths");
+    /// @notice make sure an allocation has matching lengths and totals the ALLOCATION_GRANULARITY
+    /// @param _pcvDeposits new list of pcv deposits to send to
+    /// @param _ratios new ratios corresponding to the PCV deposits
+    /// @return true if it is a valid allocation
+    function checkAllocation(
+        address[] memory _pcvDeposits,
+        uint256[] memory _ratios
+    ) public pure returns (bool) {
+        require(
+            _pcvDeposits.length == _ratios.length,
+            "PCVSplitter: PCV Deposits and ratios are different lengths"
+        );
 
-		uint total;
-		for (uint i; i < _ratios.length; i++) {
-			total = total.add(_ratios[i]);
-		}
+        uint256 total;
+        for (uint256 i; i < _ratios.length; i++) {
+            total = total.add(_ratios[i]);
+        }
 
-		require(total == ALLOCATION_GRANULARITY, "PCVSplitter: ratios do not total 100%");
-		
-		return true;
-	}
-	
-	/// @notice gets the pcvDeposits and ratios of the splitter
-	function getAllocation() public view returns (address[] memory, uint[] memory) {
-		return (pcvDeposits, ratios);
-	}
+        require(
+            total == ALLOCATION_GRANULARITY,
+            "PCVSplitter: ratios do not total 100%"
+        );
 
-	/// @notice distribute funds to single PCV deposit
-	/// @param amount amount of funds to send
-	/// @param pcvDeposit the pcv deposit to send funds
-	function _allocateSingle(uint amount, address pcvDeposit) internal virtual ;
+        return true;
+    }
 
-	/// @notice sets a new allocation for the splitter
-	/// @param _pcvDeposits new list of pcv deposits to send to
-	/// @param _ratios new ratios corresponding to the PCV deposits. Must total ALLOCATION_GRANULARITY
-	function _setAllocation(address[] memory _pcvDeposits, uint[] memory _ratios) internal {
-		checkAllocation(_pcvDeposits, _ratios);
+    /// @notice gets the pcvDeposits and ratios of the splitter
+    function getAllocation()
+        public
+        view
+        returns (address[] memory, uint256[] memory)
+    {
+        return (pcvDeposits, ratios);
+    }
 
-		pcvDeposits = _pcvDeposits;
-		ratios = _ratios;
+    /// @notice distribute funds to single PCV deposit
+    /// @param amount amount of funds to send
+    /// @param pcvDeposit the pcv deposit to send funds
+    function _allocateSingle(uint256 amount, address pcvDeposit)
+        internal
+        virtual;
 
-		emit AllocationUpdate(_pcvDeposits, _ratios);
-	}
+    /// @notice sets a new allocation for the splitter
+    /// @param _pcvDeposits new list of pcv deposits to send to
+    /// @param _ratios new ratios corresponding to the PCV deposits. Must total ALLOCATION_GRANULARITY
+    function _setAllocation(
+        address[] memory _pcvDeposits,
+        uint256[] memory _ratios
+    ) internal {
+        checkAllocation(_pcvDeposits, _ratios);
 
-	/// @notice distribute funds to all pcv deposits at specified allocation ratios
-	/// @param total amount of funds to send
-	function _allocate(uint total) internal {
-		uint granularity = ALLOCATION_GRANULARITY;
-		for (uint i; i < ratios.length; i++) {
-			uint amount = total.mul(ratios[i]) / granularity;
-			_allocateSingle(amount, pcvDeposits[i]);
-		}
-	}
+        pcvDeposits = _pcvDeposits;
+        ratios = _ratios;
+
+        emit AllocationUpdate(_pcvDeposits, _ratios);
+    }
+
+    /// @notice distribute funds to all pcv deposits at specified allocation ratios
+    /// @param total amount of funds to send
+    function _allocate(uint256 total) internal {
+        uint256 granularity = ALLOCATION_GRANULARITY;
+        for (uint256 i; i < ratios.length; i++) {
+            uint256 amount = total.mul(ratios[i]) / granularity;
+            _allocateSingle(amount, pcvDeposits[i]);
+        }
+    }
 }

--- a/contracts/pcv/UniswapPCVDeposit.sol
+++ b/contracts/pcv/UniswapPCVDeposit.sol
@@ -9,52 +9,67 @@ import "../refs/UniRef.sol";
 /// @title abstract implementation for Uniswap LP PCV Deposit
 /// @author Fei Protocol
 abstract contract UniswapPCVDeposit is IPCVDeposit, UniRef {
-	using Decimal for Decimal.D256;
+    using Decimal for Decimal.D256;
 
-	/// @notice Uniswap PCV Deposit constructor
-	/// @param _core Fei Core for reference
-	/// @param _pair Uniswap Pair to deposit to
-	/// @param _router Uniswap Router
-	/// @param _oracle oracle for reference
-	constructor(
-		address _core, 
-		address _pair, 
-		address _router, 
-		address _oracle
-	) public UniRef(_core, _pair, _router, _oracle) {}
+    /// @notice Uniswap PCV Deposit constructor
+    /// @param _core Fei Core for reference
+    /// @param _pair Uniswap Pair to deposit to
+    /// @param _router Uniswap Router
+    /// @param _oracle oracle for reference
+    constructor(
+        address _core,
+        address _pair,
+        address _router,
+        address _oracle
+    ) public UniRef(_core, _pair, _router, _oracle) {}
 
-	function withdraw(address to, uint amountUnderlying) external override onlyPCVController {
-    	uint totalUnderlying = totalValue();
-    	require(amountUnderlying <= totalUnderlying, "UniswapPCVDeposit: Insufficient underlying");
+    function withdraw(address to, uint256 amountUnderlying)
+        external
+        override
+        onlyPCVController
+    {
+        uint256 totalUnderlying = totalValue();
+        require(
+            amountUnderlying <= totalUnderlying,
+            "UniswapPCVDeposit: Insufficient underlying"
+        );
 
-    	uint totalLiquidity = liquidityOwned();
-    	Decimal.D256 memory ratioToWithdraw = Decimal.ratio(amountUnderlying, totalUnderlying);
-    	uint liquidityToWithdraw = ratioToWithdraw.mul(totalLiquidity).asUint256();
+        uint256 totalLiquidity = liquidityOwned();
+        Decimal.D256 memory ratioToWithdraw =
+            Decimal.ratio(amountUnderlying, totalUnderlying);
+        uint256 liquidityToWithdraw =
+            ratioToWithdraw.mul(totalLiquidity).asUint256();
 
-    	uint amountWithdrawn = _removeLiquidity(liquidityToWithdraw);
-		
-    	_transferWithdrawn(to, amountWithdrawn);
-		
-    	_burnFeiHeld();
+        uint256 amountWithdrawn = _removeLiquidity(liquidityToWithdraw);
 
-    	emit Withdrawal(msg.sender, to, amountWithdrawn);
+        _transferWithdrawn(to, amountWithdrawn);
+
+        _burnFeiHeld();
+
+        emit Withdrawal(msg.sender, to, amountWithdrawn);
     }
 
-	function totalValue() public view override returns(uint) {
-		(, uint tokenReserves) = getReserves();
-    	return ratioOwned().mul(tokenReserves).asUint256();
+    function totalValue() public view override returns (uint256) {
+        (, uint256 tokenReserves) = getReserves();
+        return _ratioOwned().mul(tokenReserves).asUint256();
     }
 
-	function _getAmountFeiToDeposit(uint amountToken) internal view returns (uint amountFei) {
-		(uint feiReserves, uint tokenReserves) = getReserves();
-		if (feiReserves == 0 || tokenReserves == 0) {
-			return peg().mul(amountToken).asUint256();
-		}
-		return UniswapV2Library.quote(amountToken, tokenReserves, feiReserves);
-	}
+    function _getAmountFeiToDeposit(uint256 amountToken)
+        internal
+        view
+        returns (uint256 amountFei)
+    {
+        (uint256 feiReserves, uint256 tokenReserves) = getReserves();
+        if (feiReserves == 0 || tokenReserves == 0) {
+            return peg().mul(amountToken).asUint256();
+        }
+        return UniswapV2Library.quote(amountToken, tokenReserves, feiReserves);
+    }
 
-    function _removeLiquidity(uint amount) internal virtual returns(uint);
+    function _removeLiquidity(uint256 amount)
+        internal
+        virtual
+        returns (uint256);
 
-    function _transferWithdrawn(address to, uint amount) internal virtual;
-
+    function _transferWithdrawn(address to, uint256 amount) internal virtual;
 }

--- a/contracts/pool/FeiPool.sol
+++ b/contracts/pool/FeiPool.sol
@@ -8,46 +8,48 @@ import "../refs/CoreRef.sol";
 /// @author Fei Protocol
 /// @notice deposited LP tokens will earn TRIBE over time at a linearly decreasing rate
 contract FeiPool is Pool, CoreRef {
-	
-	/// @notice Fei Pool constructor
-	/// @param _core Fei Core to reference
-	/// @param _pair Uniswap pair to stake
-	/// @param _duration duration of staking rewards
-	constructor(address _core, address _pair, uint _duration) public 
-		CoreRef(_core) Pool(_duration, "Fei USD Pool", "FPOOL") 
-	{
-		_setTokens(
-			address(tribe()),
-			_pair
-		);
-	}
+    /// @notice Fei Pool constructor
+    /// @param _core Fei Core to reference
+    /// @param _pair Uniswap pair to stake
+    /// @param _duration duration of staking rewards
+    constructor(
+        address _core,
+        address _pair,
+        uint256 _duration
+    ) public CoreRef(_core) Pool(_duration, "Fei USD Pool", "FPOOL") {
+        _setTokens(address(tribe()), _pair);
+    }
 
-	/// @notice sends tokens back to governance treasury. Only callable by governance
-	/// @param amount the amount of tokens to send back to treasury
-	function governorWithdraw(uint amount) external onlyGovernor {
-		tribe().transfer(address(core()), amount);
-	}
+    /// @notice sends tokens back to governance treasury. Only callable by governance
+    /// @param amount the amount of tokens to send back to treasury
+    function governorWithdraw(uint256 amount) external onlyGovernor {
+        tribe().transfer(address(core()), amount);
+    }
 
-	function init() public override postGenesis {
-		super.init();	
-	}
+    function init() public override postGenesis {
+        super.init();
+    }
 
-	// Represents the integral of 2R/d - 2R/d^2 x dx from t to d
-	// Integral equals 2Rx/d - Rx^2/d^2
-	// Evaluated at t = 2R*t/d (start) - R*t^2/d^2 (end)
-	// Evaluated at d = 2R - R = R
-	// Solution = R - (start - end) or equivalently end + R - start (latter more convenient to code)
-	function _unreleasedReward(
-		uint _totalReward, 
-		uint _duration, 
-		uint _time
-	) internal view override returns (uint) {
-		// 2R*t/d 
-		Decimal.D256 memory start = Decimal.ratio(_totalReward, _duration).mul(2).mul(_time);
+    // Represents the integral of 2R/d - 2R/d^2 x dx from t to d
+    // Integral equals 2Rx/d - Rx^2/d^2
+    // Evaluated at t = 2R*t/d (start) - R*t^2/d^2 (end)
+    // Evaluated at d = 2R - R = R
+    // Solution = R - (start - end) or equivalently end + R - start (latter more convenient to code)
+    function _unreleasedReward(
+        uint256 _totalReward,
+        uint256 _duration,
+        uint256 _time
+    ) internal view override returns (uint256) {
+        // 2R*t/d
+        Decimal.D256 memory start =
+            Decimal.ratio(_totalReward, _duration).mul(2).mul(_time);
 
-		// R*t^2/d^2
-		Decimal.D256 memory end = Decimal.ratio(_totalReward, _duration).div(_duration).mul(_time * _time);
+        // R*t^2/d^2
+        Decimal.D256 memory end =
+            Decimal.ratio(_totalReward, _duration).div(_duration).mul(
+                _time * _time
+            );
 
-		return end.add(_totalReward).sub(start).asUint256();
-	}
+        return end.add(_totalReward).sub(start).asUint256();
+    }
 }

--- a/contracts/pool/IPool.sol
+++ b/contracts/pool/IPool.sol
@@ -6,14 +6,26 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @title A fluid pool for earning a reward token with staked tokens
 /// @author Fei Protocol
 interface IPool {
+    // ----------- Events -----------
 
-	// ----------- Events -----------
+    event Claim(
+        address indexed _from,
+        address indexed _to,
+        uint256 _amountReward
+    );
 
-    event Claim(address indexed _from, address indexed _to, uint _amountReward);
+    event Deposit(
+        address indexed _from,
+        address indexed _to,
+        uint256 _amountStaked
+    );
 
-    event Deposit(address indexed _from, address indexed _to, uint _amountStaked);
-
-    event Withdraw(address indexed _from, address indexed _to, uint _amountStaked, uint _amountReward);
+    event Withdraw(
+        address indexed _from,
+        address indexed _to,
+        uint256 _amountStaked,
+        uint256 _amountReward
+    );
 
     // ----------- State changing API -----------
 
@@ -22,20 +34,22 @@ interface IPool {
     /// @param to the account to send rewards to
     /// @return the amount of reward claimed
     /// @dev redeeming on behalf of another account requires ERC-20 approval of the pool tokens
-    function claim(address from, address to) external returns(uint);
-    
+    function claim(address from, address to) external returns (uint256);
+
     /// @notice deposit staked tokens
     /// @param to the account to deposit to
     /// @param amount the amount of staked to deposit
     /// @dev requires ERC-20 approval of stakedToken for the Pool contract
-    function deposit(address to, uint amount) external;
+    function deposit(address to, uint256 amount) external;
 
     /// @notice claim all rewards and withdraw stakedToken
     /// @param to the account to send withdrawn tokens to
     /// @return amountStaked the amount of stakedToken withdrawn
     /// @return amountReward the amount of rewardToken received
-    function withdraw(address to) external returns(uint amountStaked, uint amountReward);
-    
+    function withdraw(address to)
+        external
+        returns (uint256 amountStaked, uint256 amountReward);
+
     /// @notice initializes the pool start time. Only callable once
     function init() external;
 
@@ -43,44 +57,47 @@ interface IPool {
 
     /// @notice the ERC20 reward token
     /// @return the IERC20 implementation address
-    function rewardToken() external view returns(IERC20);
+    function rewardToken() external view returns (IERC20);
 
     /// @notice the total amount of rewards distributed by the contract over entire period
     /// @return the total, including currently held and previously claimed rewards
-    function totalReward() external view returns (uint);
-    
+    function totalReward() external view returns (uint256);
+
     /// @notice the amount of rewards currently redeemable by an account
     /// @param account the potentially redeeming account
     /// @return amountReward the amount of reward tokens
     /// @return amountPool the amount of redeemable pool tokens
-    function redeemableReward(address account) external view returns(uint amountReward, uint amountPool);
- 
+    function redeemableReward(address account)
+        external
+        view
+        returns (uint256 amountReward, uint256 amountPool);
+
     /// @notice the total amount of rewards owned by contract and unlocked for release
     /// @return the total
-    function releasedReward() external view returns (uint);
-    
+    function releasedReward() external view returns (uint256);
+
     /// @notice the total amount of rewards owned by contract and locked
     /// @return the total
-    function unreleasedReward() external view returns (uint);
+    function unreleasedReward() external view returns (uint256);
 
     /// @notice the total balance of rewards owned by contract, locked or unlocked
     /// @return the total
-    function rewardBalance() external view returns (uint);
+    function rewardBalance() external view returns (uint256);
 
     /// @notice the total amount of rewards previously claimed
     /// @return the total
-    function claimedRewards() external view returns(uint);
+    function claimedRewards() external view returns (uint256);
 
     /// @notice the ERC20 staked token
     /// @return the IERC20 implementation address
-    function stakedToken() external view returns(IERC20);
+    function stakedToken() external view returns (IERC20);
 
     /// @notice the total amount of staked tokens in the contract
     /// @return the total
-    function totalStaked() external view returns(uint);
+    function totalStaked() external view returns (uint256);
 
     /// @notice the staked balance of a given account
     /// @param account the user account
     /// @return the total staked
-    function stakedBalance(address account) external view returns(uint);    
+    function stakedBalance(address account) external view returns (uint256);
 }

--- a/contracts/refs/CoreRef.sol
+++ b/contracts/refs/CoreRef.sol
@@ -6,91 +6,103 @@ import "./ICoreRef.sol";
 /// @title Abstract implementation of ICoreRef
 /// @author Fei Protocol
 abstract contract CoreRef is ICoreRef {
-	ICore private _core;
+    ICore private _core;
 
-	/// @notice CoreRef constructor
-	/// @param core Fei Core to reference
-	constructor(address core) public {
-		_core = ICore(core);
-	}
-
-	modifier ifMinterSelf() {
-		if (_core.isMinter(address(this))) {
-			_;
-		}
-	}
-
-	modifier ifBurnerSelf() {
-		if (_core.isBurner(address(this))) {
-			_;
-		}
-	}
-
-	modifier onlyMinter() {
-		require(_core.isMinter(msg.sender), "CoreRef: Caller is not a minter");
-		_;
-	}
-
-	modifier onlyBurner() {
-		require(_core.isBurner(msg.sender), "CoreRef: Caller is not a burner");
-		_;
-	}
-
-	modifier onlyPCVController() {
-		require(_core.isPCVController(msg.sender), "CoreRef: Caller is not a PCV controller");
-		_;
-	}
-
-	modifier onlyGovernor() {
-		require(_core.isGovernor(msg.sender), "CoreRef: Caller is not a governor");
-		_;
-	}
-
-	modifier onlyFei() {
-		require(msg.sender == address(fei()), "CoreRef: Caller is not FEI");
-		_;
-	}
-
-	modifier onlyGenesisGroup() {
-		require(msg.sender == _core.genesisGroup(), "CoreRef: Caller is not GenesisGroup");
-		_;
-	}
-
-	modifier postGenesis() {
-		require(_core.hasGenesisGroupCompleted(), "CoreRef: Still in Genesis Period");
-		_;
-	}
-
-	function setCore(address core) external override onlyGovernor {
-		_core = ICore(core);
-		emit CoreUpdate(core);
-	}
- 
-	function core() public view override returns(ICore) {
-		return _core;
-	}
-
-	function fei() public view override returns(IFei) {
-		return _core.fei();
-	}
-
-	function tribe() public view override returns(IERC20) {
-		return _core.tribe();
-	}
-
-	function feiBalance() public view override returns (uint) {
-		return fei().balanceOf(address(this));
-	}
-
-	function tribeBalance() public view override returns (uint) {
-		return tribe().balanceOf(address(this));
-	}
-
-    function _burnFeiHeld() internal {
-    	fei().burn(feiBalance());
+    /// @notice CoreRef constructor
+    /// @param core Fei Core to reference
+    constructor(address core) public {
+        _core = ICore(core);
     }
 
-    function _mintFei(uint amount) internal {
-		fei().mint(address(this), amount);
-	}
+    modifier ifMinterSelf() {
+        if (_core.isMinter(address(this))) {
+            _;
+        }
+    }
+
+    modifier ifBurnerSelf() {
+        if (_core.isBurner(address(this))) {
+            _;
+        }
+    }
+
+    modifier onlyMinter() {
+        require(_core.isMinter(msg.sender), "CoreRef: Caller is not a minter");
+        _;
+    }
+
+    modifier onlyBurner() {
+        require(_core.isBurner(msg.sender), "CoreRef: Caller is not a burner");
+        _;
+    }
+
+    modifier onlyPCVController() {
+        require(
+            _core.isPCVController(msg.sender),
+            "CoreRef: Caller is not a PCV controller"
+        );
+        _;
+    }
+
+    modifier onlyGovernor() {
+        require(
+            _core.isGovernor(msg.sender),
+            "CoreRef: Caller is not a governor"
+        );
+        _;
+    }
+
+    modifier onlyFei() {
+        require(msg.sender == address(fei()), "CoreRef: Caller is not FEI");
+        _;
+    }
+
+    modifier onlyGenesisGroup() {
+        require(
+            msg.sender == _core.genesisGroup(),
+            "CoreRef: Caller is not GenesisGroup"
+        );
+        _;
+    }
+
+    modifier postGenesis() {
+        require(
+            _core.hasGenesisGroupCompleted(),
+            "CoreRef: Still in Genesis Period"
+        );
+        _;
+    }
+
+    function setCore(address core) external override onlyGovernor {
+        _core = ICore(core);
+        emit CoreUpdate(core);
+    }
+
+    function core() public view override returns (ICore) {
+        return _core;
+    }
+
+    function fei() public view override returns (IFei) {
+        return _core.fei();
+    }
+
+    function tribe() public view override returns (IERC20) {
+        return _core.tribe();
+    }
+
+    function feiBalance() public view override returns (uint256) {
+        return fei().balanceOf(address(this));
+    }
+
+    function tribeBalance() public view override returns (uint256) {
+        return tribe().balanceOf(address(this));
+    }
+
+    function _burnFeiHeld() internal {
+        fei().burn(feiBalance());
+    }
+
+    function _mintFei(uint256 amount) internal {
+        fei().mint(address(this), amount);
+    }
 }

--- a/contracts/refs/ICoreRef.sol
+++ b/contracts/refs/ICoreRef.sol
@@ -9,8 +9,7 @@ import "../core/ICore.sol";
 /// @author Fei Protocol
 /// @notice defines some modifiers and utilities around interacting with Core
 interface ICoreRef {
-
-	// ----------- Events -----------
+    // ----------- Events -----------
 
     event CoreUpdate(address indexed _core);
 
@@ -24,7 +23,7 @@ interface ICoreRef {
 
     /// @notice address of the Core contract referenced
     /// @return ICore implementation address
-	function core() external view returns (ICore);
+    function core() external view returns (ICore);
 
     /// @notice address of the Fei contract referenced by Core
     /// @return IFei implementation address
@@ -36,9 +35,9 @@ interface ICoreRef {
 
     /// @notice fei balance of contract
     /// @return fei amount held
-	function feiBalance() external view returns(uint);
+    function feiBalance() external view returns (uint256);
 
     /// @notice tribe balance of contract
     /// @return tribe amount held
-    function tribeBalance() external view returns(uint);
+    function tribeBalance() external view returns (uint256);
 }

--- a/contracts/refs/IOracleRef.sol
+++ b/contracts/refs/IOracleRef.sol
@@ -8,37 +8,39 @@ import "../external/Decimal.sol";
 /// @author Fei Protocol
 /// @notice defines some utilities around interacting with the referenced oracle
 interface IOracleRef {
+    // ----------- Events -----------
 
-	// ----------- Events -----------
+    event OracleUpdate(address indexed _oracle);
 
-	event OracleUpdate(address indexed _oracle);
+    // ----------- State changing API -----------
 
-	// ----------- State changing API -----------
+    /// @notice updates the referenced oracle
+    /// @return true if the update is effective
+    function updateOracle() external returns (bool);
 
-	/// @notice updates the referenced oracle
-	/// @return true if the update is effective
-	function updateOracle() external returns(bool);
+    // ----------- Governor only state changing API -----------
 
-	// ----------- Governor only state changing API -----------
+    /// @notice sets the referenced oracle
+    /// @param _oracle the new oracle to reference
+    function setOracle(address _oracle) external;
 
-	/// @notice sets the referenced oracle
-	/// @param _oracle the new oracle to reference
-	function setOracle(address _oracle) external;
+    // ----------- Getters -----------
 
-	// ----------- Getters -----------
+    /// @notice the oracle reference by the contract
+    /// @return the IOracle implementation address
+    function oracle() external view returns (IOracle);
 
-	/// @notice the oracle reference by the contract
-	/// @return the IOracle implementation address
-	function oracle() external view returns(IOracle);
+    /// @notice the peg price of the referenced oracle
+    /// @return the peg as a Decimal
+    /// @dev the peg is defined as FEI per X with X being ETH, dollars, etc
+    function peg() external view returns (Decimal.D256 memory);
 
-	/// @notice the peg price of the referenced oracle
-	/// @return the peg as a Decimal
-	/// @dev the peg is defined as FEI per X with X being ETH, dollars, etc
-	function peg() external view returns(Decimal.D256 memory);
-
-	/// @notice invert a peg price
-	/// @param price the peg price to invert
-	/// @return the inverted peg as a Decimal
-	/// @dev the inverted peg would be X per FEI
-	function invert(Decimal.D256 calldata price) external pure returns(Decimal.D256 memory);
+    /// @notice invert a peg price
+    /// @param price the peg price to invert
+    /// @return the inverted peg as a Decimal
+    /// @dev the inverted peg would be X per FEI
+    function invert(Decimal.D256 calldata price)
+        external
+        pure
+        returns (Decimal.D256 memory);
 }

--- a/contracts/refs/IUniRef.sol
+++ b/contracts/refs/IUniRef.sol
@@ -11,8 +11,7 @@ import "../external/Decimal.sol";
 /// @notice defines some modifiers and utilities around interacting with Uniswap
 /// @dev the uniswap pair should be FEI and another asset
 interface IUniRef {
-
-	// ----------- Events -----------
+    // ----------- Events -----------
 
     event PairUpdate(address indexed _pair);
 
@@ -27,21 +26,24 @@ interface IUniRef {
 
     /// @notice the Uniswap router contract
     /// @return the IUniswapV2Router02 router implementation address
-    function router() external view returns(IUniswapV2Router02);
+    function router() external view returns (IUniswapV2Router02);
 
     /// @notice the referenced Uniswap pair contract
     /// @return the IUniswapV2Pair router implementation address
-    function pair() external view returns(IUniswapV2Pair);
+    function pair() external view returns (IUniswapV2Pair);
 
     /// @notice the address of the non-fei underlying token
     /// @return the token address
-    function token() external view returns(address);
+    function token() external view returns (address);
 
     /// @notice pair reserves with fei listed first
     /// @dev uses the max of pair fei balance and fei reserves. Mitigates attack vectors which manipulate the pair balance
-    function getReserves() external view returns (uint feiReserves, uint tokenReserves);
+    function getReserves()
+        external
+        view
+        returns (uint256 feiReserves, uint256 tokenReserves);
 
     /// @notice amount of pair liquidity owned by this contract
     /// @return amount of LP tokens
-	function liquidityOwned() external view returns (uint);
+    function liquidityOwned() external view returns (uint256);
 }

--- a/contracts/refs/OracleRef.sol
+++ b/contracts/refs/OracleRef.sol
@@ -7,37 +7,42 @@ import "./CoreRef.sol";
 /// @title Abstract implementation of IOracleRef
 /// @author Fei Protocol
 abstract contract OracleRef is IOracleRef, CoreRef {
-	using Decimal for Decimal.D256;
+    using Decimal for Decimal.D256;
 
-	IOracle public override oracle;
+    IOracle public override oracle;
 
-	/// @notice OracleRef constructor
-	/// @param _core Fei Core to reference
-	/// @param _oracle oracle to reference
-	constructor(address _core, address _oracle) public CoreRef(_core) {
+    /// @notice OracleRef constructor
+    /// @param _core Fei Core to reference
+    /// @param _oracle oracle to reference
+    constructor(address _core, address _oracle) public CoreRef(_core) {
         _setOracle(_oracle);
     }
 
-	function setOracle(address _oracle) external override onlyGovernor {
-		_setOracle(_oracle);
-	}
-
-    function invert(Decimal.D256 memory price) public override pure returns(Decimal.D256 memory) {
-    	return Decimal.one().div(price);
+    function setOracle(address _oracle) external override onlyGovernor {
+        _setOracle(_oracle);
     }
 
-    function updateOracle() public override returns(bool) {
-    	return oracle.update();
+    function invert(Decimal.D256 memory price)
+        public
+        pure
+        override
+        returns (Decimal.D256 memory)
+    {
+        return Decimal.one().div(price);
     }
 
-    function peg() public override view returns(Decimal.D256 memory) {
-    	(Decimal.D256 memory _peg, bool valid) = oracle.read();
-    	require(valid, "OracleRef: oracle invalid");
-    	return _peg;
+    function updateOracle() public override returns (bool) {
+        return oracle.update();
+    }
+
+    function peg() public view override returns (Decimal.D256 memory) {
+        (Decimal.D256 memory _peg, bool valid) = oracle.read();
+        require(valid, "OracleRef: oracle invalid");
+        return _peg;
     }
 
     function _setOracle(address _oracle) internal {
-    	oracle = IOracle(_oracle);
-		emit OracleUpdate(_oracle);
+        oracle = IOracle(_oracle);
+        emit OracleUpdate(_oracle);
     }
 }

--- a/contracts/refs/UniRef.sol
+++ b/contracts/refs/UniRef.sol
@@ -10,102 +10,112 @@ import "../external/SafeMathCopy.sol";
 /// @title UniRef abstract implementation contract
 /// @author Fei Protocol
 abstract contract UniRef is IUniRef, OracleRef {
-	using Decimal for Decimal.D256;
-	using Babylonian for uint;
+    using Decimal for Decimal.D256;
+    using Babylonian for uint256;
     using SignedSafeMath for int256;
-    using SafeMathCopy for uint;
+    using SafeMathCopy for uint256;
 
-	IUniswapV2Router02 public override router;
-	IUniswapV2Pair public override pair;
+    IUniswapV2Router02 public override router;
+    IUniswapV2Pair public override pair;
 
-	/// @notice UniRef constructor
-	/// @param _core Fei Core to reference
+    /// @notice UniRef constructor
+    /// @param _core Fei Core to reference
     /// @param _pair Uniswap pair to reference
     /// @param _router Uniswap Router to reference
     /// @param _oracle oracle to reference
-	constructor(address _core, address _pair, address _router, address _oracle) 
-        public OracleRef(_core, _oracle) 
-    {
-        setupPair(_pair);
+    constructor(
+        address _core,
+        address _pair,
+        address _router,
+        address _oracle
+    ) public OracleRef(_core, _oracle) {
+        _setupPair(_pair);
 
         router = IUniswapV2Router02(_router);
 
-        approveToken(address(fei()));
-        approveToken(token());
-        approveToken(_pair);
+        _approveToken(address(fei()));
+        _approveToken(token());
+        _approveToken(_pair);
     }
 
-	function setPair(address _pair) external override onlyGovernor {
-		setupPair(_pair);
+    function setPair(address _pair) external override onlyGovernor {
+        _setupPair(_pair);
 
-        approveToken(token());
-        approveToken(_pair);
-	}
+        _approveToken(token());
+        _approveToken(_pair);
+    }
 
-	function token() public override view returns (address) {
-		address token0 = pair.token0();
-		if (address(fei()) == token0) {
-			return pair.token1();
-		}
-		return token0;
-	}
-
-	function getReserves() public override view returns (uint feiReserves, uint tokenReserves) {
+    function token() public view override returns (address) {
         address token0 = pair.token0();
-        (uint reserve0, uint reserve1,) = pair.getReserves();
-        (feiReserves, tokenReserves) = address(fei()) == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
-        
-        uint feiBalance = fei().balanceOf(address(pair));
-        if(feiBalance > feiReserves) {
+        if (address(fei()) == token0) {
+            return pair.token1();
+        }
+        return token0;
+    }
+
+    function getReserves()
+        public
+        view
+        override
+        returns (uint256 feiReserves, uint256 tokenReserves)
+    {
+        address token0 = pair.token0();
+        (uint256 reserve0, uint256 reserve1, ) = pair.getReserves();
+        (feiReserves, tokenReserves) = address(fei()) == token0
+            ? (reserve0, reserve1)
+            : (reserve1, reserve0);
+
+        uint256 feiBalance = fei().balanceOf(address(pair));
+        if (feiBalance > feiReserves) {
             feiReserves = feiBalance;
         }
         return (feiReserves, tokenReserves);
-	}
+    }
 
-	function liquidityOwned() public override view returns (uint) {
-		return pair.balanceOf(address(this));
-	}
+    function liquidityOwned() public view override returns (uint256) {
+        return pair.balanceOf(address(this));
+    }
 
     /// @notice ratio of all pair liquidity owned by this contract
-	function ratioOwned() internal view returns (Decimal.D256 memory) {	
-    	uint balance = liquidityOwned();
-    	uint total = pair.totalSupply();
-    	return Decimal.ratio(balance, total);
+    function _ratioOwned() internal view returns (Decimal.D256 memory) {
+        uint256 balance = liquidityOwned();
+        uint256 total = pair.totalSupply();
+        return Decimal.ratio(balance, total);
     }
 
     /// @notice returns true if price is below the peg
     /// @dev counterintuitively checks if peg < price because price is reported as FEI per X
-    function isBelowPeg(Decimal.D256 memory peg) internal view returns (bool) {
-        (Decimal.D256 memory price,,) = getUniswapPrice();
+    function _isBelowPeg(Decimal.D256 memory peg) internal view returns (bool) {
+        (Decimal.D256 memory price, , ) = _getUniswapPrice();
         return peg.lessThan(price);
     }
 
     /// @notice approves a token for the router
-    function approveToken(address _token) internal {
-        uint maxTokens = uint(-1);
-    	IERC20(_token).approve(address(router), maxTokens);
+    function _approveToken(address _token) internal {
+        uint256 maxTokens = uint256(-1);
+        IERC20(_token).approve(address(router), maxTokens);
     }
 
-    function setupPair(address _pair) internal {
-    	pair = IUniswapV2Pair(_pair);
+    function _setupPair(address _pair) internal {
+        pair = IUniswapV2Pair(_pair);
         emit PairUpdate(_pair);
     }
 
-    function isPair(address account) internal view returns(bool) {
+    function _isPair(address account) internal view returns (bool) {
         return address(pair) == account;
     }
 
     /// @notice utility for calculating absolute distance from peg based on reserves
     /// @param reserveTarget pair reserves of the asset desired to trade with
     /// @param reserveOther pair reserves of the non-traded asset
-    /// @param peg the target peg reported as Target per Other 
-    function getAmountToPeg(
-        uint reserveTarget, 
-        uint reserveOther, 
+    /// @param peg the target peg reported as Target per Other
+    function _getAmountToPeg(
+        uint256 reserveTarget,
+        uint256 reserveOther,
         Decimal.D256 memory peg
-    ) internal pure returns (uint) {
-        uint radicand = peg.mul(reserveTarget).mul(reserveOther).asUint256();
-        uint root = radicand.sqrt();
+    ) internal pure returns (uint256) {
+        uint256 radicand = peg.mul(reserveTarget).mul(reserveOther).asUint256();
+        uint256 root = radicand.sqrt();
         if (root > reserveTarget) {
             return root - reserveTarget;
         }
@@ -113,74 +123,92 @@ abstract contract UniRef is IUniRef, OracleRef {
     }
 
     /// @notice calculate amount of Fei needed to trade back to the peg
-    function getAmountToPegFei() internal view returns (uint) {
-        (uint feiReserves, uint tokenReserves) = getReserves();
-        return getAmountToPeg(feiReserves, tokenReserves, peg());
+    function _getAmountToPegFei() internal view returns (uint256) {
+        (uint256 feiReserves, uint256 tokenReserves) = getReserves();
+        return _getAmountToPeg(feiReserves, tokenReserves, peg());
     }
 
     /// @notice calculate amount of the not Fei token needed to trade back to the peg
-    function getAmountToPegOther() internal view returns (uint) {
-        (uint feiReserves, uint tokenReserves) = getReserves();
-        return getAmountToPeg(tokenReserves, feiReserves, invert(peg()));
+    function _getAmountToPegOther() internal view returns (uint256) {
+        (uint256 feiReserves, uint256 tokenReserves) = getReserves();
+        return _getAmountToPeg(tokenReserves, feiReserves, invert(peg()));
     }
 
     /// @notice get uniswap price and reserves
     /// @return price reported as Fei per X
     /// @return reserveFei fei reserves
     /// @return reserveOther non-fei reserves
-    function getUniswapPrice() internal view returns(
-        Decimal.D256 memory, 
-        uint reserveFei, 
-        uint reserveOther
-    ) {
+    function _getUniswapPrice()
+        internal
+        view
+        returns (
+            Decimal.D256 memory,
+            uint256 reserveFei,
+            uint256 reserveOther
+        )
+    {
         (reserveFei, reserveOther) = getReserves();
-        return (Decimal.ratio(reserveFei, reserveOther), reserveFei, reserveOther);
+        return (
+            Decimal.ratio(reserveFei, reserveOther),
+            reserveFei,
+            reserveOther
+        );
     }
 
     /// @notice get final uniswap price after hypothetical FEI trade
     /// @param amountFei a signed integer representing FEI trade. Positive=sell, negative=buy
     /// @param reserveFei fei reserves
     /// @param reserveOther non-fei reserves
-    function getFinalPrice(
-    	int256 amountFei, 
-    	uint reserveFei, 
-    	uint reserveOther
+    function _getFinalPrice(
+        int256 amountFei,
+        uint256 reserveFei,
+        uint256 reserveOther
     ) internal pure returns (Decimal.D256 memory) {
-    	uint k = reserveFei.mul(reserveOther);
-    	uint adjustedReserveFei = uint(int256(reserveFei).add(amountFei));
-    	uint adjustedReserveOther = k / adjustedReserveFei;
-    	return Decimal.ratio(adjustedReserveFei, adjustedReserveOther); // alt: adjustedReserveFei^2 / k
+        uint256 k = reserveFei.mul(reserveOther);
+        uint256 adjustedReserveFei = uint256(int256(reserveFei).add(amountFei));
+        uint256 adjustedReserveOther = k / adjustedReserveFei;
+        return Decimal.ratio(adjustedReserveFei, adjustedReserveOther); // alt: adjustedReserveFei^2 / k
     }
 
     /// @notice return the percent distance from peg before and after a hypothetical trade
-    /// @param amountIn a signed amount of FEI to be traded. Positive=sell, negative=buy 
+    /// @param amountIn a signed amount of FEI to be traded. Positive=sell, negative=buy
     /// @return initialDeviation the percent distance from peg before trade
     /// @return finalDeviation the percent distance from peg after hypothetical trade
     /// @dev deviations will return Decimal.zero() if above peg
-    function getPriceDeviations(int256 amountIn) internal view returns (
-        Decimal.D256 memory initialDeviation, 
-        Decimal.D256 memory finalDeviation
-    ) {
-        (Decimal.D256 memory price, uint reserveFei, uint reserveOther) = getUniswapPrice();
-        initialDeviation = deviationBelowPeg(price, peg());
+    function _getPriceDeviations(int256 amountIn)
+        internal
+        view
+        returns (
+            Decimal.D256 memory initialDeviation,
+            Decimal.D256 memory finalDeviation
+        )
+    {
+        (Decimal.D256 memory price, uint256 reserveFei, uint256 reserveOther) =
+            _getUniswapPrice();
+        initialDeviation = _deviationBelowPeg(price, peg());
 
-        Decimal.D256 memory finalPrice = getFinalPrice(amountIn, reserveFei, reserveOther);
-        finalDeviation = deviationBelowPeg(finalPrice, peg());
-        
+        Decimal.D256 memory finalPrice =
+            _getFinalPrice(amountIn, reserveFei, reserveOther);
+        finalDeviation = _deviationBelowPeg(finalPrice, peg());
+
         return (initialDeviation, finalDeviation);
     }
 
     /// @notice return current percent distance from peg
     /// @dev will return Decimal.zero() if above peg
-    function getDistanceToPeg() internal view returns(Decimal.D256 memory distance) {
-        (Decimal.D256 memory price, , ) = getUniswapPrice();
-        return deviationBelowPeg(price, peg()); 
+    function _getDistanceToPeg()
+        internal
+        view
+        returns (Decimal.D256 memory distance)
+    {
+        (Decimal.D256 memory price, , ) = _getUniswapPrice();
+        return _deviationBelowPeg(price, peg());
     }
 
     /// @notice get deviation from peg as a percent given price
     /// @dev will return Decimal.zero() if above peg
-    function deviationBelowPeg(
-        Decimal.D256 memory price, 
+    function _deviationBelowPeg(
+        Decimal.D256 memory price,
         Decimal.D256 memory peg
     ) internal pure returns (Decimal.D256 memory) {
         // If price <= peg, then FEI is more expensive and above peg

--- a/contracts/router/FeiRouter.sol
+++ b/contracts/router/FeiRouter.sol
@@ -7,47 +7,47 @@ import "../token/IUniswapIncentive.sol";
 import "./IFeiRouter.sol";
 
 contract FeiRouter is UniswapSingleEthRouter, IFeiRouter {
+    // solhint-disable-next-line var-name-mixedcase
+    IUniswapIncentive public immutable INCENTIVE;
 
-	IUniswapIncentive public immutable INCENTIVE;
+    constructor(
+        address pair,
+        address weth,
+        address incentive
+    ) public UniswapSingleEthRouter(pair, weth) {
+        INCENTIVE = IUniswapIncentive(incentive);
+    }
 
-	constructor(
-		address pair, 
-		address weth,
-		address incentive
-	) public UniswapSingleEthRouter(pair, weth) {
-		INCENTIVE = IUniswapIncentive(incentive);
-	}
+    function buyFei(
+        uint256 minReward,
+        uint256 amountOutMin,
+        address to,
+        uint256 deadline
+    ) external payable override returns (uint256 amountOut) {
+        IOracleRef(address(INCENTIVE)).updateOracle();
 
-	function buyFei(
-		uint minReward, 
-		uint amountOutMin, 
-		address to, 
-		uint deadline
-	) external payable override returns(uint amountOut) {
-		IOracleRef(address(INCENTIVE)).updateOracle();
+        uint256 reward = 0;
+        if (!INCENTIVE.isExemptAddress(to)) {
+            (reward, , , ) = INCENTIVE.getBuyIncentive(amountOutMin);
+        }
+        require(reward >= minReward, "FeiRouter: Not enough reward");
+        return swapExactETHForTokens(amountOutMin, to, deadline);
+    }
 
-		uint reward = 0;
-		if (!INCENTIVE.isExemptAddress(to)) {
-			(reward,,,) = INCENTIVE.getBuyIncentive(amountOutMin);
-		}
-		require(reward >= minReward, "FeiRouter: Not enough reward");
-		return swapExactETHForTokens(amountOutMin, to, deadline);
-	}
+    function sellFei(
+        uint256 maxPenalty,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address to,
+        uint256 deadline
+    ) external override returns (uint256 amountOut) {
+        IOracleRef(address(INCENTIVE)).updateOracle();
 
-	function sellFei(
-		uint maxPenalty, 
-		uint amountIn, 
-		uint amountOutMin, 
-		address to, 
-		uint deadline
-	) external override returns(uint amountOut) {
-		IOracleRef(address(INCENTIVE)).updateOracle();
-
-		uint penalty = 0;
-		if (!INCENTIVE.isExemptAddress(to)) {
-			(penalty,,) = INCENTIVE.getSellPenalty(amountIn);
-		}
-		require(penalty <= maxPenalty, "FeiRouter: Penalty too high");
-		return swapExactTokensForETH(amountIn, amountOutMin, to, deadline);
-	}
+        uint256 penalty = 0;
+        if (!INCENTIVE.isExemptAddress(to)) {
+            (penalty, , ) = INCENTIVE.getSellPenalty(amountIn);
+        }
+        require(penalty <= maxPenalty, "FeiRouter: Penalty too high");
+        return swapExactTokensForETH(amountIn, amountOutMin, to, deadline);
+    }
 }

--- a/contracts/router/IFeiRouter.sol
+++ b/contracts/router/IFeiRouter.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.6.0;
 /// @title A Uniswap Router for FEI/ETH swaps
 /// @author Fei Protocol
 interface IFeiRouter {
-
     // ----------- state changing api -----------
 
     /// @notice buy FEI for ETH with some protections
@@ -12,11 +11,11 @@ interface IFeiRouter {
     /// @param to address to send FEI
     /// @param deadline block timestamp after which trade is invalid
     function buyFei(
-        uint minReward, 
-        uint amountOutMin, 
-        address to, 
-        uint deadline
-    ) external payable returns(uint amountOut);
+        uint256 minReward,
+        uint256 amountOutMin,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256 amountOut);
 
     /// @notice sell FEI for ETH with some protections
     /// @param maxPenalty maximum fei burn for purchasing
@@ -25,10 +24,10 @@ interface IFeiRouter {
     /// @param to address to send ETH
     /// @param deadline block timestamp after which trade is invalid
     function sellFei(
-        uint maxPenalty, 
-        uint amountIn, 
-        uint amountOutMin, 
-        address to, 
-        uint deadline
-    ) external returns(uint amountOut);
+        uint256 maxPenalty,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountOut);
 }

--- a/contracts/router/IUniswapSingleEthRouter.sol
+++ b/contracts/router/IUniswapSingleEthRouter.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.6.0;
 /// @title A Uniswap Router for token/ETH swaps
 /// @author Fei Protocol
 interface IUniswapSingleEthRouter {
-
     // ----------- state changing api -----------
 
     /// @notice swap ETH for tokens with some protections
@@ -12,10 +11,10 @@ interface IUniswapSingleEthRouter {
     /// @param deadline block timestamp after which trade is invalid
     /// @return amountOut the amount of tokens received
     function swapExactETHForTokens(
-        uint amountOutMin, 
-        address to, 
-        uint deadline
-    ) external payable returns(uint amountOut);
+        uint256 amountOutMin,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256 amountOut);
 
     /// @notice swap tokens for ETH with some protections
     /// @param amountIn amount of tokens to sell
@@ -24,9 +23,9 @@ interface IUniswapSingleEthRouter {
     /// @param deadline block timestamp after which trade is invalid
     /// @return amountOut the amount of ETH received
     function swapExactTokensForETH(
-        uint amountIn, 
-        uint amountOutMin, 
-        address to, 
-        uint deadline
-    ) external returns (uint amountOut);
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountOut);
 }

--- a/contracts/router/UniswapSingleEthRouter.sol
+++ b/contracts/router/UniswapSingleEthRouter.sol
@@ -6,68 +6,99 @@ import "@uniswap/lib/contracts/libraries/TransferHelper.sol";
 import "./IUniswapSingleEthRouter.sol";
 
 contract UniswapSingleEthRouter is IUniswapSingleEthRouter {
-	IWETH public immutable WETH;
-	IUniswapV2Pair public immutable PAIR;
+    // solhint-disable-next-line var-name-mixedcase
+    IWETH public immutable WETH;
 
-	constructor(
-		address pair, 
-		address weth
-	) public {
+    // solhint-disable-next-line var-name-mixedcase
+    IUniswapV2Pair public immutable PAIR;
+
+    constructor(address pair, address weth) public {
         PAIR = IUniswapV2Pair(pair);
-		WETH = IWETH(weth);
-	}
+        WETH = IWETH(weth);
+    }
 
     receive() external payable {
         assert(msg.sender == address(WETH)); // only accept ETH via fallback from the WETH contract
     }
 
-    modifier ensure(uint deadline) {
-        require(deadline >= block.timestamp, 'UniswapSingleEthRouter: EXPIRED');
+    modifier ensure(uint256 deadline) {
+        // solhint-disable-next-line not-rely-on-time
+        require(deadline >= block.timestamp, "UniswapSingleEthRouter: EXPIRED");
         _;
     }
 
-    function _getReserves() internal view returns(uint reservesETH, uint reservesOther, bool isETH0) {
-        (uint reserves0, uint reserves1, ) = PAIR.getReserves();
+    function _getReserves()
+        internal
+        view
+        returns (
+            uint256 reservesETH,
+            uint256 reservesOther,
+            bool isETH0
+        )
+    {
+        (uint256 reserves0, uint256 reserves1, ) = PAIR.getReserves();
         isETH0 = PAIR.token0() == address(WETH);
-        return isETH0 ? (reserves0, reserves1, isETH0) : (reserves1, reserves0, isETH0);
+        return
+            isETH0
+                ? (reserves0, reserves1, isETH0)
+                : (reserves1, reserves0, isETH0);
     }
 
-    function swapExactETHForTokens(uint amountOutMin, address to, uint deadline)
-        public
-        payable
-        override
-        ensure(deadline)
-        returns (uint amountOut)
-    {
-        (uint reservesETH, uint reservesOther, bool isETH0) = _getReserves();
+    function swapExactETHForTokens(
+        uint256 amountOutMin,
+        address to,
+        uint256 deadline
+    ) public payable override ensure(deadline) returns (uint256 amountOut) {
+        (uint256 reservesETH, uint256 reservesOther, bool isETH0) =
+            _getReserves();
 
-        uint amountIn = msg.value;
-        amountOut = UniswapV2Library.getAmountOut(amountIn, reservesETH, reservesOther);
-        require(amountOut >= amountOutMin, 'UniswapSingleEthRouter: INSUFFICIENT_OUTPUT_AMOUNT');
+        uint256 amountIn = msg.value;
+        amountOut = UniswapV2Library.getAmountOut(
+            amountIn,
+            reservesETH,
+            reservesOther
+        );
+        require(
+            amountOut >= amountOutMin,
+            "UniswapSingleEthRouter: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
         IWETH(WETH).deposit{value: amountIn}();
         assert(IWETH(WETH).transfer(address(PAIR), amountIn));
 
-        (uint amount0Out, uint amount1Out) = isETH0 ? (uint(0), amountOut) : (amountOut, uint(0));
+        (uint256 amount0Out, uint256 amount1Out) =
+            isETH0 ? (uint256(0), amountOut) : (amountOut, uint256(0));
         PAIR.swap(amount0Out, amount1Out, to, new bytes(0));
     }
 
-	function swapExactTokensForETH(uint amountIn, uint amountOutMin, address to, uint deadline)
-        public
-        override
-        ensure(deadline)
-        returns (uint amountOut)
-    {
-        (uint reservesETH, uint reservesOther, bool isETH0) = _getReserves();
-        amountOut = UniswapV2Library.getAmountOut(amountIn, reservesOther, reservesETH);
+    function swapExactTokensForETH(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address to,
+        uint256 deadline
+    ) public override ensure(deadline) returns (uint256 amountOut) {
+        (uint256 reservesETH, uint256 reservesOther, bool isETH0) =
+            _getReserves();
+        amountOut = UniswapV2Library.getAmountOut(
+            amountIn,
+            reservesOther,
+            reservesETH
+        );
 
-        require(amountOut >= amountOutMin, 'UniswapSingleEthRouter: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(
+            amountOut >= amountOutMin,
+            "UniswapSingleEthRouter: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
 
         address token = isETH0 ? PAIR.token1() : PAIR.token0();
         TransferHelper.safeTransferFrom(
-            token, msg.sender, address(PAIR), amountIn
+            token,
+            msg.sender,
+            address(PAIR),
+            amountIn
         );
 
-        (uint amount0Out, uint amount1Out) = isETH0 ? (amountOut, uint(0)) : (uint(0), amountOut);
+        (uint256 amount0Out, uint256 amount1Out) =
+            isETH0 ? (amountOut, uint256(0)) : (uint256(0), amountOut);
         PAIR.swap(amount0Out, amount1Out, address(this), new bytes(0));
 
         IWETH(WETH).withdraw(amountOut);

--- a/contracts/token/Fei.sol
+++ b/contracts/token/Fei.sol
@@ -9,94 +9,164 @@ import "../refs/CoreRef.sol";
 /// @title IFei implementation
 /// @author Fei Protocol
 contract Fei is IFei, ERC20Burnable, CoreRef {
+    mapping(address => address) public override incentiveContract;
 
-    mapping (address => address) public override incentiveContract;
-
+    // solhint-disable-next-line var-name-mixedcase
     bytes32 public DOMAIN_SEPARATOR;
     // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
-    bytes32 public constant PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
-    mapping(address => uint) public nonces;
+    bytes32 public constant PERMIT_TYPEHASH =
+        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    mapping(address => uint256) public nonces;
 
     /// @notice Fei token constructor
     /// @param core Fei Core address to reference
-	constructor(address core) public ERC20("Fei USD", "FEI") CoreRef(core) {
-        uint chainId;
+    constructor(address core) public ERC20("Fei USD", "FEI") CoreRef(core) {
+        uint256 chainId;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             chainId := chainid()
         }
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
-                keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
                 keccak256(bytes(name())),
-                keccak256(bytes('1')),
+                keccak256(bytes("1")),
                 chainId,
                 address(this)
             )
         );
     }
 
-    function setIncentiveContract(address account, address incentive) external override onlyGovernor {
+    function setIncentiveContract(address account, address incentive)
+        external
+        override
+        onlyGovernor
+    {
         incentiveContract[account] = incentive;
         emit IncentiveContractUpdate(account, incentive);
     }
 
-    function mint(address account, uint amount) external override onlyMinter {
+    function mint(address account, uint256 amount)
+        external
+        override
+        onlyMinter
+    {
         _mint(account, amount);
         emit Minting(account, msg.sender, amount);
     }
 
-    function burn(uint amount) public override(IFei, ERC20Burnable) {
+    function burn(uint256 amount) public override(IFei, ERC20Burnable) {
         super.burn(amount);
         emit Burning(msg.sender, msg.sender, amount);
     }
 
-    function burnFrom(address account, uint amount) public override(IFei, ERC20Burnable) onlyBurner {
+    function burnFrom(address account, uint256 amount)
+        public
+        override(IFei, ERC20Burnable)
+        onlyBurner
+    {
         _burn(account, amount);
         emit Burning(account, msg.sender, amount);
     }
 
-    function _transfer(address sender, address recipient, uint256 amount) internal override {
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal override {
         super._transfer(sender, recipient, amount);
         _checkAndApplyIncentives(sender, recipient, amount);
     }
 
-    function _checkAndApplyIncentives(address sender, address recipient, uint amount) internal {
+    function _checkAndApplyIncentives(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal {
         // incentive on sender
         address senderIncentive = incentiveContract[sender];
         if (senderIncentive != address(0)) {
-            IIncentive(senderIncentive).incentivize(sender, recipient, msg.sender, amount);
+            IIncentive(senderIncentive).incentivize(
+                sender,
+                recipient,
+                msg.sender,
+                amount
+            );
         }
 
         // incentive on recipient
         address recipientIncentive = incentiveContract[recipient];
         if (recipientIncentive != address(0)) {
-            IIncentive(recipientIncentive).incentivize(sender, recipient, msg.sender, amount);
+            IIncentive(recipientIncentive).incentivize(
+                sender,
+                recipient,
+                msg.sender,
+                amount
+            );
         }
 
         // incentive on operator
         address operatorIncentive = incentiveContract[msg.sender];
-        if (msg.sender != sender && msg.sender != recipient && operatorIncentive != address(0)) {
-            IIncentive(operatorIncentive).incentivize(sender, recipient, msg.sender, amount);
+        if (
+            msg.sender != sender &&
+            msg.sender != recipient &&
+            operatorIncentive != address(0)
+        ) {
+            IIncentive(operatorIncentive).incentivize(
+                sender,
+                recipient,
+                msg.sender,
+                amount
+            );
         }
 
         // all incentive
         address allIncentive = incentiveContract[address(0)];
         if (allIncentive != address(0)) {
-            IIncentive(allIncentive).incentivize(sender, recipient, msg.sender, amount);
+            IIncentive(allIncentive).incentivize(
+                sender,
+                recipient,
+                msg.sender,
+                amount
+            );
         }
     }
 
-    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external override {
-        require(deadline >= block.timestamp, 'Fei: EXPIRED');
-        bytes32 digest = keccak256(
-            abi.encodePacked(
-                '\x19\x01',
-                DOMAIN_SEPARATOR,
-                keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonces[owner]++, deadline))
-            )
-        );
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override {
+        // solhint-disable-next-line not-rely-on-time
+        require(deadline >= block.timestamp, "Fei: EXPIRED");
+        bytes32 digest =
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    DOMAIN_SEPARATOR,
+                    keccak256(
+                        abi.encode(
+                            PERMIT_TYPEHASH,
+                            owner,
+                            spender,
+                            value,
+                            nonces[owner]++,
+                            deadline
+                        )
+                    )
+                )
+            );
         address recoveredAddress = ecrecover(digest, v, r, s);
-        require(recoveredAddress != address(0) && recoveredAddress == owner, 'Fei: INVALID_SIGNATURE');
+        require(
+            recoveredAddress != address(0) && recoveredAddress == owner,
+            "Fei: INVALID_SIGNATURE"
+        );
         _approve(owner, spender, value);
     }
 }

--- a/contracts/token/IFei.sol
+++ b/contracts/token/IFei.sol
@@ -5,41 +5,59 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @title FEI stablecoin interface
 /// @author Fei Protocol
 interface IFei is IERC20 {
+    // ----------- Events -----------
 
-	// ----------- Events -----------
+    event Minting(
+        address indexed _to,
+        address indexed _minter,
+        uint256 _amount
+    );
 
-    event Minting(address indexed _to, address indexed _minter, uint _amount);
+    event Burning(
+        address indexed _to,
+        address indexed _burner,
+        uint256 _amount
+    );
 
-    event Burning(address indexed _to, address indexed _burner, uint _amount);
-
-    event IncentiveContractUpdate(address indexed _incentivized, address indexed _incentiveContract);
+    event IncentiveContractUpdate(
+        address indexed _incentivized,
+        address indexed _incentiveContract
+    );
 
     // ----------- State changing api -----------
 
     /// @notice burn FEI tokens from caller
     /// @param amount the amount to burn
-    function burn(uint amount) external;
+    function burn(uint256 amount) external;
 
     /// @notice permit spending of FEI
     /// @param owner the FEI holder
     /// @param spender the approved operator
     /// @param value the amount approved
     /// @param deadline the deadline after which the approval is no longer valid
-    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
 
     // ----------- Burner only state changing api -----------
 
     /// @notice burn FEI tokens from specified account
     /// @param account the account to burn from
     /// @param amount the amount to burn
-    function burnFrom(address account, uint amount) external;
+    function burnFrom(address account, uint256 amount) external;
 
     // ----------- Minter only state changing api -----------
 
     /// @notice mint FEI tokens
     /// @param account the account to mint to
     /// @param amount the amount to mint
-    function mint(address account, uint amount) external;
+    function mint(address account, uint256 amount) external;
 
     // ----------- Governor only state changing api -----------
 
@@ -52,5 +70,5 @@ interface IFei is IERC20 {
     /// @notice get associated incentive contract
     /// @param account the address to check
     /// @return the associated incentive contract, 0 address if N/A
-    function incentiveContract(address account) external view returns(address);
+    function incentiveContract(address account) external view returns (address);
 }

--- a/contracts/token/IIncentive.sol
+++ b/contracts/token/IIncentive.sol
@@ -5,18 +5,17 @@ pragma solidity ^0.6.2;
 /// @notice Called by FEI token contract when transferring with an incentivized address
 /// @dev should be appointed as a Minter or Burner as needed
 interface IIncentive {
+    // ----------- Fei only state changing api -----------
 
-	// ----------- Fei only state changing api -----------
-
-	/// @notice apply incentives on transfer
-	/// @param sender the sender address of the FEI
-	/// @param receiver the receiver address of the FEI
-	/// @param operator the operator (msg.sender) of the transfer
-	/// @param amount the amount of FEI transferred
+    /// @notice apply incentives on transfer
+    /// @param sender the sender address of the FEI
+    /// @param receiver the receiver address of the FEI
+    /// @param operator the operator (msg.sender) of the transfer
+    /// @param amount the amount of FEI transferred
     function incentivize(
-    	address sender, 
-    	address receiver, 
-    	address operator, 
-    	uint amount
+        address sender,
+        address receiver,
+        address operator,
+        uint256 amount
     ) external;
 }

--- a/contracts/token/IUniswapIncentive.sol
+++ b/contracts/token/IUniswapIncentive.sol
@@ -8,87 +8,99 @@ import "../external/Decimal.sol";
 /// @author Fei Protocol
 /// @dev incentives are only appplied if the contract is appointed as a Minter or Burner, otherwise skipped
 interface IUniswapIncentive is IIncentive {
+    // ----------- Events -----------
 
-	// ----------- Events -----------
+    event TimeWeightUpdate(uint256 _weight, bool _active);
 
-    event TimeWeightUpdate(uint _weight, bool _active);
-
-    event GrowthRateUpdate(uint _growthRate);
+    event GrowthRateUpdate(uint256 _growthRate);
 
     event ExemptAddressUpdate(address indexed _account, bool _isExempt);
 
-    event SellAllowedAddressUpdate(address indexed _account, bool _isSellAllowed);
+    event SellAllowedAddressUpdate(
+        address indexed _account,
+        bool _isSellAllowed
+    );
 
-	// ----------- Governor only state changing api -----------
+    // ----------- Governor only state changing api -----------
 
-	/// @notice set an address to be exempted from Uniswap trading incentives
-	/// @param account the address to update
-	/// @param isExempt a flag for whether to exempt or unexempt
- 	function setExemptAddress(address account, bool isExempt) external;
+    /// @notice set an address to be exempted from Uniswap trading incentives
+    /// @param account the address to update
+    /// @param isExempt a flag for whether to exempt or unexempt
+    function setExemptAddress(address account, bool isExempt) external;
 
-	/// @notice set an address to be able to send tokens to Uniswap
-	/// @param account the address to update
-	/// @param isAllowed a flag for whether the account is allowed to sell or not
-	function setSellAllowlisted(address account, bool isAllowed) external;
+    /// @notice set an address to be able to send tokens to Uniswap
+    /// @param account the address to update
+    /// @param isAllowed a flag for whether the account is allowed to sell or not
+    function setSellAllowlisted(address account, bool isAllowed) external;
 
-	/// @notice set the time weight growth function
-	function setTimeWeightGrowth(uint32 growthRate) external;
+    /// @notice set the time weight growth function
+    function setTimeWeightGrowth(uint32 growthRate) external;
 
-	/// @notice sets all of the time weight parameters
-	// @param blockNo the stored last block number of the time weight
-	/// @param weight the stored last time weight
-	/// @param growth the growth rate of the time weight per block
-	/// @param active a flag signifying whether the time weight is currently growing or not
-	function setTimeWeight(uint32 weight, uint32 growth, bool active) external;
-
-	// ----------- Getters -----------
-
-	/// @notice return true if burn incentive equals mint
-	function isIncentiveParity() external view returns (bool);
-
-	/// @notice returns true if account is marked as exempt
-	function isExemptAddress(address account) external view returns (bool);
-
-	/// @notice return true if the account is approved to sell to the Uniswap pool
-	function isSellAllowlisted(address account) external view returns (bool);
-
-	/// @notice the granularity of the time weight and growth rate
-	// solhint-disable-next-line func-name-mixedcase
-	function TIME_WEIGHT_GRANULARITY() external view returns(uint32);
-
-	/// @notice the growth rate of the time weight per block
-	function getGrowthRate() external view returns (uint32);
-
-	/// @notice the time weight of the current block
-	/// @dev factors in the stored block number and growth rate if active
-	function getTimeWeight() external view returns (uint32);
-
-	/// @notice returns true if time weight is active and growing at the growth rate
-	function isTimeWeightActive() external view returns (bool);
-
-	/// @notice get the incentive amount of a buy transfer
-	/// @param amount the FEI size of the transfer
-	/// @return incentive the FEI size of the mint incentive
-	/// @return weight the time weight of thhe incentive
-	/// @return initialDeviation the Decimal deviation from peg before a transfer
-	/// @return finalDeviation the Decimal deviation from peg after a transfer
-	/// @dev calculated based on a hypothetical buy, applies to any ERC20 FEI transfer from the pool
-	function getBuyIncentive(uint amount) external view returns(
-        uint incentive, 
+    /// @notice sets all of the time weight parameters
+    // @param blockNo the stored last block number of the time weight
+    /// @param weight the stored last time weight
+    /// @param growth the growth rate of the time weight per block
+    /// @param active a flag signifying whether the time weight is currently growing or not
+    function setTimeWeight(
         uint32 weight,
-        Decimal.D256 memory initialDeviation,
-        Decimal.D256 memory finalDeviation
-    );
+        uint32 growth,
+        bool active
+    ) external;
 
-	/// @notice get the burn amount of a sell transfer
-	/// @param amount the FEI size of the transfer
-	/// @return penalty the FEI size of the burn incentive
-	/// @return initialDeviation the Decimal deviation from peg before a transfer
-	/// @return finalDeviation the Decimal deviation from peg after a transfer
-	/// @dev calculated based on a hypothetical sell, applies to any ERC20 FEI transfer to the pool
-	function getSellPenalty(uint amount) external view returns(
-        uint penalty, 
-        Decimal.D256 memory initialDeviation,
-        Decimal.D256 memory finalDeviation
-    );
+    // ----------- Getters -----------
+
+    /// @notice return true if burn incentive equals mint
+    function isIncentiveParity() external view returns (bool);
+
+    /// @notice returns true if account is marked as exempt
+    function isExemptAddress(address account) external view returns (bool);
+
+    /// @notice return true if the account is approved to sell to the Uniswap pool
+    function isSellAllowlisted(address account) external view returns (bool);
+
+    /// @notice the granularity of the time weight and growth rate
+    // solhint-disable-next-line func-name-mixedcase
+    function TIME_WEIGHT_GRANULARITY() external view returns (uint32);
+
+    /// @notice the growth rate of the time weight per block
+    function getGrowthRate() external view returns (uint32);
+
+    /// @notice the time weight of the current block
+    /// @dev factors in the stored block number and growth rate if active
+    function getTimeWeight() external view returns (uint32);
+
+    /// @notice returns true if time weight is active and growing at the growth rate
+    function isTimeWeightActive() external view returns (bool);
+
+    /// @notice get the incentive amount of a buy transfer
+    /// @param amount the FEI size of the transfer
+    /// @return incentive the FEI size of the mint incentive
+    /// @return weight the time weight of thhe incentive
+    /// @return initialDeviation the Decimal deviation from peg before a transfer
+    /// @return finalDeviation the Decimal deviation from peg after a transfer
+    /// @dev calculated based on a hypothetical buy, applies to any ERC20 FEI transfer from the pool
+    function getBuyIncentive(uint256 amount)
+        external
+        view
+        returns (
+            uint256 incentive,
+            uint32 weight,
+            Decimal.D256 memory initialDeviation,
+            Decimal.D256 memory finalDeviation
+        );
+
+    /// @notice get the burn amount of a sell transfer
+    /// @param amount the FEI size of the transfer
+    /// @return penalty the FEI size of the burn incentive
+    /// @return initialDeviation the Decimal deviation from peg before a transfer
+    /// @return finalDeviation the Decimal deviation from peg after a transfer
+    /// @dev calculated based on a hypothetical sell, applies to any ERC20 FEI transfer to the pool
+    function getSellPenalty(uint256 amount)
+        external
+        view
+        returns (
+            uint256 penalty,
+            Decimal.D256 memory initialDeviation,
+            Decimal.D256 memory finalDeviation
+        );
 }

--- a/contracts/utils/Roots.sol
+++ b/contracts/utils/Roots.sol
@@ -4,10 +4,10 @@ import "@uniswap/lib/contracts/libraries/Babylonian.sol";
 
 library Roots {
     // Newton's method https://en.wikipedia.org/wiki/Cube_root#Numerical_methods
-    function cubeRoot(uint y) internal pure returns (uint z) {
+    function cubeRoot(uint256 y) internal pure returns (uint256 z) {
         if (y > 7) {
             z = y;
-            uint x = y / 3 + 1;
+            uint256 x = y / 3 + 1;
             while (x < z) {
                 z = x;
                 x = (y / (x * x) + (2 * x)) / 3;
@@ -17,7 +17,7 @@ library Roots {
         }
     }
 
-    function sqrt(uint y) internal pure returns (uint) {
+    function sqrt(uint256 y) internal pure returns (uint256) {
         return Babylonian.sqrt(y);
     }
 }

--- a/contracts/utils/Timed.sol
+++ b/contracts/utils/Timed.sol
@@ -7,15 +7,15 @@ import "../external/SafeMathCopy.sol";
 /// @title an abstract contract for timed events
 /// @author Fei Protocol
 abstract contract Timed {
-    using SafeCast for uint;
+    using SafeCast for uint256;
 
     /// @notice the start timestamp of the timed period
-    uint public startTime;
+    uint256 public startTime;
 
     /// @notice the duration of the timed period
-	uint public duration;
+    uint256 public duration;
 
-    constructor(uint _duration) public {
+    constructor(uint256 _duration) public {
         duration = _duration;
     }
 
@@ -26,18 +26,18 @@ abstract contract Timed {
 
     /// @notice number of seconds remaining until time is up
     /// @return remaining
-    function remainingTime() public view returns (uint) {
+    function remainingTime() public view returns (uint256) {
         return SafeMathCopy.sub(duration, timeSinceStart());
     }
 
     /// @notice number of seconds since contract was initialized
     /// @return timestamp
     /// @dev will be less than or equal to duration
-    function timeSinceStart() public view returns (uint) {
-		uint _duration = duration;
-		// solhint-disable-next-line not-rely-on-time
-		uint timePassed = SafeMathCopy.sub(block.timestamp, startTime);
-		return timePassed > _duration ? _duration : timePassed;
+    function timeSinceStart() public view returns (uint256) {
+        uint256 _duration = duration;
+        // solhint-disable-next-line not-rely-on-time
+        uint256 timePassed = SafeMathCopy.sub(block.timestamp, startTime);
+        return timePassed > _duration ? _duration : timePassed;
     }
 
     function _initTimed() internal {

--- a/test/pcv/EthUniswapPCVController.test.js
+++ b/test/pcv/EthUniswapPCVController.test.js
@@ -230,7 +230,7 @@ describe('EthUniswapPCVController', function () {
           'ReweightMinDistanceUpdate',
           { _basisPoints: '50' }
         );
-        expect(await this.pcvController.minDistanceForReweight()).to.be.bignumber.equal('5000000000000000');
+        expect((await this.pcvController.minDistanceForReweight())[0]).to.be.bignumber.equal('5000000000000000');
       });
 
       it('Non-governor set reverts', async function() {


### PR DESCRIPTION
Resolves OZ audit issues N06, N29

Decided not to update any style discrepancies in `dao` to keep changes to forked code to a minimum

Summary:
- ran VSCode format on all contract files except `mock` and `dao` (this made uint->uint256 happen)
- Enforced internal functions begin with _ convention
- Ran solhint and added ignore on relevant areas
- made _feiTribeExchangeRate internal
