### PR TITLE
Fixed Reweight Cadence

### DIFF
--- a/contracts/pcv/IUniswapPCVController.sol
+++ b/contracts/pcv/IUniswapPCVController.sol
@@ -29,6 +29,8 @@ interface IUniswapPCVController {
 
     function setPCVDeposit(address _pcvDeposit) external;
 
+    function setDuration(uint256 _duration) external;
+
     function setReweightIncentive(uint256 amount) external;
 
     function setReweightMinDistance(uint256 basisPoints) external;


### PR DESCRIPTION
This change removes the `incentiveParity` trigger condition from reweights and replaces it with a fixed cadence timer on the EthUniswapPCVController