### PR TITLE
Normalize IDO

### DIFF
--- a/contracts/genesis/IDO.sol
+++ b/contracts/genesis/IDO.sol
@@ -83,6 +83,9 @@ contract IDO is IDOInterface, UniRef, LinearTokenTimelock {
                 : (amountOut, uint256(0));
         pair.swap(amount0Out, amount1Out, msg.sender, new bytes(0));
 
+        fei().burnFrom(address(pair), amountFei);
+        pair.sync();
+        
         return amountOut;
     }
 }

--- a/contracts/mock/MockUniswapV2PairLiquidity.sol
+++ b/contracts/mock/MockUniswapV2PairLiquidity.sol
@@ -91,6 +91,8 @@ contract MockUniswapV2PairLiquidity {
         }
     }
 
+    function sync() external { } // no-op 
+
     // @openzeppelin/contracts/token/ERC20/ERC20.sol
 
     mapping (address => uint256) private _balances;

--- a/contracts/orchestration/CoreOrchestrator.sol
+++ b/contracts/orchestration/CoreOrchestrator.sol
@@ -236,6 +236,8 @@ contract CoreOrchestrator is Ownable {
             TOKEN_TIMELOCK_RELEASE_WINDOW
         );
         core.grantMinter(ido);
+        core.grantBurner(ido);
+
         core.allocateTribe(ido, (tribeSupply * IDO_TRIBE_PERCENTAGE) / 100);
         core.allocateTribe(
             timelockedDelegator,

--- a/test/genesis/IDO.test.js
+++ b/test/genesis/IDO.test.js
@@ -36,6 +36,8 @@ describe('IDO', function () {
     this.window = new BN(4 * 365 * 24 * 60 * 60);
     this.ido = await IDO.new(this.core.address, beneficiaryAddress1, this.window, this.pair.address, this.router.address);
     await this.core.grantMinter(this.ido.address, {from: governorAddress});
+    await this.core.grantBurner(this.ido.address, {from: governorAddress});
+
     await this.core.allocateTribe(this.ido.address, 100000, {from: governorAddress});
   });
 
@@ -89,6 +91,8 @@ describe('IDO', function () {
     describe('From Genesis Group', function() {
       beforeEach(async function() {
         await this.pair.setReserves('500000', '100000');
+        await this.fei.mint(this.pair.address, '500000', {from: minterAddress});
+
         await this.fei.mint(genesisGroup, '50000', {from: minterAddress});
         await this.core.allocateTribe(this.pair.address, 100000, {from: governorAddress});
       });
@@ -109,7 +113,7 @@ describe('IDO', function () {
         });
 
         it('updates pair balances', async function() {
-          expect(await this.fei.balanceOf(this.pair.address)).to.be.bignumber.equal(new BN(50000));
+          expect(await this.fei.balanceOf(this.pair.address)).to.be.bignumber.equal(new BN(500000)); // swap amount is burned
         });
       });
     });


### PR DESCRIPTION
There is an issue with genesis where there is a free arb for participating and pre-committing 100% with the intention of backrunning the group by selling TRIBE at the inflated price.

This PR solves that issue by burning the FEI sent to the pool which normalizes the price to the average of what everyone paid.

This has a second benefit of adding a buffer to the PCV due to the FEI being removed from circulation.