### PR TITLE
Move WithdrawERC20 to helper PCVDeposit class

### DIFF
--- a/contracts/pcv/EthLidoPCVDeposit.sol
+++ b/contracts/pcv/EthLidoPCVDeposit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
-import "./IPCVDeposit.sol";
+import "./PCVDeposit.sol";
 import "../refs/CoreRef.sol";
 import "../external/Decimal.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -32,7 +32,7 @@ interface IStableSwapSTETH {
 /// @title implementation for PCV Deposit that can take ETH and get stETH either
 /// by staking on Lido or swapping on Curve, and sell back stETH for ETH on Curve.
 /// @author eswak, realisation
-contract EthLidoPCVDeposit is IPCVDeposit, CoreRef {
+contract EthLidoPCVDeposit is PCVDeposit {
     using SafeERC20 for ERC20;
     using Decimal for Decimal.D256;
 
@@ -160,19 +160,6 @@ contract EthLidoPCVDeposit is IPCVDeposit, CoreRef {
         Address.sendValue(payable(to), actualAmountOut);
 
         emit Withdrawal(msg.sender, to, actualAmountOut);
-    }
-
-    /// @notice withdraw ERC20 from the contract
-    /// @param token address of the ERC20 to send
-    /// @param to address destination of the ERC20
-    /// @param amount quantity of ERC20 to send
-    function withdrawERC20(
-      address token,
-      address to,
-      uint256 amount
-    ) public override onlyPCVController {
-        ERC20(token).safeTransfer(to, amount);
-        emit WithdrawERC20(msg.sender, token, to, amount);
     }
 
     /// @notice Returns the current balance of stETH held by the contract

--- a/contracts/pcv/PCVDeposit.sol
+++ b/contracts/pcv/PCVDeposit.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "../refs/CoreRef.sol";
+import "./IPCVDeposit.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title abstract contract for withdrawing ERC-20 tokens using a PCV Controller
+/// @author Fei Protocol
+abstract contract PCVDeposit is IPCVDeposit, CoreRef {
+    using SafeERC20 for IERC20;
+
+    /// @notice withdraw ERC20 from the contract
+    /// @param token address of the ERC20 to send
+    /// @param to address destination of the ERC20
+    /// @param amount quantity of ERC20 to send
+    function withdrawERC20(
+      address token, 
+      address to, 
+      uint256 amount
+    ) public override onlyPCVController {
+        IERC20(token).safeTransfer(to, amount);
+        emit WithdrawERC20(msg.sender, token, to, amount);
+    }
+}

--- a/contracts/pcv/PCVSwapperUniswap.sol
+++ b/contracts/pcv/PCVSwapperUniswap.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./IPCVSwapper.sol";
+import "./PCVDeposit.sol";
 import "../utils/Incentivized.sol";
 import "../refs/OracleRef.sol";
 import "../utils/Timed.sol";
@@ -14,7 +15,7 @@ import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 
 /// @title implementation for PCV Swapper that swaps ERC20 tokens on Uniswap
 /// @author eswak
-contract PCVSwapperUniswap is IPCVSwapper, OracleRef, Timed, Incentivized {
+contract PCVSwapperUniswap is IPCVSwapper, PCVDeposit, OracleRef, Timed, Incentivized {
     using SafeERC20 for ERC20;
     using Decimal for Decimal.D256;
 
@@ -122,19 +123,6 @@ contract PCVSwapperUniswap is IPCVSwapper, OracleRef, Timed, Incentivized {
         emit WithdrawETH(msg.sender, to, amountOut);
     }
 
-    /// @notice withdraw ERC20 from the contract
-    /// @param token address of the ERC20 to send
-    /// @param to address destination of the ERC20
-    /// @param amount quantity of ERC20 to send
-    function withdrawERC20(
-      address token, 
-      address to, 
-      uint256 amount
-    ) public override onlyPCVController {
-        ERC20(token).safeTransfer(to, amount);
-        emit WithdrawERC20(msg.sender, token, to, amount);
-    }
-
     /// @notice Sets the address receiving swap's inbound tokens
     /// @param _tokenReceivingAddress the address that will receive tokens
     function setReceivingAddress(address _tokenReceivingAddress) external override onlyGovernor {
@@ -222,9 +210,9 @@ contract PCVSwapperUniswap is IPCVSwapper, OracleRef, Timed, Incentivized {
 
     /// @notice see external function getNextAmountSpent()
     function _getExpectedAmountIn() internal view returns (uint256) {
-      uint256 balance = ERC20(tokenSpent).balanceOf(address(this));
-      require(balance != 0, "PCVSwapperUniswap: no tokenSpent left.");
-      return Math.min(maxSpentPerSwap, balance);
+      uint256 amount = ERC20(tokenSpent).balanceOf(address(this));
+      require(amount != 0, "PCVSwapperUniswap: no tokenSpent left.");
+      return Math.min(maxSpentPerSwap, amount);
     }
 
     /// @notice see external function getNextAmountReceived()

--- a/contracts/pcv/UniswapPCVDeposit.sol
+++ b/contracts/pcv/UniswapPCVDeposit.sol
@@ -2,13 +2,14 @@
 pragma solidity ^0.8.0;
 
 import "./IUniswapPCVDeposit.sol";
+import "./PCVDeposit.sol";
 import "../refs/UniRef.sol";
 import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title implementation for Uniswap LP PCV Deposit
 /// @author Fei Protocol
-contract UniswapPCVDeposit is IUniswapPCVDeposit, UniRef {
+contract UniswapPCVDeposit is IUniswapPCVDeposit, PCVDeposit, UniRef {
     using Decimal for Decimal.D256;
 
     /// @notice a slippage protection parameter, deposits revert when spot price is > this % from oracle
@@ -94,19 +95,6 @@ contract UniswapPCVDeposit is IUniswapPCVDeposit, UniRef {
         _burnFeiHeld(); // burn remaining FEI
 
         emit Withdrawal(msg.sender, to, amountWithdrawn);
-    }
-
-    /// @notice withdraw ERC20 from the contract
-    /// @param token address of the ERC20 to send
-    /// @param to address destination of the ERC20
-    /// @param amount quantity of ERC20 to send
-    function withdrawERC20(
-        address token,
-        address to,
-        uint256 amount
-    ) external override onlyPCVController {
-        SafeERC20.safeTransfer(IERC20(token), to, amount);
-        emit WithdrawERC20(msg.sender, address(token), to, amount);
     }
 
     /// @notice sets the new slippage parameter for depositing liquidity

--- a/contracts/stabilizer/ReserveStabilizer.sol
+++ b/contracts/stabilizer/ReserveStabilizer.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.0;
 
 import "./IReserveStabilizer.sol";
-import "../pcv/IPCVDeposit.sol";
+import "../pcv/PCVDeposit.sol";
 import "../refs/OracleRef.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title implementation for an ERC20 Reserve Stabilizer
 /// @author Fei Protocol
-contract ReserveStabilizer is OracleRef, IReserveStabilizer, IPCVDeposit {
+contract ReserveStabilizer is OracleRef, IReserveStabilizer, PCVDeposit {
     using Decimal for Decimal.D256;
 
     /// @notice the USD per FEI exchange rate denominated in basis points (1/10000)
@@ -64,19 +64,6 @@ contract ReserveStabilizer is OracleRef, IReserveStabilizer, IPCVDeposit {
     function withdraw(address to, uint256 amountOut) external virtual override onlyPCVController {
         _transfer(to, amountOut);
         emit Withdrawal(msg.sender, to, amountOut);
-    }
-
-    /// @notice withdraw ERC20 from the contract
-    /// @param token address of the ERC20 to send
-    /// @param to address destination of the ERC20
-    /// @param amount quantity of ERC20 to send
-    function withdrawERC20(
-        address token,
-        address to,
-        uint256 amount
-    ) external override onlyPCVController {
-        SafeERC20.safeTransfer(IERC20(token), to, amount);
-        emit WithdrawERC20(msg.sender, address(token), to, amount);
     }
 
     /// @notice new PCV deposited to the stabilizer


### PR DESCRIPTION
Moves the withdrawERC20 method to a helper child class called PCVDeposit.sol.

Also resolves OZ audit issue L06 by removing declaration namespace collision in ReserveStabilizer.

There was an additional collision with `balance` in the PCVSwapperUniswap this PR also corrects