### PR TITLE
IDO Unlock

### DIFF
--- a/contracts/genesis/IDO.sol
+++ b/contracts/genesis/IDO.sol
@@ -85,4 +85,9 @@ contract IDO is IDOInterface, UniRef, LinearTokenTimelock {
 
         return amountOut;
     }
+
+    /// @notice unlock override to beneficiary of timelock
+    function unlockLiquidity() external override onlyGovernor {
+        _release(beneficiary, totalToken());
+    }
 }

--- a/contracts/genesis/IDOInterface.sol
+++ b/contracts/genesis/IDOInterface.sol
@@ -15,4 +15,9 @@ interface IDOInterface {
     function deploy(Decimal.D256 calldata feiRatio) external;
 
     function swapFei(uint256 amountFei) external returns (uint256);
+
+    // ----------- Governor only state changing API -----------
+
+    function unlockLiquidity() external;
+
 }

--- a/contracts/utils/ILinearTokenTimelock.sol
+++ b/contracts/utils/ILinearTokenTimelock.sol
@@ -15,6 +15,8 @@ interface ILinearTokenTimelock {
 
     function release(address to, uint amount) external;
 
+    function releaseMax(address to) external;
+
     function setPendingBeneficiary(address _pendingBeneficiary) external;
 
     function acceptBeneficiary() external;

--- a/contracts/utils/LinearTokenTimelock.sol
+++ b/contracts/utils/LinearTokenTimelock.sol
@@ -59,15 +59,19 @@ contract LinearTokenTimelock is ILinearTokenTimelock, Timed {
         _;
     }
 
-    /// @notice releases unlocked tokens to beneficiary
-    function release(address to, uint amount) external override onlyBeneficiary balanceCheck {
+    /// @notice releases `amount` unlocked tokens to address `to`
+    function release(address to, uint256 amount) external override onlyBeneficiary balanceCheck {
         require(amount != 0, "LinearTokenTimelock: no amount desired");
 
         uint256 available = availableForRelease();
         require(amount <= available, "LinearTokenTimelock: not enough released tokens");
 
-        lockedToken.transfer(to, amount);
-        emit Release(beneficiary, to, amount);
+        _release(to, amount);
+    }
+
+    /// @notice releases maximum unlocked tokens to address `to`
+    function releaseMax(address to) external override onlyBeneficiary balanceCheck {
+        _release(to, availableForRelease());
     }
 
     /// @notice the total amount of tokens held by timelock
@@ -117,5 +121,10 @@ contract LinearTokenTimelock is ILinearTokenTimelock, Timed {
 
     function _setLockedToken(address tokenAddress) internal {
         lockedToken = IERC20(tokenAddress);
+    }
+
+    function _release(address to, uint256 amount) internal {
+        lockedToken.transfer(to, amount);
+        emit Release(beneficiary, to, amount);
     }
 }

--- a/test/dao/TimelockedDelegator.test.js
+++ b/test/dao/TimelockedDelegator.test.js
@@ -90,6 +90,22 @@ describe('TimelockedDelegator', function () {
         });
       });
 
+      describe('ReleaseMax Another Quarter', function() {
+        beforeEach(async function() {
+          await time.increase(this.quarter);
+          expect(await this.delegator.availableForRelease()).to.be.bignumber.equal(this.quarterAmount);
+          await this.delegator.releaseMax(beneficiaryAddress1, {from: beneficiaryAddress1});
+        });
+        it('releases tokens', async function() {
+          expect(await this.delegator.totalToken()).to.be.bignumber.equal(this.totalTribe.div(new BN(2)));
+          expect(await this.tribe.balanceOf(beneficiaryAddress1)).to.be.bignumber.equal(this.totalTribe.div(new BN(2)));
+        });
+
+        it('updates released amounts', async function() {
+          expect(await this.delegator.alreadyReleasedAmount()).to.be.bignumber.equal(this.totalTribe.div(new BN(2)));
+        });
+      });
+
       describe('Excess Release', function() {
         it('reverts', async function() {
           await time.increase(this.quarter);

--- a/test/genesis/IDO.test.js
+++ b/test/genesis/IDO.test.js
@@ -78,6 +78,22 @@ describe('IDO', function () {
     });
   });
 
+  describe('UnlockLiquidity', function() {
+    describe('Not Governor', function() {
+      it('reverts', async function() {
+        await expectRevert(this.ido.unlockLiquidity({from: userAddress}), "CoreRef: Caller is not a governor");
+      });
+    });
+
+    describe('From Governor', function() {
+      beforeEach(async function() {
+        await this.ido.unlockLiquidity({from: governorAddress});
+      });
+      it('succeeds', async function() {
+        expect(await this.ido.totalToken()).to.be.bignumber.equal(new BN('0'));
+      });
+    });
+  });
 
   describe('Swap', function() {
     describe('Not Genesis Group', function() {


### PR DESCRIPTION
Allows governance to unlock the IDO liquidity in case we want to upgrade to a different AMM.

Also allows for the beneficiary to release the max available tokens