### PR TITLE
Pre release fix flash attacks

### DIFF
--- a/contracts/bondingcurve/BondingCurve.sol
+++ b/contracts/bondingcurve/BondingCurve.sol
@@ -79,7 +79,7 @@ abstract contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed {
     }
 
     /// @notice batch allocate held PCV
-    function allocate() external override postGenesis whenNotPaused {
+    function allocate() external override postGenesis whenNotPaused nonContract {
         uint256 amount = getTotalPCVHeld();
         require(amount != 0, "BondingCurve: No PCV held");
 

--- a/contracts/genesis/GenesisGroup.sol
+++ b/contracts/genesis/GenesisGroup.sol
@@ -144,7 +144,7 @@ contract GenesisGroup is IGenesisGroup, CoreRef, ERC20, Timed {
     }
 
     /// @notice launch Fei Protocol. Callable once Genesis Period has ended
-    function launch() external override {
+    function launch() external override nonContract {
         require(isTimeEnded(), "GenesisGroup: Still in Genesis Period");
 
         // Complete Genesis

--- a/contracts/mock/MockBot.sol
+++ b/contracts/mock/MockBot.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.6.0;
+
+import "../genesis/IGenesisGroup.sol";
+import "../bondingcurve/IBondingCurve.sol";
+import "../pcv/IUniswapPCVController.sol";
+import "../staking/IRewardsDistributor.sol";
+
+contract MockBot {
+
+	function genesisLaunch(address genesis) public {
+		IGenesisGroup(genesis).launch();
+	}
+
+    function bondingCurveAllocate(address bondingCurve) public {
+		IBondingCurve(bondingCurve).allocate();
+	}
+
+    function controllerReweight(address controller) public {
+        IUniswapPCVController(controller).reweight();
+    }
+
+    function distributorDrip(address distributor) public {
+        IRewardsDistributor(distributor).drip();
+    }
+}
+

--- a/contracts/pcv/EthUniswapPCVController.sol
+++ b/contracts/pcv/EthUniswapPCVController.sol
@@ -55,7 +55,7 @@ contract EthUniswapPCVController is IUniswapPCVController, UniRef {
     receive() external payable {}
 
     /// @notice reweights the linked PCV Deposit to the peg price. Needs to be reweight eligible
-    function reweight() external override postGenesis whenNotPaused {
+    function reweight() external override postGenesis whenNotPaused nonContract {
         updateOracle();
         require(
             reweightEligible(),

--- a/contracts/pcv/UniswapPCVDeposit.sol
+++ b/contracts/pcv/UniswapPCVDeposit.sol
@@ -68,11 +68,7 @@ abstract contract UniswapPCVDeposit is IPCVDeposit, UniRef {
         view
         returns (uint256 amountFei)
     {
-        (uint256 feiReserves, uint256 tokenReserves) = getReserves();
-        if (feiReserves == 0 || tokenReserves == 0) {
-            return peg().mul(amountToken).asUint256();
-        }
-        return UniswapV2Library.quote(amountToken, tokenReserves, feiReserves);
+        return peg().mul(amountToken).asUint256();
     }
 
     function _removeLiquidity(uint256 amount)

--- a/contracts/refs/CoreRef.sol
+++ b/contracts/refs/CoreRef.sol
@@ -3,6 +3,7 @@ pragma experimental ABIEncoderV2;
 
 import "./ICoreRef.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 
 /// @title A Reference to Core
 /// @author Fei Protocol
@@ -81,6 +82,11 @@ abstract contract CoreRef is ICoreRef, Pausable {
             _core.hasGenesisGroupCompleted(),
             "CoreRef: Still in Genesis Period"
         );
+        _;
+    }
+
+    modifier nonContract() {
+        require(!Address.isContract(msg.sender), "CoreRef: Caller is a contract");
         _;
     }
 

--- a/contracts/staking/FeiRewardsDistributor.sol
+++ b/contracts/staking/FeiRewardsDistributor.sol
@@ -48,7 +48,7 @@ contract FeiRewardsDistributor is IRewardsDistributor, CoreRef, Timed {
 
     /// @notice sends the unlocked amount of TRIBE to the stakingRewards contract
     /// @return amount of TRIBE sent
-    function drip() public override postGenesis whenNotPaused returns(uint256) {
+    function drip() public override postGenesis whenNotPaused nonContract returns(uint256) {
         require(isDripAvailable(), "FeiRewardsDistributor: Not passed drip frequency");
         // solhint-disable-next-line not-rely-on-time
         lastDistributionTime = block.timestamp;

--- a/test/bondingcurve/EthBondingCurve.test.js
+++ b/test/bondingcurve/EthBondingCurve.test.js
@@ -14,6 +14,7 @@ const {
   MockEthPCVDeposit,
   Fei,
   MockOracle, 
+  MockBot,
   EthBondingCurve,
   getCore
 } = require('../helpers');
@@ -431,6 +432,13 @@ describe('EthBondingCurve', function () {
       it('reverts', async function() {
         await this.bondingCurve.pause({from: governorAddress});
         await expectRevert(this.bondingCurve.allocate({from: keeperAddress}), "Pausable: paused");
+      });
+    });
+
+    describe('From Contract', function() {
+      it('reverts', async function() {
+        let bot = await MockBot.new();
+        await expectRevert(bot.bondingCurveAllocate(this.bondingCurve.address), "CoreRef: Caller is a contract");
       });
     });
 

--- a/test/genesis/GenesisGroup.test.js
+++ b/test/genesis/GenesisGroup.test.js
@@ -186,7 +186,7 @@ describe('GenesisGroup', function () {
 
     it('reverts', async function() {
       await this.genesisGroup.approve(this.flashGenesis.address, '750', {from: userAddress});
-      await expectRevert(this.flashGenesis.zap(userAddress), "GenesisGroup: No redeeming in launch block");
+      await expectRevert(this.flashGenesis.zap(userAddress), "CoreRef: Caller is a contract");
     });
   });
   describe('Launch', function() {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -32,6 +32,7 @@ const FeiRewardsDistributor = contract.fromArtifact('FeiRewardsDistributor');
 
 const MockBondingCurve = contract.fromArtifact('MockBondingCurve');
 const MockBondingCurveOracle = contract.fromArtifact('MockBondingCurveOracle');
+const MockBot = contract.fromArtifact('MockBot');
 const MockCoreRef = contract.fromArtifact('MockCoreRef');
 const MockERC20 = contract.fromArtifact('MockERC20');
 const MockEthPCVDeposit = contract.fromArtifact('MockEthPCVDeposit');
@@ -121,6 +122,7 @@ module.exports = {
     // mock contracts
     MockBondingCurve,
     MockBondingCurveOracle,
+    MockBot,
     MockCoreRef,
     MockEthPCVDeposit,
     MockERC20,

--- a/test/pcv/EthUniswapPCVController.test.js
+++ b/test/pcv/EthUniswapPCVController.test.js
@@ -10,6 +10,7 @@ const {
   expect,
   EthUniswapPCVController,
   Fei,
+  MockBot,
   MockPCVDeposit,
   MockOracle,
   MockPair,
@@ -146,6 +147,14 @@ describe('EthUniswapPCVController', function () {
         await expectRevert(this.pcvController.reweight(), "Pausable: paused");
       });
     });
+
+    describe('From Contract', function() {
+      it('reverts', async function() {
+        let bot = await MockBot.new();
+        await expectRevert(bot.controllerReweight(this.pcvController.address), "CoreRef: Caller is a contract");
+      });
+    });
+
     describe('Not at incentive parity', function () {
       it('reverts', async function() {
         await this.pair.set(100000, 51000000, LIQUIDITY_INCREMENT, {from: userAddress, value: 100000}); // 510:1 FEI/ETH with 10k liquidity

--- a/test/staking/FeiRewardsDistributor.test.js
+++ b/test/staking/FeiRewardsDistributor.test.js
@@ -11,6 +11,7 @@ const {
     MockStakingRewards,
     FeiRewardsDistributor,
     MockERC20,
+    MockBot,
     getCore,
     expectApprox
   } = require('../helpers');
@@ -211,6 +212,13 @@ const {
             it('reverts', async function() {
               await this.distributor.pause({from: governorAddress});
               await expectRevert(this.distributor.drip(), "Pausable: paused");
+            });
+        });
+
+        describe('From Contract', function() {
+            it('reverts', async function() {
+              let bot = await MockBot.new();
+              await expectRevert(bot.distributorDrip(this.distributor.address), "CoreRef: Caller is a contract");
             });
         });
 


### PR DESCRIPTION
It is possible to execute a flash loan and profit via the following trade:

1. Flash borrow ETH
2. Buy on spot market
3. Buy on bonding curve and execute bonding curve allocation
4. Sell FEI from 2 and 3
5. Profit

The end result is the spot price of FEI/ETH is lower than at the beginning, essentially arbing by spiking the price of FEI since it uses the spot price when depositing. The solution has 2 parts:
1. deposit at oracle price not spot price
2. Restrict allocate() and other potentially risky flows to EOA only

Spreadsheet detailing attack https://docs.google.com/spreadsheets/d/1PU51ptA8_xxCEJjWqMbobmNZqX5VBToAAwHm3mmDpk8/edit#gid=0