### PR TITLE
Governor Cancel States

### DIFF
--- a/contracts/dao/GovernorAlpha.sol
+++ b/contracts/dao/GovernorAlpha.sol
@@ -205,7 +205,7 @@ contract GovernorAlpha {
 
     function cancel(uint proposalId) public {
         ProposalState state = state(proposalId);
-        require(state != ProposalState.Executed, "GovernorAlpha: cannot cancel executed proposal");
+        require(state == ProposalState.Active || state == ProposalState.Pending, "GovernorAlpha: can only cancel Active or Pending Proposal");
 
         Proposal storage proposal = proposals[proposalId];
         require(msg.sender == guardian || tribe.getPriorVotes(proposal.proposer, sub256(block.number, 1)) < proposalThreshold(), "GovernorAlpha: proposer above threshold");


### PR DESCRIPTION
Addresses OpenZeppelin audit issue N17

Make it so GovernorAlpha proposals can only be cancelled in Active or Pending states