### PR TITLE
FIP-2

### DIFF
--- a/contracts/pcv/EthPCVDripper.sol
+++ b/contracts/pcv/EthPCVDripper.sol
@@ -52,11 +52,17 @@ contract EthPCVDripper is CoreRef, Timed {
        afterTime
        whenNotPaused
    {
+       require(isTargetBalanceLow(), "EthPCVDripper: target balance too high");
+
        // reset timer
        _initTimed();
 
        // drip
        payable(target).sendValue(amountToDrip);
        emit Dripped(amountToDrip);
+   }
+
+   function isTargetBalanceLow() public view returns(bool) {
+       return target.balance < amountToDrip;
    }
 }

--- a/contracts/pcv/EthPCVDripper.sol
+++ b/contracts/pcv/EthPCVDripper.sol
@@ -16,7 +16,7 @@ contract EthPCVDripper is CoreRef, Timed {
    uint256 public amountToDrip;
 
    event Dripped(uint256 amount);
-   event Withdrawl(address indexed to, uint256 amount);
+   event Withdrawal(address indexed to, uint256 amount);
 
    /// @notice Uniswap PCV Deposit constructor
    /// @param _core Fei Core for reference
@@ -43,7 +43,7 @@ contract EthPCVDripper is CoreRef, Timed {
        onlyPCVController
    {
        payable(to).sendValue(amount);
-       emit Withdrawl(to, amount);
+       emit Withdrawal(to, amount);
    }
  
    /// @notice drip ETH to target

--- a/contracts/pcv/EthPCVDripper.sol
+++ b/contracts/pcv/EthPCVDripper.sol
@@ -18,8 +18,11 @@ contract EthPCVDripper is CoreRef, Timed {
    event Dripped(uint256 amount);
    event Withdrawal(address indexed to, uint256 amount);
 
-   /// @notice Uniswap PCV Deposit constructor
+   /// @notice ETH PCV Dripper constructor
    /// @param _core Fei Core for reference
+   /// @param _target address to drip to
+   /// @param _frequency frequency of dripping
+   /// @param _amountToDrip amount to drip on each drip
    constructor(
        address _core,
        address payable _target,
@@ -62,6 +65,7 @@ contract EthPCVDripper is CoreRef, Timed {
        emit Dripped(amountToDrip);
    }
 
+   /// @notice checks whether the target balance is less than the drip amount
    function isTargetBalanceLow() public view returns(bool) {
        return target.balance < amountToDrip;
    }

--- a/contracts/pcv/EthPCVDripper.sol
+++ b/contracts/pcv/EthPCVDripper.sol
@@ -9,8 +9,14 @@ import "../utils/Timed.sol";
 contract EthPCVDripper is CoreRef, Timed {
    using Address for address payable;
  
+   /// @notice target address to drip to
    address public target;
+
+   /// @notice amount to drip after each window
    uint256 public amountToDrip;
+
+   event Dripped(uint256 amount);
+   event Withdrawl(address indexed to, uint256 amount);
 
    /// @notice Uniswap PCV Deposit constructor
    /// @param _core Fei Core for reference
@@ -37,6 +43,7 @@ contract EthPCVDripper is CoreRef, Timed {
        onlyPCVController
    {
        payable(to).sendValue(amount);
+       emit Withdrawl(to, amount);
    }
  
    /// @notice drip ETH to target
@@ -50,5 +57,6 @@ contract EthPCVDripper is CoreRef, Timed {
 
        // drip
        payable(target).sendValue(amountToDrip);
+       emit Dripped(amountToDrip);
    }
 }

--- a/contracts/pcv/EthPCVDripper.sol
+++ b/contracts/pcv/EthPCVDripper.sol
@@ -1,0 +1,54 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+ 
+import "../refs/CoreRef.sol";
+import "../utils/Timed.sol";
+
+/// @title a PCV dripper
+/// @author Fei Protocol
+contract EthPCVDripper is CoreRef, Timed {
+   using Address for address payable;
+ 
+   address public target;
+   uint256 public amountToDrip;
+
+   /// @notice Uniswap PCV Deposit constructor
+   /// @param _core Fei Core for reference
+   constructor(
+       address _core,
+       address _target,
+       uint256 _frequency,
+       uint256 _amountToDrip
+   ) public CoreRef(_core) Timed(_frequency) {
+       target = _target;
+       amountToDrip = _amountToDrip;
+
+        // start timer
+       _initTimed();
+   }
+ 
+   receive() external payable {}
+ 
+   /// @notice withdraw ETH from the PCV dripper
+   /// @param amount of tokens withdrawn
+   /// @param to the address to send PCV to
+   function withdrawETH(address to, uint256 amount)
+       external
+       onlyPCVController
+   {
+       payable(to).sendValue(amount);
+   }
+ 
+   /// @notice drip ETH to target
+   function drip()
+       external
+       afterTime
+       whenNotPaused
+   {
+       // reset timer
+       _initTimed();
+
+       // drip
+       payable(target).sendValue(amountToDrip);
+   }
+}

--- a/contracts/pcv/EthPCVDripper.sol
+++ b/contracts/pcv/EthPCVDripper.sol
@@ -10,7 +10,7 @@ contract EthPCVDripper is CoreRef, Timed {
    using Address for address payable;
  
    /// @notice target address to drip to
-   address public target;
+   address payable public target;
 
    /// @notice amount to drip after each window
    uint256 public amountToDrip;
@@ -22,7 +22,7 @@ contract EthPCVDripper is CoreRef, Timed {
    /// @param _core Fei Core for reference
    constructor(
        address _core,
-       address _target,
+       address payable _target,
        uint256 _frequency,
        uint256 _amountToDrip
    ) public CoreRef(_core) Timed(_frequency) {
@@ -38,11 +38,11 @@ contract EthPCVDripper is CoreRef, Timed {
    /// @notice withdraw ETH from the PCV dripper
    /// @param amount of tokens withdrawn
    /// @param to the address to send PCV to
-   function withdrawETH(address to, uint256 amount)
+   function withdrawETH(address payable to, uint256 amount)
        external
        onlyPCVController
    {
-       payable(to).sendValue(amount);
+       to.sendValue(amount);
        emit Withdrawal(to, amount);
    }
  
@@ -58,7 +58,7 @@ contract EthPCVDripper is CoreRef, Timed {
        _initTimed();
 
        // drip
-       payable(target).sendValue(amountToDrip);
+       target.sendValue(amountToDrip);
        emit Dripped(amountToDrip);
    }
 

--- a/contracts/pcv/EthReserveStabilizer.sol
+++ b/contracts/pcv/EthReserveStabilizer.sol
@@ -10,7 +10,10 @@ import "@openzeppelin/contracts/utils/Address.sol";
 /// @author Fei Protocol
 contract EthReserveStabilizer is OracleRef, IReserveStabilizer {
 
+    /// @notice the USD per FEI exchange rate denominated in basis points (1/10000)
     uint256 public override usdPerFeiBasisPoints;
+    
+    /// @notice the denominator for basis granularity (10,000)
     uint256 public constant BASIS_POINTS_GRANULARITY = 10_000;
 
     constructor(
@@ -20,13 +23,14 @@ contract EthReserveStabilizer is OracleRef, IReserveStabilizer {
     ) public OracleRef(_core, _oracle) {
         require(_usdPerFeiBasisPoints <= BASIS_POINTS_GRANULARITY, "ReserveStabilizer: Exceeds bp granularity");
         usdPerFeiBasisPoints = _usdPerFeiBasisPoints;
+        emit UsdPerFeiRateUpdate(_usdPerFeiBasisPoints);
     }
 
     receive() external payable {}
 
     /// @notice exchange FEI for ETH from the reserves
     /// @param feiAmount of FEI to sell
-    function exchangeFeiForEth(uint256 feiAmount) public override whenNotPaused returns (uint256 amountOut) {
+    function exchangeFeiForEth(uint256 feiAmount) external override whenNotPaused returns (uint256 amountOut) {
         updateOracle();
 
         fei().burnFrom(msg.sender, feiAmount);

--- a/contracts/pcv/EthReserveStabilizer.sol
+++ b/contracts/pcv/EthReserveStabilizer.sol
@@ -55,8 +55,8 @@ contract EthReserveStabilizer is OracleRef, IReserveStabilizer {
     /// @notice withdraw ETH from the reserves
     /// @param to address to send ETH
     /// @param amountOut amount of ETH to send
-    function withdraw(address to, uint256 amountOut) external override onlyPCVController {
-        Address.sendValue(payable(to), amountOut);
+    function withdraw(address payable to, uint256 amountOut) external override onlyPCVController {
+        Address.sendValue(to, amountOut);
         emit Withdrawal(msg.sender, to, amountOut);
     }
 

--- a/contracts/pcv/EthReserveStabilizer.sol
+++ b/contracts/pcv/EthReserveStabilizer.sol
@@ -1,0 +1,66 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "./IPCVDeposit.sol";
+import "./IReserveStabilizer.sol";
+import "../refs/OracleRef.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+/// @title implementation for an ETH Reserve Stabilizer
+/// @author Fei Protocol
+contract EthReserveStabilizer is OracleRef, IReserveStabilizer {
+
+    uint256 public override usdPerFeiBasisPoints;
+    uint256 public constant BASIS_POINTS_GRANULARITY = 10_000;
+
+    constructor(
+        address _core,
+        address _oracle,
+        uint _usdPerFeiBasisPoints
+    ) public OracleRef(_core, _oracle) {
+        require(_usdPerFeiBasisPoints <= BASIS_POINTS_GRANULARITY, "ReserveStabilizer: Exceeds bp granularity");
+        usdPerFeiBasisPoints = _usdPerFeiBasisPoints;
+    }
+
+    receive() external payable {}
+
+    /// @notice exchange FEI for ETH from the reserves
+    /// @param feiAmount of FEI to sell
+    function exchangeFeiForEth(uint256 feiAmount) public override whenNotPaused returns (uint256 amountOut) {
+        updateOracle();
+
+        fei().burnFrom(msg.sender, feiAmount);
+
+        amountOut = getAmountOut(feiAmount);
+
+        Address.sendValue(msg.sender, amountOut);
+        emit FeiExchange(msg.sender, feiAmount, amountOut);
+    }
+
+    /// @notice returns the amount out of ETH from the reserves
+    /// @param amountFeiIn the amount of FEI in
+    function getAmountOut(uint256 amountFeiIn) public view override returns(uint256) {
+        uint256 adjustedAmountIn = amountFeiIn * usdPerFeiBasisPoints / BASIS_POINTS_GRANULARITY;
+        return _getEthAmountOut(adjustedAmountIn);
+    }
+
+    function _getEthAmountOut(uint256 usdAmountIn) internal view returns(uint256) {
+        return invert(peg()).mul(usdAmountIn).asUint256();
+    }
+
+    /// @notice withdraw ETH from the reserves
+    /// @param to address to send ETH
+    /// @param amountOut amount of ETH to send
+    function withdraw(address to, uint256 amountOut) external override onlyPCVController {
+        Address.sendValue(payable(to), amountOut);
+        emit Withdrawal(msg.sender, to, amountOut);
+    }
+
+    /// @notice sets the USD per FEI exchange rate rate
+    /// @param _usdPerFeiBasisPoints the USD per FEI exchange rate denominated in basis points (1/10000)
+    function setUsdPerFeiRate(uint256 _usdPerFeiBasisPoints) external override onlyGovernor {
+        require(_usdPerFeiBasisPoints <= BASIS_POINTS_GRANULARITY, "ReserveStabilizer: Exceeds bp granularity");
+        usdPerFeiBasisPoints = _usdPerFeiBasisPoints;
+        emit UsdPerFeiRateUpdate(_usdPerFeiBasisPoints);
+    }
+}

--- a/contracts/pcv/EthReserveStabilizer.sol
+++ b/contracts/pcv/EthReserveStabilizer.sol
@@ -30,7 +30,7 @@ contract EthReserveStabilizer is OracleRef, IReserveStabilizer {
 
     /// @notice exchange FEI for ETH from the reserves
     /// @param feiAmount of FEI to sell
-    function exchangeFeiForEth(uint256 feiAmount) external override whenNotPaused returns (uint256 amountOut) {
+    function exchangeFei(uint256 feiAmount) external override whenNotPaused returns (uint256 amountOut) {
         updateOracle();
 
         fei().burnFrom(msg.sender, feiAmount);

--- a/contracts/pcv/EthReserveStabilizer.sol
+++ b/contracts/pcv/EthReserveStabilizer.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "./IPCVDeposit.sol";
 import "./IReserveStabilizer.sol";
 import "../refs/OracleRef.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/pcv/IReserveStabilizer.sol
+++ b/contracts/pcv/IReserveStabilizer.sol
@@ -17,7 +17,7 @@ interface IReserveStabilizer {
 
     // ----------- State changing api -----------
 
-    function exchangeFeiForEth(uint256 feiAmount) external returns (uint256);
+    function exchangeFei(uint256 feiAmount) external returns (uint256);
 
     // ----------- PCV Controller only state changing api -----------
 

--- a/contracts/pcv/IReserveStabilizer.sol
+++ b/contracts/pcv/IReserveStabilizer.sol
@@ -21,7 +21,7 @@ interface IReserveStabilizer {
 
     // ----------- PCV Controller only state changing api -----------
 
-    function withdraw(address to, uint256 amount) external;
+    function withdraw(address payable to, uint256 amount) external;
 
     // ----------- Governor only state changing api -----------
 

--- a/contracts/pcv/IReserveStabilizer.sol
+++ b/contracts/pcv/IReserveStabilizer.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.6.2;
+
+/// @title a Reserve Stabilizer interface
+/// @author Fei Protocol
+interface IReserveStabilizer {
+
+    // ----------- Events -----------
+    event FeiExchange(address indexed to, uint256 feiAmountIn, uint256 amountOut);
+
+    event UsdPerFeiRateUpdate(uint256 basisPoints);
+
+    event Withdrawal(
+        address indexed _caller,
+        address indexed _to,
+        uint256 _amount
+    );
+
+    // ----------- State changing api -----------
+
+    function exchangeFeiForEth(uint256 feiAmount) external returns (uint256);
+
+    // ----------- PCV Controller only state changing api -----------
+
+    function withdraw(address to, uint256 amount) external;
+
+    // ----------- Governor only state changing api -----------
+
+    function setUsdPerFeiRate(uint256 exchangeRateBasisPoints) external;
+
+    // ----------- Getters -----------
+
+    function usdPerFeiBasisPoints() external view returns (uint256);
+
+    function getAmountOut(uint256 amountIn) external view returns (uint256);
+}

--- a/contracts/staking/TribeDripper.sol
+++ b/contracts/staking/TribeDripper.sol
@@ -1,0 +1,70 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+ 
+import "../refs/CoreRef.sol";
+import "../utils/Timed.sol";
+
+/// @title a Tribe dripper
+/// @author Fei Protocol
+contract TribeDripper is CoreRef, Timed {
+ 
+   /// @notice target address to drip to
+   address public target;
+
+   /// @notice amount to drip after each window
+   uint256[] public amountsToDrip;
+
+   /// @notice index of the amount to drip
+   uint256 public dripIndex;
+
+   event Dripped(uint256 amount, uint256 dripIndex);
+   event Withdrawal(address indexed to, uint256 amount);
+
+   /// @notice Tribe Dripper constructor
+   /// @param _core Fei Core for reference
+   /// @param _target target address to receive TRIBE
+   /// @param _frequency TRIBE drip frequency
+   constructor(
+       address _core,
+       address _target,
+       uint256 _frequency,
+       uint256[] memory _amountsToDrip
+   ) public CoreRef(_core) Timed(_frequency) {
+       target = _target;
+       amountsToDrip = _amountsToDrip;
+   }
+ 
+   receive() external payable {}
+ 
+   /// @notice withdraw TRIBE from the Tribe dripper
+   /// @param amount of tokens withdrawn
+   /// @param to the address to send PCV to
+   function withdraw(address to, uint256 amount)
+       external
+       onlyPCVController
+   {
+       tribe().transfer(to, amount);
+       emit Withdrawal(to, amount);
+   }
+ 
+   /// @notice drip TRIBE to target
+   function drip()
+       external
+       whenNotPaused
+   {
+       require(!isTimeStarted() || isTimeEnded(), "TribeDripper: time not ended");
+
+       // reset timer
+       _initTimed();
+
+       uint256 currentDripIndex = dripIndex;
+       require(currentDripIndex < amountsToDrip.length, "TribeDripper: index out of bounds");
+       
+       uint256 amountToDrip = amountsToDrip[currentDripIndex];
+       dripIndex = currentDripIndex + 1;
+
+       // drip
+       tribe().transfer(target, amountToDrip);
+       emit Dripped(amountToDrip, currentDripIndex);
+   }
+}

--- a/migrations/14_fip_2.js
+++ b/migrations/14_fip_2.js
@@ -1,0 +1,13 @@
+const EthReserveStabilizer = artifacts.require("EthReserveStabilizer");
+const EthPCVDripper = artifacts.require("EthPCVDripper");
+
+module.exports = function(deployer) { 
+    require('dotenv').config();
+    const core = process.env.MAINNET_CORE;
+    const oracle = process.env.MAINNET_UNISWAP_ORACLE;
+    deployer.then(function() {
+        return deployer.deploy(EthReserveStabilizer, core, oracle, "9500");
+    }).then(function(instance) {
+       return deployer.deploy(EthPCVDripper, core, instance.address, "60", "5000000000000000000"); // 5 ETH per minute
+    })
+}

--- a/migrations/14_fip_2.js
+++ b/migrations/14_fip_2.js
@@ -8,6 +8,6 @@ module.exports = function(deployer) {
     deployer.then(function() {
         return deployer.deploy(EthReserveStabilizer, core, oracle, "9500");
     }).then(function(instance) {
-       return deployer.deploy(EthPCVDripper, core, instance.address, "60", "5000000000000000000"); // 5 ETH per minute
+       return deployer.deploy(EthPCVDripper, core, instance.address, "3600", "5000000000000000000000"); // 5000 ETH per hour
     })
 }

--- a/migrations/14_fip_2.js
+++ b/migrations/14_fip_2.js
@@ -1,13 +1,27 @@
 const EthReserveStabilizer = artifacts.require("EthReserveStabilizer");
 const EthPCVDripper = artifacts.require("EthPCVDripper");
+const TribeDripper = artifacts.require("TribeDripper");
 
 module.exports = function(deployer) { 
     require('dotenv').config();
     const core = process.env.MAINNET_CORE;
     const oracle = process.env.MAINNET_UNISWAP_ORACLE;
+    const rewardsDistributor = process.env.MAINNET_FEI_REWARDS_DISTRIBUTOR;
     deployer.then(function() {
         return deployer.deploy(EthReserveStabilizer, core, oracle, "9500");
     }).then(function(instance) {
        return deployer.deploy(EthPCVDripper, core, instance.address, "3600", "5000000000000000000000"); // 5000 ETH per hour
-    })
+    }).then(function() {
+        return deployer.deploy(
+            TribeDripper, 
+            core, 
+            rewardsDistributor, 
+            "604800", // weekly distribution
+            [
+              "47000000000000000000000000", 
+              "31000000000000000000000000", 
+              "22000000000000000000000000"
+            ]
+        );
+    });
 }

--- a/migrations/14_reserve_stabilizer.js
+++ b/migrations/14_reserve_stabilizer.js
@@ -1,9 +1,0 @@
-require('dotenv').config();
-
-const EthReserveStabilizer = artifacts.require("EthReserveStabilizer");
-const core = process.env.MAINNET_CORE;
-const oracle = process.env.MAINNET_UNISWAP_ORACLE
-
-module.exports = function(deployer) {
-    return deployer.deploy(EthReserveStabilizer, core, oracle, 10000);
-}

--- a/migrations/14_reserve_stabilizer.js
+++ b/migrations/14_reserve_stabilizer.js
@@ -1,0 +1,9 @@
+require('dotenv').config();
+
+const EthReserveStabilizer = artifacts.require("EthReserveStabilizer");
+const core = process.env.MAINNET_CORE;
+const oracle = process.env.MAINNET_UNISWAP_ORACLE
+
+module.exports = function(deployer) {
+    return deployer.deploy(EthReserveStabilizer, core, oracle, 10000);
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -26,6 +26,7 @@ const IDO = contract.fromArtifact('IDO');
 const Roots = contract.fromArtifact('RootsWrapper');
 const TimelockedDelegator = contract.fromArtifact('TimelockedDelegator');
 const Tribe = contract.fromArtifact('Tribe');
+const TribeDripper = contract.fromArtifact("TribeDripper");
 const UniswapIncentive = contract.fromArtifact('UniswapIncentive');
 const UniswapOracle = contract.fromArtifact('UniswapOracle');
 const FeiStakingRewards = contract.fromArtifact('FeiStakingRewards');
@@ -121,6 +122,7 @@ module.exports = {
     IDO,
     TimelockedDelegator,
     Tribe,
+    TribeDripper,
     UniswapIncentive,
     UniswapOracle,
     // mock contracts

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -14,6 +14,7 @@ const { expect } = chai;
 const BondingCurveOracle = contract.fromArtifact('BondingCurveOracle');
 const Core = contract.fromArtifact('Core');
 const EthBondingCurve = contract.fromArtifact('EthBondingCurve');
+const EthReserveStabilizer = contract.fromArtifact('EthReserveStabilizer');
 const EthUniswapPCVController = contract.fromArtifact('EthUniswapPCVController');
 const EthUniswapPCVDeposit = contract.fromArtifact('EthUniswapPCVDeposit');
 const Fei = contract.fromArtifact('Fei');
@@ -105,6 +106,7 @@ module.exports = {
     BondingCurveOracle,
     Core,
     EthBondingCurve,
+    EthReserveStabilizer,
     EthUniswapPCVController,
     EthUniswapPCVDeposit,
     Fei,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -15,6 +15,7 @@ const BondingCurveOracle = contract.fromArtifact('BondingCurveOracle');
 const Core = contract.fromArtifact('Core');
 const EthBondingCurve = contract.fromArtifact('EthBondingCurve');
 const EthReserveStabilizer = contract.fromArtifact('EthReserveStabilizer');
+const EthPCVDripper = contract.fromArtifact('EthPCVDripper');
 const EthUniswapPCVController = contract.fromArtifact('EthUniswapPCVController');
 const EthUniswapPCVDeposit = contract.fromArtifact('EthUniswapPCVDeposit');
 const Fei = contract.fromArtifact('Fei');
@@ -107,6 +108,7 @@ module.exports = {
     Core,
     EthBondingCurve,
     EthReserveStabilizer,
+    EthPCVDripper,
     EthUniswapPCVController,
     EthUniswapPCVDeposit,
     Fei,

--- a/test/pcv/EthPCVDripper.test.js
+++ b/test/pcv/EthPCVDripper.test.js
@@ -1,6 +1,5 @@
 const {
     userAddress,
-    beneficiaryAddress1,
     governorAddress, 
     pcvControllerAddress,
     web3,
@@ -10,7 +9,9 @@ const {
     balance,
     expect,
     EthPCVDripper,
-    getCore
+    MockPCVDeposit,
+    getCore,
+    beneficiaryAddress1
   } = require('../helpers');
   
   describe('EthPCVDripper', function () {
@@ -18,8 +19,10 @@ const {
     beforeEach(async function () {
       this.core = await getCore(true);
       
+      this.pcvDeposit = await MockPCVDeposit.new(beneficiaryAddress1);
       this.dripAmount = new BN('500000000000000000');
-      this.pcvDripper = await EthPCVDripper.new(this.core.address, beneficiaryAddress1, '1000', this.dripAmount);
+
+      this.pcvDripper = await EthPCVDripper.new(this.core.address, this.pcvDeposit.address, '1000', this.dripAmount);
 
       await web3.eth.sendTransaction({from: userAddress, to: this.pcvDripper.address, value: "1000000000000000000"});
     });
@@ -40,23 +43,80 @@ const {
       });
   
       describe('After time', function() {
-
-          it('succeeds', async function() {
+          beforeEach(async function() {
             await time.increase('1000');
-
-            let dripperBalanceBefore = await balance.current(this.pcvDripper.address);
-            let beneficiaryBalanceBefore = await balance.current(beneficiaryAddress1);
-            await this.pcvDripper.drip();
-            let dripperBalanceAfter = await balance.current(this.pcvDripper.address);
-            let beneficiaryBalanceAfter = await balance.current(beneficiaryAddress1);
-
-            expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(this.dripAmount);
-            expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(this.dripAmount);
-
-            // timer reset
-            expect(await this.pcvDripper.isTimeEnded()).to.be.equal(false);
           });
+          describe('Target balance low enough', function() {
+            it('succeeds', async function() {
+                let dripperBalanceBefore = await balance.current(this.pcvDripper.address);
+                let beneficiaryBalanceBefore = await balance.current(this.pcvDeposit.address);
+                await this.pcvDripper.drip();
+                let dripperBalanceAfter = await balance.current(this.pcvDripper.address);
+                let beneficiaryBalanceAfter = await balance.current(this.pcvDeposit.address);
+    
+                expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(this.dripAmount);
+                expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(this.dripAmount);
+    
+                // timer reset
+                expect(await this.pcvDripper.isTimeEnded()).to.be.equal(false);
+            });
+        });
+
+        describe('Target balance too high', function() {
+            beforeEach(async function() {
+                await web3.eth.sendTransaction({from: userAddress, to: this.pcvDeposit.address, value: this.dripAmount});
+            });
+
+            it('reverts', async function() {        
+                await expectRevert(this.pcvDripper.drip(), "EthPCVDripper: target balance too high");
+            });
+        });
       });
+
+      describe('Second attempt', function() {
+        beforeEach(async function() {
+            await time.increase('1000');
+            await this.pcvDripper.drip();
+        });
+
+        describe('Before time', function() {
+            it('reverts', async function() {
+                await expectRevert(this.pcvDripper.drip(), "Timed: time not ended");
+            });
+        });
+
+        describe('After time', function() {
+            describe('Target balance low enough', function() {
+                beforeEach(async function() {
+                    await this.pcvDeposit.withdraw(userAddress, this.dripAmount);
+                    await time.increase('1000');
+                });
+                it('succeeds', async function() {
+                    let dripperBalanceBefore = await balance.current(this.pcvDripper.address);
+                    let beneficiaryBalanceBefore = await balance.current(this.pcvDeposit.address);
+                    await this.pcvDripper.drip();
+                    let dripperBalanceAfter = await balance.current(this.pcvDripper.address);
+                    let beneficiaryBalanceAfter = await balance.current(this.pcvDeposit.address);
+        
+                    expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(this.dripAmount);
+                    expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(this.dripAmount);
+        
+                    // timer reset
+                    expect(await this.pcvDripper.isTimeEnded()).to.be.equal(false);
+                });
+            });
+    
+            describe('Target balance too high', function() {
+                beforeEach(async function() {
+                    await web3.eth.sendTransaction({from: userAddress, to: this.pcvDeposit.address, value: this.dripAmount});
+                    await time.increase('1000');
+                });
+
+                it('reverts', async function() {        
+                    await expectRevert(this.pcvDripper.drip(), "EthPCVDripper: target balance too high");
+                });
+            });
+        });
     });
   
     describe('Withdraw', function() {
@@ -81,3 +141,4 @@ const {
       });
     });
   });
+});

--- a/test/pcv/EthPCVDripper.test.js
+++ b/test/pcv/EthPCVDripper.test.js
@@ -1,0 +1,83 @@
+const {
+    userAddress,
+    beneficiaryAddress1,
+    governorAddress, 
+    pcvControllerAddress,
+    web3,
+    BN,
+    expectRevert,
+    time,
+    balance,
+    expect,
+    EthPCVDripper,
+    getCore
+  } = require('../helpers');
+  
+  describe('EthPCVDripper', function () {
+  
+    beforeEach(async function () {
+      this.core = await getCore(true);
+      
+      this.dripAmount = new BN('500000000000000000');
+      this.pcvDripper = await EthPCVDripper.new(this.core.address, beneficiaryAddress1, '1000', this.dripAmount);
+
+      await web3.eth.sendTransaction({from: userAddress, to: this.pcvDripper.address, value: "1000000000000000000"});
+    });
+  
+    describe('Drip', function() {
+      describe('Paused', function() {
+        it('reverts', async function() {
+            await time.increase('1000');
+            await this.pcvDripper.pause({from: governorAddress});
+            await expectRevert(this.pcvDripper.drip(), "Pausable: paused");
+        });
+      });
+
+      describe('Before time', function() {
+        it('reverts', async function() {
+            await expectRevert(this.pcvDripper.drip(), "Timed: time not ended");
+        });
+      });
+  
+      describe('After time', function() {
+
+          it('succeeds', async function() {
+            await time.increase('1000');
+
+            let dripperBalanceBefore = await balance.current(this.pcvDripper.address);
+            let beneficiaryBalanceBefore = await balance.current(beneficiaryAddress1);
+            await this.pcvDripper.drip();
+            let dripperBalanceAfter = await balance.current(this.pcvDripper.address);
+            let beneficiaryBalanceAfter = await balance.current(beneficiaryAddress1);
+
+            expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(this.dripAmount);
+            expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(this.dripAmount);
+
+            // timer reset
+            expect(await this.pcvDripper.isTimeEnded()).to.be.equal(false);
+          });
+      });
+    });
+  
+    describe('Withdraw', function() {
+      it('enough eth succeeds', async function() {
+        let dripperBalanceBefore = await balance.current(this.pcvDripper.address);
+        let beneficiaryBalanceBefore = await balance.current(beneficiaryAddress1);
+
+        await this.pcvDripper.withdrawETH(beneficiaryAddress1, '10000', {from: pcvControllerAddress});
+        let dripperBalanceAfter = await balance.current(this.pcvDripper.address);
+        let beneficiaryBalanceAfter = await balance.current(beneficiaryAddress1);
+
+        expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(new BN('10000'));
+        expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(new BN('10000'));
+      });
+
+      it('not enough eth reverts', async function() {
+        await expectRevert(this.pcvDripper.withdrawETH(beneficiaryAddress1, '10000000000000000000', {from: pcvControllerAddress}), "revert");
+      });
+
+      it('non pcvController', async function() {
+        await expectRevert(this.pcvDripper.withdrawETH(beneficiaryAddress1, '10000', {from: beneficiaryAddress1}), "CoreRef: Caller is not a PCV controller");
+      });
+    });
+  });

--- a/test/pcv/EthReserveStabilizer.test.js
+++ b/test/pcv/EthReserveStabilizer.test.js
@@ -39,7 +39,7 @@ const {
       describe('Enough FEI', function() {
         it('exchanges for appropriate amount of ETH', async function() {
           let reserveBalanceBefore = await balance.current(this.reserveStabilizer.address);
-          await this.reserveStabilizer.exchangeFeiForEth(40000000, {from: userAddress});
+          await this.reserveStabilizer.exchangeFei(40000000, {from: userAddress});
           let reserveBalanceAfter = await balance.current(this.reserveStabilizer.address);
 
           expect(reserveBalanceBefore.sub(reserveBalanceAfter)).to.be.bignumber.equal(new BN('90000'));
@@ -53,7 +53,7 @@ const {
           await this.oracle.setExchangeRate('800');
 
           let reserveBalanceBefore = await balance.current(this.reserveStabilizer.address);
-          await this.reserveStabilizer.exchangeFeiForEth(40000000, {from: userAddress});
+          await this.reserveStabilizer.exchangeFei(40000000, {from: userAddress});
           let reserveBalanceAfter = await balance.current(this.reserveStabilizer.address);
 
           expect(reserveBalanceBefore.sub(reserveBalanceAfter)).to.be.bignumber.equal(new BN('45000'));
@@ -67,7 +67,7 @@ const {
           await this.reserveStabilizer.setUsdPerFeiRate('9500', {from: governorAddress});
 
           let reserveBalanceBefore = await balance.current(this.reserveStabilizer.address);
-          await this.reserveStabilizer.exchangeFeiForEth(40000000, {from: userAddress});
+          await this.reserveStabilizer.exchangeFei(40000000, {from: userAddress});
           let reserveBalanceAfter = await balance.current(this.reserveStabilizer.address);
 
           expect(reserveBalanceBefore.sub(reserveBalanceAfter)).to.be.bignumber.equal(new BN('95000'));
@@ -78,21 +78,21 @@ const {
 
       describe('Not Enough FEI', function() {
         it('reverts', async function() {
-          await expectRevert(this.reserveStabilizer.exchangeFeiForEth(50000000, {from: userAddress}), "ERC20: burn amount exceeds balance");
+          await expectRevert(this.reserveStabilizer.exchangeFei(50000000, {from: userAddress}), "ERC20: burn amount exceeds balance");
         });
       });
 
       describe('Not Enough ETH', function() {
         it('reverts', async function() {
           await this.fei.mint(userAddress, new BN('4000000000000000000000000000'), {from: minterAddress});  
-          await expectRevert(this.reserveStabilizer.exchangeFeiForEth(new BN('4000000000000000000000000000'), {from: userAddress}), "revert");
+          await expectRevert(this.reserveStabilizer.exchangeFei(new BN('4000000000000000000000000000'), {from: userAddress}), "revert");
         });
       });
 
       describe('Paused', function() {
         it('reverts', async function() {
           await this.reserveStabilizer.pause({from: governorAddress});
-          await expectRevert(this.reserveStabilizer.exchangeFeiForEth(new BN('400000'), {from: userAddress}), "Pausable: paused");
+          await expectRevert(this.reserveStabilizer.exchangeFei(new BN('400000'), {from: userAddress}), "Pausable: paused");
         });
       });
     });

--- a/test/pcv/EthReserveStabilizer.test.js
+++ b/test/pcv/EthReserveStabilizer.test.js
@@ -1,0 +1,136 @@
+
+
+const {
+    userAddress, 
+    governorAddress, 
+    minterAddress, 
+    pcvControllerAddress,
+    web3,
+    BN,
+    expectRevert,
+    balance,
+    expect,
+    EthReserveStabilizer,
+    MockPCVDeposit,
+    Fei,
+    MockOracle,
+    getCore
+  } = require('../helpers');
+  
+  describe('EthReserveStabilizer', function () {
+  
+    beforeEach(async function () {
+      this.core = await getCore(true);
+  
+      this.fei = await Fei.at(await this.core.fei());
+      this.oracle = await MockOracle.new(400); // 400:1 oracle price
+      this.pcvDeposit = await MockPCVDeposit.new(userAddress);
+
+      this.reserveStabilizer = await EthReserveStabilizer.new(this.core.address, this.oracle.address, '9000');
+
+      await this.core.grantBurner(this.reserveStabilizer.address, {from: governorAddress});
+
+      await web3.eth.sendTransaction({from: userAddress, to: this.reserveStabilizer.address, value: "1000000000000000000"});
+
+      await this.fei.mint(userAddress, 40000000, {from: minterAddress});  
+    });
+  
+    describe('Exchange', function() {
+      describe('Enough FEI', function() {
+        it('exchanges for appropriate amount of ETH', async function() {
+          let reserveBalanceBefore = await balance.current(this.reserveStabilizer.address);
+          await this.reserveStabilizer.exchangeFeiForEth(40000000, {from: userAddress});
+          let reserveBalanceAfter = await balance.current(this.reserveStabilizer.address);
+
+          expect(reserveBalanceBefore.sub(reserveBalanceAfter)).to.be.bignumber.equal(new BN('90000'));
+
+          expect(await this.fei.balanceOf(userAddress)).to.be.bignumber.equal(new BN('0'));
+        });
+      });
+
+      describe('Double Oracle price', function() {
+        it('exchanges for appropriate amount of ETH', async function() {
+          await this.oracle.setExchangeRate('800');
+
+          let reserveBalanceBefore = await balance.current(this.reserveStabilizer.address);
+          await this.reserveStabilizer.exchangeFeiForEth(40000000, {from: userAddress});
+          let reserveBalanceAfter = await balance.current(this.reserveStabilizer.address);
+
+          expect(reserveBalanceBefore.sub(reserveBalanceAfter)).to.be.bignumber.equal(new BN('45000'));
+
+          expect(await this.fei.balanceOf(userAddress)).to.be.bignumber.equal(new BN('0'));
+        });
+      });
+  
+      describe('Higher usd per fei', function() {
+        it('exchanges for appropriate amount of ETH', async function() {
+          await this.reserveStabilizer.setUsdPerFeiRate('9500', {from: governorAddress});
+
+          let reserveBalanceBefore = await balance.current(this.reserveStabilizer.address);
+          await this.reserveStabilizer.exchangeFeiForEth(40000000, {from: userAddress});
+          let reserveBalanceAfter = await balance.current(this.reserveStabilizer.address);
+
+          expect(reserveBalanceBefore.sub(reserveBalanceAfter)).to.be.bignumber.equal(new BN('95000'));
+
+          expect(await this.fei.balanceOf(userAddress)).to.be.bignumber.equal(new BN('0'));
+        });
+      });
+
+      describe('Not Enough FEI', function() {
+        it('reverts', async function() {
+          await expectRevert(this.reserveStabilizer.exchangeFeiForEth(50000000, {from: userAddress}), "ERC20: burn amount exceeds balance");
+        });
+      });
+
+      describe('Not Enough ETH', function() {
+        it('reverts', async function() {
+          await this.fei.mint(userAddress, new BN('4000000000000000000000000000'), {from: minterAddress});  
+          await expectRevert(this.reserveStabilizer.exchangeFeiForEth(new BN('4000000000000000000000000000'), {from: userAddress}), "revert");
+        });
+      });
+
+      describe('Paused', function() {
+        it('reverts', async function() {
+          await this.reserveStabilizer.pause({from: governorAddress});
+          await expectRevert(this.reserveStabilizer.exchangeFeiForEth(new BN('400000'), {from: userAddress}), "Pausable: paused");
+        });
+      });
+    });
+  
+    describe('Withdraw', function() {
+      it('enough eth succeeds', async function() {
+        let reserveBalanceBefore = await balance.current(this.reserveStabilizer.address);
+        let userBalanceBefore = await balance.current(userAddress);
+
+        await this.reserveStabilizer.withdraw(userAddress, '10000', {from: pcvControllerAddress});
+        let reserveBalanceAfter = await balance.current(this.reserveStabilizer.address);
+        let userBalanceAfter = await balance.current(userAddress);
+
+        expect(reserveBalanceBefore.sub(reserveBalanceAfter)).to.be.bignumber.equal(new BN('10000'));
+        expect(userBalanceAfter.sub(userBalanceBefore)).to.be.bignumber.equal(new BN('10000'));
+      });
+
+      it('not enough eth reverts', async function() {
+        await expectRevert(this.reserveStabilizer.withdraw(userAddress, '10000000000000000000', {from: pcvControllerAddress}), "revert");
+      });
+
+      it('non pcvController', async function() {
+        await expectRevert(this.reserveStabilizer.withdraw(userAddress, '10000', {from: userAddress}), "CoreRef: Caller is not a PCV controller");
+      });
+    });
+
+    describe('Set USD per FEI', function() {
+      it('governor succeeds', async function() {
+        await this.reserveStabilizer.setUsdPerFeiRate('10000', {from: governorAddress});
+        expect(await this.reserveStabilizer.usdPerFeiBasisPoints()).to.be.bignumber.equal(new BN('10000'));
+      });
+
+      it('non-governor reverts', async function() {
+        await expectRevert(this.reserveStabilizer.setUsdPerFeiRate('10000', {from: userAddress}), "CoreRef: Caller is not a governor");
+      });
+
+      it('too high usd per fei reverts', async function() {
+        await expectRevert(this.reserveStabilizer.setUsdPerFeiRate('10001', {from: governorAddress}), "ReserveStabilizer: Exceeds bp granularity");
+      });
+    });
+  });

--- a/test/staking/TribeDripper.test.js
+++ b/test/staking/TribeDripper.test.js
@@ -134,7 +134,7 @@ const {
     });
 
     describe('Withdraw', function() {
-      it('enough eth succeeds', async function() {
+      it('enough tribe succeeds', async function() {
         let dripperBalanceBefore = await this.tribe.balanceOf(this.tribeDripper.address);
         let beneficiaryBalanceBefore = await this.tribe.balanceOf(beneficiaryAddress1);
 
@@ -146,7 +146,7 @@ const {
         expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(new BN('10000'));
       });
 
-      it('not enough eth reverts', async function() {
+      it('not enough tribe reverts', async function() {
         await expectRevert(this.tribeDripper.withdraw(beneficiaryAddress1, this.totalDripAmount.mul(new BN('2')), {from: pcvControllerAddress}), "revert");
       });
 

--- a/test/staking/TribeDripper.test.js
+++ b/test/staking/TribeDripper.test.js
@@ -1,0 +1,157 @@
+const {
+    governorAddress, 
+    pcvControllerAddress,
+    BN,
+    expectRevert,
+    time,
+    expect,
+    Tribe,
+    TribeDripper,
+    getCore,
+    beneficiaryAddress1
+  } = require('../helpers');
+
+  describe('TribeDripper', function () {
+
+    beforeEach(async function () {
+      this.core = await getCore(true);
+      this.tribe = await Tribe.at(await this.core.tribe());
+
+      this.totalDripAmount = new BN("100000000000000000000000000");
+      this.dripAmounts = [
+        "50000000000000000000000000", 
+        "30000000000000000000000000", 
+        "20000000000000000000000000"
+      ];
+      this.tribeDripper = await TribeDripper.new(this.core.address, beneficiaryAddress1, '1000', this.dripAmounts);
+
+      await this.core.allocateTribe(this.tribeDripper.address, this.totalDripAmount, {from: governorAddress});
+    });
+
+    describe('Drip', function() {
+        describe('Paused', function() {
+            it('reverts', async function() {
+                await this.tribeDripper.pause({from: governorAddress});
+                await expectRevert(this.tribeDripper.drip(), "Pausable: paused");
+            });
+        });
+
+        describe('Drip1', function() {
+            it('succeeds', async function() {
+                let dripperBalanceBefore = await this.tribe.balanceOf(this.tribeDripper.address);
+                let beneficiaryBalanceBefore = await this.tribe.balanceOf(beneficiaryAddress1);
+                await this.tribeDripper.drip();
+                let dripperBalanceAfter = await this.tribe.balanceOf(this.tribeDripper.address);
+                let beneficiaryBalanceAfter = await this.tribe.balanceOf(beneficiaryAddress1);
+
+                expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(this.dripAmounts[0]);
+                expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(this.dripAmounts[0]);
+
+                // timer reset
+                expect(await this.tribeDripper.isTimeEnded()).to.be.equal(false);
+            });
+        });
+
+        describe('Drip2', function() {
+            beforeEach(async function() {
+                await this.tribeDripper.drip();
+            });
+
+            describe('Before time', function() {
+                it('reverts', async function() {
+                    await expectRevert(this.tribeDripper.drip(), "TribeDripper: time not ended");
+                });
+            });
+
+            describe('After time', function() {
+                beforeEach(async function() {
+                    await time.increase('1000');
+                });
+                it('succeeds', async function() {
+                    let dripperBalanceBefore = await this.tribe.balanceOf(this.tribeDripper.address);
+                    let beneficiaryBalanceBefore = await this.tribe.balanceOf(beneficiaryAddress1);
+                    await this.tribeDripper.drip();
+                    let dripperBalanceAfter = await this.tribe.balanceOf(this.tribeDripper.address);
+                    let beneficiaryBalanceAfter = await this.tribe.balanceOf(beneficiaryAddress1);
+
+                    expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(this.dripAmounts[1]);
+                    expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(this.dripAmounts[1]);
+
+                    // timer reset
+                    expect(await this.tribeDripper.isTimeEnded()).to.be.equal(false);
+                });
+            });
+        });
+
+        describe('Drip3', function() {
+            beforeEach(async function() {
+                await this.tribeDripper.drip();
+                await time.increase('1000');
+                await this.tribeDripper.drip();
+            });
+
+            describe('Before time', function() {
+                it('reverts', async function() {
+                    await expectRevert(this.tribeDripper.drip(), "TribeDripper: time not ended");
+                });
+            });
+
+            describe('After time', function() {
+                beforeEach(async function() {
+                    await time.increase('1000');
+                });
+                it('succeeds', async function() {
+                    let dripperBalanceBefore = await this.tribe.balanceOf(this.tribeDripper.address);
+                    let beneficiaryBalanceBefore = await this.tribe.balanceOf(beneficiaryAddress1);
+                    await this.tribeDripper.drip();
+                    let dripperBalanceAfter = await this.tribe.balanceOf(this.tribeDripper.address);
+                    let beneficiaryBalanceAfter = await this.tribe.balanceOf(beneficiaryAddress1);
+
+                    expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(this.dripAmounts[2]);
+                    expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(this.dripAmounts[2]);
+
+                    // timer reset
+                    expect(await this.tribeDripper.isTimeEnded()).to.be.equal(false);
+                });
+            });
+        });
+
+        describe('Drip4', function() {
+            beforeEach(async function() {
+                await this.tribeDripper.drip();
+                await time.increase('1000');
+                await this.tribeDripper.drip();
+                await time.increase('1000');
+                await this.tribeDripper.drip();
+                await time.increase('1000');
+            });
+
+            it('reverts', async function() {
+                await expectRevert(this.tribeDripper.drip(), "TribeDripper: index out of bounds");
+            });
+
+        });
+    });
+
+    describe('Withdraw', function() {
+      it('enough eth succeeds', async function() {
+        let dripperBalanceBefore = await this.tribe.balanceOf(this.tribeDripper.address);
+        let beneficiaryBalanceBefore = await this.tribe.balanceOf(beneficiaryAddress1);
+
+        await this.tribeDripper.withdraw(beneficiaryAddress1, '10000', {from: pcvControllerAddress});
+        let dripperBalanceAfter = await this.tribe.balanceOf(this.tribeDripper.address);
+        let beneficiaryBalanceAfter = await this.tribe.balanceOf(beneficiaryAddress1);
+
+        expect(dripperBalanceBefore.sub(dripperBalanceAfter)).to.be.bignumber.equal(new BN('10000'));
+        expect(beneficiaryBalanceAfter.sub(beneficiaryBalanceBefore)).to.be.bignumber.equal(new BN('10000'));
+      });
+
+      it('not enough eth reverts', async function() {
+        await expectRevert(this.tribeDripper.withdraw(beneficiaryAddress1, this.totalDripAmount.mul(new BN('2')), {from: pcvControllerAddress}), "revert");
+      });
+
+      it('non pcvController', async function() {
+        await expectRevert(this.tribeDripper.withdraw(beneficiaryAddress1, '10000', {from: beneficiaryAddress1}), "CoreRef: Caller is not a PCV controller");
+      });
+    });
+}); 


### PR DESCRIPTION
EDIT: added the TribeDripper

Adds three contracts:
* EthReserveStabilizer which allows for exchanging FEI for ETH at a usd conversion rate
* EthPCVDripper which can send in the ETH to the reserve stabilizer in batches over time
* TribeDripper sends TRIBE to the FeiRewardsDistributor to smoothen the front-loading of rewards

The FeiRewardsDistributor calculates the amount to release every week by taking the total balance of TRIBE and subtracting unreleased future rewards.
When a new TRIBE airdrop happens, it frontloads all the rewards for the weeks that have already passed into the first week.
For FIP-2 this would lead to 6x rewards in week 1 (1x base rewards + 100% boost x 5 drips) instead of 2x.

The TribeDripper drips in 47m, 31m, and 22m TRIBE each over the first 3 weeks to smoothen the distribution.

Week 1: 1x base rewards + 47% boost x 5 drips = ~3.35x
Week 2: 1.47x base rewards + 31% x 6 drips = ~3.33x
Week 3: 1.78x base rewards + 22% x 7 drips = ~3.32x
Week 4+: 2x base rewards

These would be voted on per FIP-2: 
https://tribe.fei.money/t/fip-2-fei-redemption-tribe-staking/3033 
