### PR TITLE
Feature : Collateralization oracle

### DIFF
--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -1,0 +1,109 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "./UniswapOracle.sol";
+import "../refs/CoreRef.sol";
+import "../external/SafeMathCopy.sol";
+import "../pcv/EthUniswapPCVDeposit.sol";
+
+/// @title Collateralization Oracle
+/// @author eswak
+contract CollateralizationOracle is IOracle, CoreRef {
+    using Decimal for Decimal.D256;
+    using SafeMathCopy for uint256;
+
+    /// @notice reference oracles for various PCV currencies
+    IUniswapOracle public ethPriceOracle;
+
+    // @notice reference EthUniswapPCVDeposit
+    EthUniswapPCVDeposit public ethUniswapPCVDeposit;
+
+    /// @notice UniswapOracle constructor
+    /// @param _core Fei Core for reference
+    /// @param _ethPriceOracle Oracle for ETH price
+    /// @param _ethUniswapPCVDeposit reference to the EthUniswapPCVDeposit contract
+    constructor(
+        address _core,
+        address _ethPriceOracle,
+        address payable _ethUniswapPCVDeposit
+    ) public CoreRef(_core) {
+        ethPriceOracle = UniswapOracle(_ethPriceOracle);
+        ethUniswapPCVDeposit = EthUniswapPCVDeposit(_ethUniswapPCVDeposit);
+    }
+
+    /// @notice get the current circulating suply of FEI
+    /// @return number of FEI in circulation
+    function _circulatingFei() internal view returns(uint256) {
+      (uint256 feiInPool, uint256 ethInPool) = ethUniswapPCVDeposit.getReserves();
+      uint256 ethPcv = ethUniswapPCVDeposit.totalValue();
+      uint256 feiPcv = Decimal.ratio(ethPcv, ethInPool).mul(feiInPool).asUint256();
+
+      return Decimal.from(fei().totalSupply()).sub(feiPcv).asUint256();
+    }
+
+    /// @notice get the current ETH controlled by the protocol
+    /// @return number of ETH in control of the protocol
+    function _ethPcv() internal view returns(uint256) {
+      return ethUniswapPCVDeposit.totalValue();
+    }
+
+    /// @notice get the current ETHUSD price from the ethPriceOracle
+    /// @return price in USD per ETH
+    function _ethUsd() internal view returns(uint256) {
+      (Decimal.D256 memory ethPriceValue,) = ethPriceOracle.read();
+
+      return ethPriceValue.asUint256();
+    }
+
+    function _collateralizationRatio() internal view returns(Decimal.D256 memory) {
+      return Decimal.from(_ethUsd()).mul(_ethPcv()).div(_circulatingFei());
+    }
+
+    /// @notice updates the oracle price
+    /// @return true if oracle is updated and false if unchanged
+    function update() external override whenNotPaused returns (bool) {
+        bool updated = ethPriceOracle.update();
+
+        emit Update(_collateralizationRatio().asUint256());
+
+        return updated;
+    }
+
+    /// @notice determine if read value is stale
+    /// @return true if read value is stale
+    function isOutdated() external view override returns (bool) {
+        return ethPriceOracle.isOutdated();
+    }
+
+    /// @notice get the current circulating suply of FEI
+    /// @return number of FEI in circulation
+    function circulatingFei() external view returns(uint256) {
+      return _circulatingFei();
+    }
+
+    /// @notice get the current ETH controlled by the protocol
+    /// @return number of ETH in control of the protocol
+    function ethPcv() external view returns(uint256) {
+      return _ethPcv();
+    }
+
+    /// @notice get the current ETHUSD price from the ethPriceOracle
+    /// @return price in USD per ETH
+    function ethUsd() external view returns(uint256) {
+      return _ethUsd();
+    }
+
+    /// @notice read the oracle value
+    /// @return oracle value
+    /// @return true if value is valid
+    /// @dev price is to be denominated in percentage, with 18 decimals (1.25e18 for 125%)
+    /// @dev Can be innacurate if outdated, need to call `isOutdated()` to check
+    function read() external view override returns (Decimal.D256 memory, bool) {
+        (, bool ethPriceOracleIsValid) = ethPriceOracle.read();
+        bool valid = !paused() && ethPriceOracleIsValid;
+
+        Decimal.D256 memory value = _collateralizationRatio();
+
+        return (value, valid);
+    }
+}

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -1,34 +1,39 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "./UniswapOracle.sol";
+import "./IOracle.sol";
 import "../refs/CoreRef.sol";
 import "../external/SafeMathCopy.sol";
