### PR TITLE
add getters to incentives for multipliers

### DIFF
--- a/contracts/refs/IUniRef.sol
+++ b/contracts/refs/IUniRef.sol
@@ -30,5 +30,10 @@ interface IUniRef {
         view
         returns (uint256 feiReserves, uint256 tokenReserves);
 
+    function deviationBelowPeg(
+        Decimal.D256 calldata price,
+        Decimal.D256 calldata peg
+    ) external pure returns (Decimal.D256 memory);
+
     function liquidityOwned() external view returns (uint256);
 }

--- a/contracts/refs/UniRef.sol
+++ b/contracts/refs/UniRef.sol
@@ -81,6 +81,15 @@ abstract contract UniRef is IUniRef, OracleRef {
         return (feiReserves, tokenReserves);
     }
 
+    /// @notice get deviation from peg as a percent given price
+    /// @dev will return Decimal.zero() if above peg
+    function deviationBelowPeg(
+        Decimal.D256 calldata price,
+        Decimal.D256 calldata peg
+    ) external pure override returns (Decimal.D256 memory) {
+        return _deviationBelowPeg(price, peg);
+    }
+
     /// @notice amount of pair liquidity owned by this contract
     /// @return amount of LP tokens
     function liquidityOwned() public view override returns (uint256) {

--- a/contracts/token/IUniswapIncentive.sol
+++ b/contracts/token/IUniswapIncentive.sol
@@ -60,4 +60,14 @@ interface IUniswapIncentive is IIncentive {
             Decimal.D256 memory initialDeviation,
             Decimal.D256 memory finalDeviation
         );
+
+    function getSellPenaltyMultiplier(
+        Decimal.D256 calldata initialDeviation,
+        Decimal.D256 calldata finalDeviation
+    ) external view returns (Decimal.D256 memory);
+
+    function getBuyIncentiveMultiplier(
+        Decimal.D256 calldata initialDeviation,
+        Decimal.D256 calldata finalDeviation
+    ) external view returns (Decimal.D256 memory);
 }

--- a/contracts/token/UniswapIncentive.sol
+++ b/contracts/token/UniswapIncentive.sol
@@ -246,6 +246,26 @@ contract UniswapIncentive is IUniswapIncentive, UniRef {
         return (penalty, initialDeviation, finalDeviation);
     }
 
+    /// @notice returns the multiplier used to calculate the sell penalty
+    /// @param initialDeviation the percent from peg at start of trade
+    /// @param finalDeviation the percent from peg at the end of trade
+    function getSellPenaltyMultiplier(
+        Decimal.D256 calldata initialDeviation,
+        Decimal.D256 calldata finalDeviation
+    ) external view override returns (Decimal.D256 memory) {
+        return _calculateIntegratedSellPenaltyMultiplier(initialDeviation, finalDeviation);
+    }
+
+    /// @notice returns the multiplier used to calculate the buy reward
+    /// @param initialDeviation the percent from peg at start of trade
+    /// @param finalDeviation the percent from peg at the end of trade
+    function getBuyIncentiveMultiplier(
+        Decimal.D256 calldata initialDeviation,
+        Decimal.D256 calldata finalDeviation
+    ) external view override returns (Decimal.D256 memory) {
+        return _calculateBuyIncentiveMultiplier(initialDeviation, finalDeviation, getTimeWeight());
+    }
+
     function _incentivizeBuy(address target, uint256 amountIn)
         internal
         ifMinterSelf

--- a/test/token/UniswapIncentive.test.js
+++ b/test/token/UniswapIncentive.test.js
@@ -242,6 +242,179 @@ describe('UniswapIncentive', function () {
     });
   });
 
