### PR TITLE
Fix Timelock Admin

### DIFF
--- a/contracts/dao/Timelock.sol
+++ b/contracts/dao/Timelock.sol
@@ -15,7 +15,7 @@ contract Timelock {
     event QueueTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature, bytes data, uint eta);
 
     uint public constant GRACE_PERIOD = 14 days;
-    uint public constant MINIMUM_DELAY = 1 hours;
+    uint public constant MINIMUM_DELAY = 0;
     uint public constant MAXIMUM_DELAY = 30 days;
 
     address public admin;

--- a/contracts/orchestration/CoreOrchestrator.sol
+++ b/contracts/orchestration/CoreOrchestrator.sol
@@ -34,7 +34,7 @@ contract CoreOrchestrator is Ownable {
     // ----------- Time periods -----------
     uint256 public constant RELEASE_WINDOW = 4 * 365 days;
 
-    uint256 public constant TIMELOCK_DELAY = 2 days;
+    uint256 public constant TIMELOCK_DELAY = 1 days;
     uint256 public constant GENESIS_DURATION = 3 days;
 
     uint256 public constant POOL_DURATION = 2 * 365 days;
@@ -271,7 +271,6 @@ contract CoreOrchestrator is Ownable {
 
     function initGovernance() public onlyOwner {
         (governorAlpha, timelock) = governanceOrchestrator.init(
-            admin,
             tribe,
             TIMELOCK_DELAY
         );

--- a/contracts/orchestration/IOrchestrator.sol
+++ b/contracts/orchestration/IOrchestrator.sol
@@ -84,7 +84,6 @@ interface IGenesisOrchestrator is IOrchestrator {
 
 interface IGovernanceOrchestrator is IOrchestrator {
     function init(
-        address admin,
         address tribe,
         uint256 timelockDelay
     ) external returns (address governorAlpha, address timelock);


### PR DESCRIPTION
This is not in scope for OZ but it is a major issue and small code change so if you have time to review that would be amazing.

Fixes an issue where the Fei team admin is unintentionally set as the Timelock admin. This would effectively give Fei control over all of the PCV (subject to a timelock) which is unintended behavior.

Made some changes to allow for the atomic linking of the timelock and governor alpha at t=0.

Also changed voting delay from 2 days to 1 day