### PR TITLE
Import cleanup

### DIFF
--- a/contracts/core/ICore.sol
+++ b/contracts/core/ICore.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IPermissions.sol";
 import "../token/IFei.sol";
 

--- a/contracts/core/IPermissions.sol
+++ b/contracts/core/IPermissions.sol
@@ -1,9 +1,6 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "../token/IFei.sol";
-
 /// @title Permissions interface
 /// @author Fei Protocol
 interface IPermissions {

--- a/contracts/external/UniswapV2Library.sol
+++ b/contracts/external/UniswapV2Library.sol
@@ -1,0 +1,17 @@
+ pragma solidity >=0.6.0;
+
+ import "./SafeMathCopy.sol";
+
+ library UniswapV2Library {
+    using SafeMathCopy for uint;
+
+    // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) internal pure returns (uint amountOut) {
+        require(amountIn > 0, 'UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT');
+        require(reserveIn > 0 && reserveOut > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+        uint amountInWithFee = amountIn.mul(997);
+        uint numerator = amountInWithFee.mul(reserveOut);
+        uint denominator = reserveIn.mul(1000).add(amountInWithFee);
+        amountOut = numerator / denominator;
+    }
+ }

--- a/contracts/external/UniswapV2OracleLibrary.sol
+++ b/contracts/external/UniswapV2OracleLibrary.sol
@@ -1,0 +1,35 @@
+pragma solidity >=0.6.0;
+
+import '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';
+import '@uniswap/lib/contracts/libraries/FixedPoint.sol';
+
+// library with helper methods for oracles that are concerned with computing average prices
+library UniswapV2OracleLibrary {
+    using FixedPoint for *;
+
+    // helper function that returns the current block timestamp within the range of uint32, i.e. [0, 2**32 - 1]
+    function currentBlockTimestamp() internal view returns (uint32) {
+        return uint32(block.timestamp % 2 ** 32);
+    }
+
+    // produces the cumulative price using counterfactuals to save gas and avoid a call to sync.
+    function currentCumulativePrices(
+        address pair
+    ) internal view returns (uint price0Cumulative, uint price1Cumulative, uint32 blockTimestamp) {
+        blockTimestamp = currentBlockTimestamp();
+        price0Cumulative = IUniswapV2Pair(pair).price0CumulativeLast();
+        price1Cumulative = IUniswapV2Pair(pair).price1CumulativeLast();
+
+        // if time has elapsed since the last update on the pair, mock the accumulated price values
+        (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast) = IUniswapV2Pair(pair).getReserves();
+        if (blockTimestampLast != blockTimestamp) {
+            // subtraction overflow is desired
+            uint32 timeElapsed = blockTimestamp - blockTimestampLast;
+            // addition overflow is desired
+            // counterfactual
+            price0Cumulative += uint(FixedPoint.fraction(reserve1, reserve0)._x) * timeElapsed;
+            // counterfactual
+            price1Cumulative += uint(FixedPoint.fraction(reserve0, reserve1)._x) * timeElapsed;
+        }
+    }
+}

--- a/contracts/genesis/IDO.sol
+++ b/contracts/genesis/IDO.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
 import "./IDOInterface.sol";
+import "../external/UniswapV2Library.sol";
 import "../utils/LinearTokenTimelock.sol";
 import "../refs/UniRef.sol";
 

--- a/contracts/oracle/IBondingCurveOracle.sol
+++ b/contracts/oracle/IBondingCurveOracle.sol
@@ -3,7 +3,6 @@ pragma experimental ABIEncoderV2;
 
 import "./IOracle.sol";
 import "../bondingcurve/IBondingCurve.sol";
-import "../external/Decimal.sol";
 
 /// @title bonding curve oracle interface for Fei Protocol
 /// @author Fei Protocol

--- a/contracts/oracle/UniswapOracle.sol
+++ b/contracts/oracle/UniswapOracle.sol
@@ -4,10 +4,10 @@ pragma experimental ABIEncoderV2;
 // Referencing Uniswap Example Simple Oracle
 // https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/examples/ExampleOracleSimple.sol
 
-import "@uniswap/v2-periphery/contracts/libraries/UniswapV2OracleLibrary.sol";
 import "./IUniswapOracle.sol";
 import "../refs/CoreRef.sol";
 import "../external/SafeMathCopy.sol";
+import "../external/UniswapV2OracleLibrary.sol";
 
 /// @title Uniswap Oracle for ETH/USDC
 /// @author Fei Protocol

--- a/contracts/pcv/EthUniswapPCVController.sol
+++ b/contracts/pcv/EthUniswapPCVController.sol
@@ -1,13 +1,11 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
 import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
 import "@openzeppelin/contracts/math/Math.sol";
 import "./IUniswapPCVController.sol";
 import "../refs/UniRef.sol";
-import "../external/Decimal.sol";
-import "../external/SafeMathCopy.sol";
+import "../external/UniswapV2Library.sol";
 
 /// @title a IUniswapPCVController implementation for ETH
 /// @author Fei Protocol

--- a/contracts/pcv/EthUniswapPCVDeposit.sol
+++ b/contracts/pcv/EthUniswapPCVDeposit.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts/utils/Address.sol";
 import "./UniswapPCVDeposit.sol";
 
 /// @title implementation for an ETH Uniswap LP PCV Deposit

--- a/contracts/pcv/UniswapPCVDeposit.sol
+++ b/contracts/pcv/UniswapPCVDeposit.sol
@@ -1,9 +1,7 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
 import "./IPCVDeposit.sol";
-import "../external/Decimal.sol";
 import "../refs/UniRef.sol";
 
 /// @title abstract implementation for Uniswap LP PCV Deposit

--- a/contracts/refs/ICoreRef.sol
+++ b/contracts/refs/ICoreRef.sol
@@ -1,8 +1,6 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "../token/IFei.sol";
 import "../core/ICore.sol";
 
 /// @title CoreRef interface

--- a/contracts/refs/IOracleRef.sol
+++ b/contracts/refs/IOracleRef.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import "../oracle/IOracle.sol";
-import "../external/Decimal.sol";
 
 /// @title OracleRef interface
 /// @author Fei Protocol

--- a/contracts/refs/UniRef.sol
+++ b/contracts/refs/UniRef.sol
@@ -6,7 +6,6 @@ import "@openzeppelin/contracts/utils/SafeCast.sol";
 import "@uniswap/lib/contracts/libraries/Babylonian.sol";
 import "./OracleRef.sol";
 import "./IUniRef.sol";
-import "../external/SafeMathCopy.sol";
 
 /// @title A Reference to Uniswap
 /// @author Fei Protocol

--- a/contracts/router/FeiRouter.sol
+++ b/contracts/router/FeiRouter.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
 import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 import "@uniswap/lib/contracts/libraries/TransferHelper.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "../external/SafeMathCopy.sol";
+import "../external/UniswapV2Library.sol";
 import "./IFeiRouter.sol";
 
 /// @title A Uniswap Router for FEI/ETH swaps


### PR DESCRIPTION
Removes some redundant imports

Also removes external dependency on Uniswap libraries by bringing them into the repo. This is because the [solidity tool](https://gitcoin.co/grants/1621/solt-the-solidity-tool) used to verify the contracts could not recognize nested npm dependencies, which the Uniswap libraries have.