### PR TITLE
Fix Timed Behavior

### DIFF
--- a/contracts/bondingcurve/BondingCurve.sol
+++ b/contracts/bondingcurve/BondingCurve.sol
@@ -51,6 +51,8 @@ abstract contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed {
     {
         _setScale(_scale);
         incentiveAmount = _incentive;
+
+        _initTimed();
     }
 
     /// @notice sets the bonding curve Scale target

--- a/contracts/utils/Timed.sol
+++ b/contracts/utils/Timed.sol
@@ -16,7 +16,7 @@ abstract contract Timed {
     uint256 public duration;
 
     constructor(uint256 _duration) public {
-        duration = _duration;
+        _setDuration(_duration);
     }
 
     /// @notice return true if time period has ended
@@ -34,6 +34,9 @@ abstract contract Timed {
     /// @return timestamp
     /// @dev will be less than or equal to duration
     function timeSinceStart() public view returns (uint256) {
+        if (startTime == 0) {
+            return 0; // uninitialized
+        }
         uint256 _duration = duration;
         // solhint-disable-next-line not-rely-on-time
         uint256 timePassed = SafeMathCopy.sub(block.timestamp, startTime);
@@ -43,5 +46,9 @@ abstract contract Timed {
     function _initTimed() internal {
         // solhint-disable-next-line not-rely-on-time
         startTime = block.timestamp;
+    }
+
+    function _setDuration(uint _duration) internal {
+        duration = _duration;
     }
 }

--- a/test/bondingcurve/EthBondingCurve.test.js
+++ b/test/bondingcurve/EthBondingCurve.test.js
@@ -448,6 +448,8 @@ describe('EthBondingCurve', function () {
 
         this.keeperFei = await this.fei.balanceOf(keeperAddress);
 
+        await time.increase(this.incentiveDuration);
+
         await this.bondingCurve.purchase(userAddress, this.purchaseAmount, {value: this.purchaseAmount});
         expectEvent(await this.bondingCurve.allocate({from: keeperAddress}),
           'Allocate',


### PR DESCRIPTION
Make it so that the behavior of the Timed contract is that `isTimeEnded()` is false when uninitialized (unless duration is 0)