+  describe('Deviation from peg', function() {
+    describe('Below', function() {
+      it('1%', async function() {
+        let deviation = await this.incentive.deviationBelowPeg(['10100'], ['10000']);
+        expect(deviation[0]).to.be.equal('10000000000000000');
+      });
+
+      it('10%', async function() {
+        let deviation = await this.incentive.deviationBelowPeg(['11000'], ['10000']);
+        expect(deviation[0]).to.be.equal('100000000000000000');
+      });
+    });
+
+    describe('At Peg', function() {
+      it('0%', async function() {
+        let deviation = await this.incentive.deviationBelowPeg(['10000'], ['10000']);
+        expect(deviation[0]).to.be.equal('0');
+      });
+    });
+
+    describe('Above', function() {
+      it('1%', async function() {
+        let deviation = await this.incentive.deviationBelowPeg(['9900'], ['10000']);
+        expect(deviation[0]).to.be.equal('0');
+      });
+
+      it('10%', async function() {
+        let deviation = await this.incentive.deviationBelowPeg(['9000'], ['10000']);
+        expect(deviation[0]).to.be.equal('0');
+      });
+    });
+  });
+
+  describe('Get Buy Incentive Multiplier', function() {
+    describe('1% initial', function() {
+
+      describe('0% final', function() {
+        it('Time weight 0', async function() {
+          await this.incentive.setTimeWeight('0', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['10000000000000000'], ['0']);
+          expect(multiplier[0]).to.be.equal('0');
+        });
+
+        it('Time weight 1', async function() {
+          await this.incentive.setTimeWeight('100000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['10000000000000000'], ['0']);
+          expect(multiplier[0]).to.be.equal('3300000000000000');
+        });
+
+        it('Time weight 5', async function() {
+          await this.incentive.setTimeWeight('500000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['10000000000000000'], ['0']);
+          expect(multiplier[0]).to.be.equal('3300000000000000');
+        });
+      });
+
+      describe('1% final', function() {
+        it('Time weight 0', async function() {
+          await this.incentive.setTimeWeight('0', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['10000000000000000'], ['10000000000000000']);
+          expect(multiplier[0]).to.be.equal('0');
+        });
+
+        it('Time weight 1', async function() {
+          await this.incentive.setTimeWeight('100000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['10000000000000000'], ['10000000000000000']);
+          expect(multiplier[0]).to.be.equal('10000000000000000');
+        });
+
+        it('Time weight 5', async function() {
+          await this.incentive.setTimeWeight('500000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['10000000000000000'], ['10000000000000000']);
+          expect(multiplier[0]).to.be.equal('10000000000000000');
+        });
+      });
+    });
+
+    describe('5% initial', function() {
+      describe('0% final', function() {
+        it('Time weight 0', async function() {
+          await this.incentive.setTimeWeight('0', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['0']);
+          expect(multiplier[0]).to.be.equal('0');
+        });
+
+        it('Time weight 1', async function() {
+          await this.incentive.setTimeWeight('100000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['0']);
+          expect(multiplier[0]).to.be.equal('50000000000000000');
+        });
+
+        it('Time weight 5', async function() {
+          await this.incentive.setTimeWeight('500000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['0']);
+          expect(multiplier[0]).to.be.equal('82500000000000000');
+        });
+      });
+
+      describe('1% final', function() {
+        it('Time weight 0', async function() {
+          await this.incentive.setTimeWeight('0', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['10000000000000000']);
+          expect(multiplier[0]).to.be.equal('0');
+        });
+
+        it('Time weight 1', async function() {
+          await this.incentive.setTimeWeight('100000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['10000000000000000']);
+          expect(multiplier[0]).to.be.equal('50000000000000000');
+        });
+
+        it('Time weight 5', async function() {
+          await this.incentive.setTimeWeight('500000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['10000000000000000']);
+          expect(multiplier[0]).to.be.equal('102300000000000000');
+        });
+      });
+
+      describe('5% final', function() {
+        it('Time weight 0', async function() {
+          await this.incentive.setTimeWeight('0', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['50000000000000000']);
+          expect(multiplier[0]).to.be.equal('0');
+        });
+
+        it('Time weight 1', async function() {
+          await this.incentive.setTimeWeight('100000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['50000000000000000']);
+          expect(multiplier[0]).to.be.equal('50000000000000000');
+        });
+
+        it('Time weight 5', async function() {
+          await this.incentive.setTimeWeight('500000', '0', true, {from: governorAddress});
+          let multiplier = await this.incentive.getBuyIncentiveMultiplier(['50000000000000000'], ['50000000000000000']);
+          expect(multiplier[0]).to.be.equal('250000000000000000');
+        });
+      });
+    });
+  });
+
+  describe('Get Sell Multiplier', function() {
+    describe('0% initial', function() {
+      it('1% final', async function() {
+        let multiplier = await this.incentive.getSellPenaltyMultiplier(['0'], ['10000000000000000']);
+        expect(multiplier[0]).to.be.equal('3300000000000000');
+      });
+
+      it('5% final', async function() {
+        let multiplier = await this.incentive.getSellPenaltyMultiplier(['0'], ['50000000000000000']);
+        expect(multiplier[0]).to.be.equal('82500000000000000');
+      });
+    });
+
+    describe('1% initial', function() {
+      it('1% final', async function() {
+        let multiplier = await this.incentive.getSellPenaltyMultiplier(['10000000000000000'], ['10000000000000000']);
+        expect(multiplier[0]).to.be.equal('10000000000000000');
+      });
+
+      it('5% final', async function() {
+        let multiplier = await this.incentive.getSellPenaltyMultiplier(['10000000000000000'], ['50000000000000000']);
+        expect(multiplier[0]).to.be.equal('102300000000000000');
+      });
+    });
+
+    describe('5% initial', function() {
+      it('5% final', async function() {
+        let multiplier = await this.incentive.getSellPenaltyMultiplier(['50000000000000000'], ['50000000000000000']);
+        expect(multiplier[0]).to.be.equal('250000000000000000');
+      });
+    });
+  });
+
   describe('At peg', function() {
     beforeEach(async function() {
       await this.pair.setReserves(100000, 50000000);


### PR DESCRIPTION
To allow for easier integrations and introspection (esp twap oracles), added getters to expose some of the core incentive logic around multipliers