### PR TITLE
Prevent Self Sells

### DIFF
--- a/contracts/token/UniswapIncentive.sol
+++ b/contracts/token/UniswapIncentive.sol
@@ -52,6 +52,7 @@ contract UniswapIncentive is IUniswapIncentive, UniRef {
         address operator,
         uint256 amountIn
     ) external override onlyFei {
+        require(sender != receiver, "UniswapIncentive: cannot send self");
         updateOracle();
 
         if (_isPair(sender)) {

--- a/test/token/UniswapIncentive.test.js
+++ b/test/token/UniswapIncentive.test.js
@@ -235,6 +235,12 @@ describe('UniswapIncentive', function () {
     });
   });
 
+  describe('Self sell', function() {
+    it('reverts', async function() {
+      await expectRevert(this.pair.withdrawFei(this.pair.address, 1000000), "UniswapIncentive: cannot send self");
+    });
+  });
+
   describe('At peg', function() {
     beforeEach(async function() {
       await this.pair.setReserves(100000, 50000000);


### PR DESCRIPTION
This PR protects against weird edge cases where the UniswapIncentive pool could sell to itself