### PR TITLE
Fix Incentives Better

### DIFF
--- a/contracts/token/UniswapIncentive.sol
+++ b/contracts/token/UniswapIncentive.sol
@@ -172,7 +172,7 @@ contract UniswapIncentive is IUniswapIncentive, UniRef {
             "UniswapIncentive: Price already at or above peg"
         );
 
-        Decimal.D256 memory incentive = _calculateBuyIncentiveMultiplier(deviation, weight);
+        Decimal.D256 memory incentive = _calculateBuyIncentiveMultiplier(deviation, deviation, weight);
         Decimal.D256 memory penalty = _calculateSellPenaltyMultiplier(deviation);
         return incentive.equals(penalty);
     }
@@ -214,7 +214,7 @@ contract UniswapIncentive is IUniswapIncentive, UniRef {
         }
 
         Decimal.D256 memory multiplier =
-            _calculateBuyIncentiveMultiplier(initialDeviation, weight);
+            _calculateBuyIncentiveMultiplier(initialDeviation, finalDeviation, weight);
         incentive = multiplier.mul(incentivizedAmount).asUint256();
         return (incentive, weight, initialDeviation, finalDeviation);
     }
@@ -254,7 +254,7 @@ contract UniswapIncentive is IUniswapIncentive, UniRef {
         }
 
         Decimal.D256 memory multiplier =
-            _calculateSellPenaltyMultiplier(finalDeviation);
+            _calculateIntegratedSellPenaltyMultiplier(initialDeviation, finalDeviation);
         penalty = multiplier.mul(incentivizedAmount).asUint256();
         return (penalty, initialDeviation, finalDeviation);
     }
@@ -303,13 +303,14 @@ contract UniswapIncentive is IUniswapIncentive, UniRef {
     }
 
     function _calculateBuyIncentiveMultiplier(
-        Decimal.D256 memory deviation,
+        Decimal.D256 memory initialDeviation,
+        Decimal.D256 memory finalDeviation,
         uint32 weight
     ) internal pure returns (Decimal.D256 memory) {
         Decimal.D256 memory correspondingPenalty =
-            _calculateSellPenaltyMultiplier(deviation);
+            _calculateIntegratedSellPenaltyMultiplier(finalDeviation, initialDeviation); // flip direction
         Decimal.D256 memory buyMultiplier =
-            deviation.mul(uint256(weight)).div(
+            initialDeviation.mul(uint256(weight)).div(
                 uint256(TIME_WEIGHT_GRANULARITY)
             );
 
@@ -318,6 +319,28 @@ contract UniswapIncentive is IUniswapIncentive, UniRef {
         }
 
         return buyMultiplier;
+    }
+
+    // The sell penalty smoothed over the curve
+    function _calculateIntegratedSellPenaltyMultiplier(Decimal.D256 memory initialDeviation, Decimal.D256 memory finalDeviation)
+        internal
+        pure
+        returns (Decimal.D256 memory)
+    {
+        if (initialDeviation.equals(finalDeviation)) {
+            return _calculateSellPenaltyMultiplier(initialDeviation);
+        }
+        Decimal.D256 memory numerator = _sellPenaltyBound(finalDeviation).sub(_sellPenaltyBound(initialDeviation));
+        Decimal.D256 memory denominator = finalDeviation.sub(initialDeviation);
+        return numerator.div(denominator);
+    }
+
+    function _sellPenaltyBound(Decimal.D256 memory deviation)         
+        internal
+        pure
+        returns (Decimal.D256 memory)
+    {
+        return deviation.pow(3).mul(33);
     }
 
     function _calculateSellPenaltyMultiplier(Decimal.D256 memory deviation)


### PR DESCRIPTION
Converts the sell penalty to the smooth integral of the distance rather than the lump worst case penalty.

For example a trade starting at .95 and ending at .90 will not just do a (1-.90)^2 burn but rather take the integral of the burn function from .05 to .1 with respect to the distance from the peg.

Commit #1 reverts https://github.com/fei-protocol/fei-protocol-core/pull/63.
Commit #2 implements the fix