-import "../pcv/EthUniswapPCVDeposit.sol";
+import "../pcv/UniswapPCVDeposit.sol";
 
 /// @title Collateralization Oracle
 /// @author eswak
 contract CollateralizationOracle is IOracle, CoreRef {
     using Decimal for Decimal.D256;
     using SafeMathCopy for uint256;
+    using Babylonian for uint256;
 
     /// @notice reference oracles for various PCV currencies
-    IUniswapOracle public ethPriceOracle;
+    IOracle public ethUsdPriceOracle;
+    IOracle public ethFeiPriceOracle;
 
     // @notice reference EthUniswapPCVDeposit
-    EthUniswapPCVDeposit public ethUniswapPCVDeposit;
+    UniswapPCVDeposit public ethUniswapPCVDeposit;
 
     /// @notice UniswapOracle constructor
     /// @param _core Fei Core for reference
-    /// @param _ethPriceOracle Oracle for ETH price
+    /// @param _ethUsdPriceOracle Oracle for ETH price in USD
+    /// @param _ethFeiPriceOracle Oracle for ETH price in FEI
     /// @param _ethUniswapPCVDeposit reference to the EthUniswapPCVDeposit contract
     constructor(
         address _core,
-        address _ethPriceOracle,
+        address _ethUsdPriceOracle,
+        address _ethFeiPriceOracle,
         address payable _ethUniswapPCVDeposit
     ) public CoreRef(_core) {
-        ethPriceOracle = UniswapOracle(_ethPriceOracle);
-        ethUniswapPCVDeposit = EthUniswapPCVDeposit(_ethUniswapPCVDeposit);
+        ethUsdPriceOracle = IOracle(_ethUsdPriceOracle);
+        ethFeiPriceOracle = IOracle(_ethFeiPriceOracle);
+        ethUniswapPCVDeposit = UniswapPCVDeposit(_ethUniswapPCVDeposit);
     }
 
     /// @notice get the current circulating suply of FEI
@@ -38,7 +43,7 @@ contract CollateralizationOracle is IOracle, CoreRef {
       uint256 ethPcv = ethUniswapPCVDeposit.totalValue();
       uint256 feiPcv = Decimal.ratio(ethPcv, ethInPool).mul(feiInPool).asUint256();
 
-      return Decimal.from(fei().totalSupply()).sub(feiPcv).asUint256();
+      return fei().totalSupply() - feiPcv;
     }
 
     /// @notice get the current ETH controlled by the protocol
@@ -47,24 +52,64 @@ contract CollateralizationOracle is IOracle, CoreRef {
       return ethUniswapPCVDeposit.totalValue();
     }
 
-    /// @notice get the current ETHUSD price from the ethPriceOracle
+    /// @notice get the current ETHUSD price from the ethUsdPriceOracle
     /// @return price in USD per ETH
     function _ethUsd() internal view returns(uint256) {
-      (Decimal.D256 memory ethPriceValue,) = ethPriceOracle.read();
+      (Decimal.D256 memory ethPriceValue,) = ethUsdPriceOracle.read();
 
       return ethPriceValue.asUint256();
     }
 
-    function _collateralizationRatio() internal view returns(Decimal.D256 memory) {
-      return Decimal.from(_ethUsd()).mul(_ethPcv()).div(_circulatingFei());
+    /// @notice get the current ETH and FEI in the Uniswap pool
+    /// @return number of ETH in pool
+    /// @return number of FEI in pool
+    /// @return validity of the ETH-FEI price oracle
+    function _ethFeiInPool() internal view returns(uint256, uint256, bool) {
+      // external calls
+      (uint256 feiInPool, uint256 ethInPool) = ethUniswapPCVDeposit.getReserves();
+      (Decimal.D256 memory ethFei, bool ethFeiPriceOracleIsValid) = ethFeiPriceOracle.read();
+
+      // resistant eth/fei in pool
+      Decimal.D256 memory k = Decimal.from(feiInPool).mul(ethInPool);
+      uint256 resistantEthInPool = k.div(ethFei).asUint256().sqrt();
+      uint256 resistantFeiInPool = k.div(resistantEthInPool).asUint256();
+
+      return (resistantEthInPool, resistantFeiInPool, ethFeiPriceOracleIsValid);
+    }
+
+    /// @notice get the current collateralization ratio
+    /// @return collateralization ratio
+    /// @return true if price is valid
+    /// @dev price is to be denominated in percentage, with 18 decimals (1.25e18 for 125%)
+    function _collateralizationRatio() internal view returns(Decimal.D256 memory, bool) {
+      // external calls
+      uint256 ethPcv = ethUniswapPCVDeposit.totalValue();
+      uint256 feiTotalSupply = fei().totalSupply();
+      (Decimal.D256 memory ethUsd, bool ethUsdPriceOracleIsValid) = ethUsdPriceOracle.read();
+      (
+        uint256 resistantEthInPool,
+        uint256 resistantFeiInPool,
+        bool ethFeiPriceOracleIsValid
+      ) = _ethFeiInPool();
+
+      // compute collateralization ratio & validity
+      uint256 feiPcv = Decimal.ratio(ethPcv, resistantEthInPool).mul(resistantFeiInPool).asUint256();
+      uint256 circulatingFei = feiTotalSupply - feiPcv;
+      Decimal.D256 memory ratio = ethUsd.mul(ethPcv).div(circulatingFei);
+      bool valid = !paused() && ethUsdPriceOracleIsValid && ethFeiPriceOracleIsValid;
+
+      return (ratio, valid);
     }
 
     /// @notice updates the oracle price
     /// @return true if oracle is updated and false if unchanged
     function update() external override whenNotPaused returns (bool) {
-        bool updated = ethPriceOracle.update();
+        bool updated = ethUsdPriceOracle.update();
+        updated = updated || ethFeiPriceOracle.update();
 
-        emit Update(_collateralizationRatio().asUint256());
+        (Decimal.D256 memory ratio,) = _collateralizationRatio();
+
+        emit Update(ratio.asUint256());
 
         return updated;
     }
@@ -72,7 +117,7 @@ contract CollateralizationOracle is IOracle, CoreRef {
     /// @notice determine if read value is stale
     /// @return true if read value is stale
     function isOutdated() external view override returns (bool) {
-        return ethPriceOracle.isOutdated();
+        return ethUsdPriceOracle.isOutdated() || ethFeiPriceOracle.isOutdated();
     }
 
     /// @notice get the current circulating suply of FEI
@@ -87,10 +132,25 @@ contract CollateralizationOracle is IOracle, CoreRef {
       return _ethPcv();
     }
 
-    /// @notice get the current ETHUSD price from the ethPriceOracle
+    /// @notice get the current ETHUSD price from the ethUsdPriceOracle
     /// @return price in USD per ETH
     function ethUsd() external view returns(uint256) {
       return _ethUsd();
+    }
+
+    /// @notice get the current collateralization ratio
+    /// @return collateralization ratio
+    /// @dev price is to be denominated in percentage, with 18 decimals (1.25e18 for 125%)
+    function collateralizationRatio() external view returns(uint256) {
+      (Decimal.D256 memory ratio,) = _collateralizationRatio();
+      return ratio.mul(1000000000000000000).asUint256();
+    }
+
+    /// @notice get a boolean wheter  current collateralization ratio
+    /// @return true if the protocol is currently overcollateralized
+    function overCollateralized() external view returns(bool) {
+      (Decimal.D256 memory ratio,) = _collateralizationRatio();
+      return ratio.mul(1000000000000000000).asUint256() > 1000000000000000000;
     }
 
     /// @notice read the oracle value
@@ -99,11 +159,6 @@ contract CollateralizationOracle is IOracle, CoreRef {
     /// @dev price is to be denominated in percentage, with 18 decimals (1.25e18 for 125%)
     /// @dev Can be innacurate if outdated, need to call `isOutdated()` to check
     function read() external view override returns (Decimal.D256 memory, bool) {
-        (, bool ethPriceOracleIsValid) = ethPriceOracle.read();
-        bool valid = !paused() && ethPriceOracleIsValid;
-
-        Decimal.D256 memory value = _collateralizationRatio();
-
-        return (value, valid);
+        return _collateralizationRatio();
     }
 }

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -109,7 +109,9 @@ contract CollateralizationOracle is IOracle, CoreRef {
 
         (Decimal.D256 memory ratio,) = _collateralizationRatio();
 
-        emit Update(ratio.asUint256());
+        if (updated) {
+            emit Update(ratio.asUint256());
+        }
 
         return updated;
     }

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -144,15 +144,17 @@ contract CollateralizationOracle is IOracle, CoreRef {
     /// @return collateralization ratio
     /// @dev price is to be denominated in percentage, with 18 decimals (1.25e18 for 125%)
     function collateralizationRatio() external view returns(uint256) {
-      (Decimal.D256 memory ratio,) = _collateralizationRatio();
-      return ratio.mul(1000000000000000000).asUint256();
+        (Decimal.D256 memory ratio, bool valid) = _collateralizationRatio();
+        require(valid, "CollateralizationOracle: invalid price oracle values or paused.");
+        return ratio.mul(1000000000000000000).asUint256();
     }
 
-    /// @notice get a boolean wheter  current collateralization ratio
+    /// @notice get a boolean whether current collateralization ratio is > 1
     /// @return true if the protocol is currently overcollateralized
     function overCollateralized() external view returns(bool) {
-      (Decimal.D256 memory ratio,) = _collateralizationRatio();
-      return ratio.mul(1000000000000000000).asUint256() > 1000000000000000000;
+        (Decimal.D256 memory ratio, bool valid) = _collateralizationRatio();
+        require(valid, "CollateralizationOracle: invalid price oracle values or paused.");
+        return ratio.greaterThan(Decimal.one());
     }
 
     /// @notice read the oracle value

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -26,6 +26,7 @@ const TimelockedDelegator = contract.fromArtifact('TimelockedDelegator');
 const Tribe = contract.fromArtifact('Tribe');
 const UniswapIncentive = contract.fromArtifact('UniswapIncentive');
 const UniswapOracle = contract.fromArtifact('UniswapOracle');
+const CollateralizationOracle = contract.fromArtifact('CollateralizationOracle');
 const FeiStakingRewards = contract.fromArtifact('FeiStakingRewards');
 const FeiRewardsDistributor = contract.fromArtifact('FeiRewardsDistributor');
 
@@ -119,6 +120,7 @@ module.exports = {
     Tribe,
     UniswapIncentive,
     UniswapOracle,
+    CollateralizationOracle,
     // mock contracts
     MockBondingCurve,
     MockBondingCurveOracle,
@@ -129,7 +131,7 @@ module.exports = {
     MockIDO,
     MockIncentive,
     MockIncentivized,
-    MockOracle, 
+    MockOracle,
     MockPair,
     MockPairTrade,
     MockPCVDeposit,

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -85,7 +85,14 @@ describe('CollateralizationOracle', function () {
 
     it('ethUsd', async function() {
       let result = await this.collateralizationOracle.ethUsd();
-      expect(result).to.be.bignumber.equal(new BN(500));
+      expect(result / 1e18).to.be.equal(500);
+    });
+
+    it('ethFeiInPool', async function() {
+      let result = await this.collateralizationOracle.ethFeiInPool();
+      expect(result[0]).to.be.bignumber.equal(new BN(200000)); // eth in pool
+      expect(result[1]).to.be.bignumber.equal(new BN(100000000)); // fei in pool
+      expect(result[2]).to.be.equal(true);
     });
 
     it('collateralizationRatio', async function() {

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -1,0 +1,130 @@
+const {
+  userAddress,
+  governorAddress,
+  guardianAddress,
+  BN,
+  expectEvent,
+  expectRevert,
+  time,
+  expect,
+  UniswapOracle,
+  CollateralizationOracle,
+  MockPairTrade,
+  EthUniswapPCVDeposit,
+  MockRouter,
+  Fei,
+  MockWeth,
+  MockPair,
+  MockOracle,
+  MockIncentive,
+  minterAddress,
+  getCore
+} = require('../helpers');
+
+describe('CollateralizationOracle', function () {
+  beforeEach(async function () {
+    this.core = await getCore(true);
+
+    this.fei = await Fei.at(await this.core.fei());
+    this.ethPriceOracle = await MockOracle.new(500);
+    this.token = await MockWeth.new();
+    this.pair = await MockPair.new(this.token.address, this.fei.address);
+    this.router = await MockRouter.new(this.pair.address);
+    await this.router.setWETH(this.token.address);
+    this.pcvDeposit = await EthUniswapPCVDeposit.new(this.core.address, this.pair.address, this.router.address, this.ethPriceOracle.address);
+    await this.core.grantMinter(this.pcvDeposit.address, {from: governorAddress});
+    this.incentive = await MockIncentive.new(this.core.address);
+
+    await this.fei.setIncentiveContract(this.pair.address, this.incentive.address, {from: governorAddress});
+    await this.incentive.setExempt(true);
+
+    this.collateralizationOracle = await CollateralizationOracle.new(
+      this.core.address,
+      this.ethPriceOracle.address,
+      this.pcvDeposit.address
+    );
+  });
+
+  describe('Init', function() {
+    it('ethPriceOracle', async function() {
+      expect(await this.collateralizationOracle.ethPriceOracle()).to.be.equal(this.ethPriceOracle.address);
+    });
+
+    it('not paused', async function() {
+      expect(await this.collateralizationOracle.paused()).to.be.equal(false);
+    });
+  });
+
+  describe('view properties', function() {
+    beforeEach(async function() {
+      // 50 000 000 $ worth of ETH in PCV
+      // 500 $ / ETH
+      // 40 000 000 FEI in circulation
+      await this.pair.set(1e5, 500e5, 10e3, {from: userAddress, value: 1e5}); // 500:1 FEI/ETH with 10k liquidity
+      await this.fei.mint(this.pcvDeposit.address, 550e5, {from: minterAddress}); // seed Fei to burn
+      await this.fei.mint(userAddress, 400e5, {from: minterAddress}); // some additional circulating Fei
+      await this.pcvDeposit.deposit(1e5, {value: 1e5}); // deposit LP
+      await this.collateralizationOracle.update();
+    });
+
+    it('circulatingFei', async function() {
+      let result = await this.collateralizationOracle.circulatingFei();
+      expect(result).to.be.bignumber.equal(new BN(400e5));
+    });
+
+    it('ethPcv', async function() {
+      let result = await this.collateralizationOracle.ethPcv();
+      expect(result).to.be.bignumber.equal(new BN(1e5));
+    });
+
+    it('ethUsd', async function() {
+      let result = await this.collateralizationOracle.ethUsd();
+      expect(result).to.be.bignumber.equal(new BN(500));
+    });
+  });
+
+  describe('Read', function() {
+    beforeEach(async function() {
+      // 50 000 000 $ worth of ETH in PCV
+      // 500 $ / ETH
+      // 40 000 000 FEI in circulation
+      await this.pair.set(1e5, 500e5, 10e3, {from: userAddress, value: 1e5}); // 500:1 FEI/ETH with 10k liquidity
+      await this.fei.mint(this.pcvDeposit.address, 550e5, {from: minterAddress}); // seed Fei to burn
+      await this.fei.mint(userAddress, 400e5, {from: minterAddress}); // some additional circulating Fei
+      await this.pcvDeposit.deposit(1e5, {value: 1e5}); // deposit LP
+      await this.collateralizationOracle.update();
+    });
+
+    describe('Paused', function() {
+      beforeEach(async function() {
+        await this.collateralizationOracle.pause({from: governorAddress});
+      });
+
+      it('returns invalid', async function() {
+        let result = await this.collateralizationOracle.read();
+        expect(result[1]).to.be.equal(false);
+      });
+    });
+
+    describe('Unpaused', function() {
+      it('returns valid', async function() {
+        let result = await this.collateralizationOracle.read();
+        expect(result[1]).to.be.equal(true);
+      });
+
+      it('current collateralization ratio', async function() {
+        let result = await this.collateralizationOracle.read();
+        expect(result[0].value).to.be.equal('1250000000000000000'); // 1.25 with 18 decimals
+        expect(result[1]).to.be.equal(true); // valid
+      });
+    });
+  });
+  describe('Update', function() {
+    describe('Paused', function() {
+      it('reverts', async function() {
+        await this.collateralizationOracle.pause({from: governorAddress});
+        await expectRevert(this.collateralizationOracle.update(), "Pausable: paused");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Hi,

Here is a pull request to add a Collateralization Oracle as discussed [on the governance forums](https://tribe.fei.money/t/ethreweightqueuer-proposal-to-improve-reweight-mechanism-maintain-peg/1521/41).

This contract is pretty straightforward & mainly composed of pure functions : 
- It interacts with `EthUniswapPCVDeposit` to get the `totalValue()` and `getReserves()`.
- Circulating FEI supply is defined as FEI `totalSupply()` minus FEI in the Uniswap pool owned by `EthUniswapPCVDeposit`.
- `UniswapOracle` is used for the ETH/USD current price.
- `UniswapOracle` is used for the ETH/FEI current price (234b68f16b803c0dba7785565173dc8ca40c8159).
- It should be upgraded as PCV is deployed elsewhere in the future (as in #95).

I also implemented a small test suite inspired from the one of `UniswapOracle` :
Can be run with ` npm run test -- -g CollateralizationOracle` 
![image](https://user-images.githubusercontent.com/6916865/114373571-044b5900-9b83-11eb-9fa5-e6a0019e1990.png)

Also tested on a local mainnet fork, with results consistent with what's observed on https://app.fei.money/analytics (see comments below)

Best,