### PR TITLE
Add backup oracle to OracleRef constructor

### DIFF
--- a/contracts/bondingcurve/BondingCurve.sol
+++ b/contracts/bondingcurve/BondingCurve.sol
@@ -40,7 +40,8 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
     /// @param _core Fei Core to reference
     /// @param _pcvDeposits the PCV Deposits for the PCVSplitter
     /// @param _ratios the ratios for the PCVSplitter
-    /// @param _oracle the UniswapOracle to reference
+    /// @param _oracle the oracle to reference
+    /// @param _backupOracle the backup oracle to reference
     /// @param _duration the duration between incentivizing allocations
     /// @param _incentive the amount rewarded to the caller of an allocation
     /// @param _token the ERC20 token associated with this curve, null if ETH
@@ -49,6 +50,7 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
     constructor(
         address _core,
         address _oracle,
+        address _backupOracle,
         uint256 _scale,
         address[] memory _pcvDeposits,
         uint256[] memory _ratios,
@@ -58,7 +60,7 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
         uint256 _discount,
         uint256 _buffer
     )
-        OracleRef(_core, _oracle)
+        OracleRef(_core, _oracle, address(0))
         PCVSplitter(_pcvDeposits, _ratios)
         Timed(_duration)
         Incentivized(_incentive)

--- a/contracts/bondingcurve/BondingCurve.sol
+++ b/contracts/bondingcurve/BondingCurve.sol
@@ -60,7 +60,7 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
         uint256 _discount,
         uint256 _buffer
     )
-        OracleRef(_core, _oracle, address(0))
+        OracleRef(_core, _oracle, _backupOracle)
         PCVSplitter(_pcvDeposits, _ratios)
         Timed(_duration)
         Incentivized(_incentive)

--- a/contracts/bondingcurve/EthBondingCurve.sol
+++ b/contracts/bondingcurve/EthBondingCurve.sol
@@ -20,11 +20,13 @@ contract EthBondingCurve is BondingCurve {
     constructor(
         address core,
         address oracle,
+        address backupOracle,
         BondingCurveParams memory params
     )
         BondingCurve(
             core,
             oracle,
+            backupOracle,
             params.scale,
             params.pcvDeposits,
             params.ratios,

--- a/contracts/pcv/PCVSwapperUniswap.sol
+++ b/contracts/pcv/PCVSwapperUniswap.sol
@@ -44,12 +44,17 @@ contract PCVSwapperUniswap is IPCVSwapper, OracleRef, Timed, Incentivized {
     // solhint-disable-next-line var-name-mixedcase
     address public immutable WETH;
 
+    struct OracleAddresses {
+        address _oracle;
+        address _backupOracle;
+    }
+
     constructor(
         address _core,
         IUniswapV2Pair _pair,
         // solhint-disable-next-line var-name-mixedcase
         address _WETH,
-        address _oracle,
+        OracleAddresses memory oracleAddresses,
         uint256 _swapFrequency,
         address _tokenSpent,
         address _tokenReceived,
@@ -60,8 +65,8 @@ contract PCVSwapperUniswap is IPCVSwapper, OracleRef, Timed, Incentivized {
         uint256 _swapIncentiveAmount
     ) OracleRef(
       _core, 
-      _oracle, 
-      address(0) // no backup oracle due to stack overflow in constructor. Can be set through governance
+      oracleAddresses._oracle, 
+      oracleAddresses._backupOracle
     ) Timed(_swapFrequency) Incentivized(_swapIncentiveAmount) {
         pair = _pair;
         WETH = _WETH;

--- a/contracts/pcv/PCVSwapperUniswap.sol
+++ b/contracts/pcv/PCVSwapperUniswap.sol
@@ -58,7 +58,7 @@ contract PCVSwapperUniswap is IPCVSwapper, OracleRef, Timed, Incentivized {
         uint256 _maximumSlippageBasisPoints,
         bool _invertOraclePrice,
         uint256 _swapIncentiveAmount
-    ) OracleRef(_core, _oracle) Timed(_swapFrequency) Incentivized(_swapIncentiveAmount) {
+    ) OracleRef(_core, _oracle, address(0)) Timed(_swapFrequency) Incentivized(_swapIncentiveAmount) {
         pair = _pair;
         WETH = _WETH;
         tokenSpent = _tokenSpent;

--- a/contracts/pcv/PCVSwapperUniswap.sol
+++ b/contracts/pcv/PCVSwapperUniswap.sol
@@ -58,7 +58,11 @@ contract PCVSwapperUniswap is IPCVSwapper, OracleRef, Timed, Incentivized {
         uint256 _maximumSlippageBasisPoints,
         bool _invertOraclePrice,
         uint256 _swapIncentiveAmount
-    ) OracleRef(_core, _oracle, address(0)) Timed(_swapFrequency) Incentivized(_swapIncentiveAmount) {
+    ) OracleRef(
+      _core, 
+      _oracle, 
+      address(0) // no backup oracle due to stack overflow in constructor. Can be set through governance
+    ) Timed(_swapFrequency) Incentivized(_swapIncentiveAmount) {
         pair = _pair;
         WETH = _WETH;
         tokenSpent = _tokenSpent;

--- a/contracts/pcv/UniswapPCVController.sol
+++ b/contracts/pcv/UniswapPCVController.sol
@@ -27,6 +27,7 @@ contract UniswapPCVController is IUniswapPCVController, UniRef, Timed, Incentivi
     /// @param _core Fei Core for reference
     /// @param _pcvDeposit PCV Deposit to reweight
     /// @param _oracle oracle for reference
+    /// @param _backupOracle the backup oracle to reference
     /// @param _incentiveAmount amount of FEI for triggering a reweight
     /// @param _minDistanceForReweightBPs minimum distance from peg to reweight in basis points
     /// @param _pair Uniswap pair contract to reweight
@@ -35,11 +36,12 @@ contract UniswapPCVController is IUniswapPCVController, UniRef, Timed, Incentivi
         address _core,
         address _pcvDeposit,
         address _oracle,
+        address _backupOracle,
         uint256 _incentiveAmount,
         uint256 _minDistanceForReweightBPs,
         address _pair,
         uint256 _reweightFrequency
-    ) UniRef(_core, _pair, _oracle) Timed(_reweightFrequency) Incentivized(_incentiveAmount) {
+    ) UniRef(_core, _pair, _oracle, _backupOracle) Timed(_reweightFrequency) Incentivized(_incentiveAmount) {
         pcvDeposit = IPCVDeposit(_pcvDeposit);
         emit PCVDepositUpdate(address(0), _pcvDeposit);
 

--- a/contracts/pcv/UniswapPCVDeposit.sol
+++ b/contracts/pcv/UniswapPCVDeposit.sol
@@ -24,14 +24,16 @@ contract UniswapPCVDeposit is IUniswapPCVDeposit, UniRef {
     /// @param _pair Uniswap Pair to deposit to
     /// @param _router Uniswap Router
     /// @param _oracle oracle for reference
+    /// @param _backupOracle the backup oracle to reference
     /// @param _maxBasisPointsFromPegLP the max basis points of slippage from peg allowed on LP deposit
     constructor(
         address _core,
         address _pair,
         address _router,
         address _oracle,
+        address _backupOracle,
         uint256 _maxBasisPointsFromPegLP
-    ) UniRef(_core, _pair, _oracle) {
+    ) UniRef(_core, _pair, _oracle, _backupOracle) {
         router = IUniswapV2Router02(_router);
 
         _approveToken(address(fei()));

--- a/contracts/refs/OracleRef.sol
+++ b/contracts/refs/OracleRef.sol
@@ -22,7 +22,7 @@ abstract contract OracleRef is IOracleRef, CoreRef {
     /// @param _backupOracle backup oracle to reference
     constructor(address _core, address _oracle, address _backupOracle) CoreRef(_core) {
         _setOracle(_oracle);
-        if (_backupOracle != address(0)) {
+        if (_backupOracle != address(0) && _backupOracle != _oracle) {
             _setBackupOracle(_backupOracle);
         }
     }

--- a/contracts/refs/OracleRef.sol
+++ b/contracts/refs/OracleRef.sol
@@ -19,8 +19,12 @@ abstract contract OracleRef is IOracleRef, CoreRef {
     /// @notice OracleRef constructor
     /// @param _core Fei Core to reference
     /// @param _oracle oracle to reference
-    constructor(address _core, address _oracle) CoreRef(_core) {
+    /// @param _backupOracle backup oracle to reference
+    constructor(address _core, address _oracle, address _backupOracle) CoreRef(_core) {
         _setOracle(_oracle);
+        if (_backupOracle != address(0)) {
+            _setBackupOracle(_backupOracle);
+        }
     }
 
     /// @notice sets the referenced oracle
@@ -67,6 +71,7 @@ abstract contract OracleRef is IOracleRef, CoreRef {
     }
 
     function _setOracle(address newOracle) internal {
+        require(newOracle != address(0), "OracleRef: no oracle provided");
         address oldOracle = address(oracle);
         oracle = IOracle(newOracle);
         emit OracleUpdate(oldOracle, newOracle);

--- a/contracts/refs/UniRef.sol
+++ b/contracts/refs/UniRef.sol
@@ -20,11 +20,13 @@ abstract contract UniRef is IUniRef, OracleRef {
     /// @param _core Fei Core to reference
     /// @param _pair Uniswap pair to reference
     /// @param _oracle oracle to reference
+    /// @param _backupOracle backup oracle to reference
     constructor(
         address _core,
         address _pair,
-        address _oracle
-    ) OracleRef(_core, _oracle) {
+        address _oracle,
+        address _backupOracle
+    ) OracleRef(_core, _oracle, _backupOracle) {
         _setupPair(_pair);
     }
 

--- a/contracts/stabilizer/EthReserveStabilizer.sol
+++ b/contracts/stabilizer/EthReserveStabilizer.sol
@@ -14,13 +14,15 @@ contract EthReserveStabilizer is ReserveStabilizer {
     /// @notice ETH Reserve Stabilizer constructor
     /// @param _core Fei Core to reference
     /// @param _oracle the ETH price oracle to reference
+    /// @param _backupOracle the backup oracle to reference
     /// @param _usdPerFeiBasisPoints the USD price per FEI to sell ETH at
     constructor(
         address _core,
         address _oracle,
+        address _backupOracle,
         uint256 _usdPerFeiBasisPoints,
         address _WETH
-    ) ReserveStabilizer(_core, _oracle, IERC20(address(0)), _usdPerFeiBasisPoints) {
+    ) ReserveStabilizer(_core, _oracle, _backupOracle, IERC20(address(0)), _usdPerFeiBasisPoints) {
         WETH = _WETH;
     }
 

--- a/contracts/stabilizer/ReserveStabilizer.sol
+++ b/contracts/stabilizer/ReserveStabilizer.sol
@@ -23,14 +23,16 @@ contract ReserveStabilizer is OracleRef, IReserveStabilizer, IPCVDeposit {
 
     /// @notice ERC20 Reserve Stabilizer constructor
     /// @param _core Fei Core to reference
-    /// @param _oracle the ETH price oracle to reference
+    /// @param _oracle the price oracle to reference
+    /// @param _backupOracle the backup oracle to reference
     /// @param _usdPerFeiBasisPoints the USD price per FEI to sell tokens at
     constructor(
         address _core,
         address _oracle,
+        address _backupOracle,
         IERC20 _token,
         uint256 _usdPerFeiBasisPoints
-    ) OracleRef(_core, _oracle) {
+    ) OracleRef(_core, _oracle, _backupOracle) {
         require(_usdPerFeiBasisPoints <= BASIS_POINTS_GRANULARITY, "ReserveStabilizer: Exceeds bp granularity");
         usdPerFeiBasisPoints = _usdPerFeiBasisPoints;
         emit UsdPerFeiRateUpdate(0, _usdPerFeiBasisPoints);

--- a/contracts/stabilizer/TribeReserveStabilizer.sol
+++ b/contracts/stabilizer/TribeReserveStabilizer.sol
@@ -22,16 +22,18 @@ contract TribeReserveStabilizer is ITribeReserveStabilizer, ReserveStabilizer {
     /// @notice Tribe Reserve Stabilizer constructor
     /// @param _core Fei Core to reference
     /// @param _tribeOracle the TRIBE price oracle to reference
+    /// @param _backupOracle the backup oracle to reference
     /// @param _usdPerFeiBasisPoints the USD price per FEI to sell TRIBE at
     /// @param _feiOracle the FEI price oracle to reference
     /// @param _feiPriceThresholdBasisPoints the FEI price below which the stabilizer becomes active. Reported in basis points (1/10000)
     constructor(
         address _core,
         address _tribeOracle,
+        address _backupOracle,
         uint256 _usdPerFeiBasisPoints,
         IOracle _feiOracle,
         uint256 _feiPriceThresholdBasisPoints
-    ) ReserveStabilizer(_core, _tribeOracle, IERC20(address(0)), _usdPerFeiBasisPoints) {
+    ) ReserveStabilizer(_core, _tribeOracle, _backupOracle, IERC20(address(0)), _usdPerFeiBasisPoints) {
         feiOracle = _feiOracle;
         _feiPriceThreshold = Decimal.ratio(_feiPriceThresholdBasisPoints, BASIS_POINTS_GRANULARITY);
         emit FeiPriceThresholdUpdate(0, _feiPriceThresholdBasisPoints);

--- a/test/bondingcurve/BondingCurve.test.js
+++ b/test/bondingcurve/BondingCurve.test.js
@@ -45,7 +45,19 @@ describe('BondingCurve', function () {
     this.buffer = new BN('100');
     this.incentiveAmount = new BN('100');
     this.incentiveDuration = new BN('10');
-    this.bondingCurve = await BondingCurve.new(this.core.address, this.oracle.address, this.scale, [this.pcvDeposit1.address, this.pcvDeposit2.address], [9000, 1000], this.incentiveDuration, this.incentiveAmount, this.token.address, 100, 100);
+    this.bondingCurve = await BondingCurve.new(
+      this.core.address, 
+      this.oracle.address, 
+      this.oracle.address, 
+      this.scale, 
+      [this.pcvDeposit1.address, this.pcvDeposit2.address], 
+      [9000, 1000], 
+      this.incentiveDuration, 
+      this.incentiveAmount, 
+      this.token.address, 
+      100, 
+      100
+    );
 
     await this.token.mint(userAddress, '1000000000000000000000000');
     await this.core.grantMinter(this.bondingCurve.address, {from: governorAddress});

--- a/test/bondingcurve/EthBondingCurve.test.js
+++ b/test/bondingcurve/EthBondingCurve.test.js
@@ -44,7 +44,7 @@ describe('EthBondingCurve', function () {
     this.buffer = new BN('100');
     this.incentiveAmount = new BN('100');
     this.incentiveDuration = new BN('10');
-    this.bondingCurve = await EthBondingCurve.new(this.core.address, this.oracle.address, {
+    this.bondingCurve = await EthBondingCurve.new(this.core.address, this.oracle.address, this.oracle.address, {
       scale: '100000000000', buffer: '100', discount: '100', duration: this.incentiveDuration.toString(), incentive: this.incentiveAmount.toString(), pcvDeposits: [this.pcvDeposit1.address, this.pcvDeposit2.address], ratios: [9000, 1000]
     });
     await this.core.grantMinter(this.bondingCurve.address, {from: governorAddress});

--- a/test/pcv/PCVSwapperUniswap.test.js
+++ b/test/pcv/PCVSwapperUniswap.test.js
@@ -52,7 +52,10 @@ describe('PCVSwapperUniswap', function () {
       this.core.address, // core
       this.pair.address, // pair
       this.weth.address, // weth
-      this.oracle.address, // oracle
+      {
+        _oracle: this.oracle.address, // oracle
+        _backupOracle: this.oracle.address // backup oracle
+      }, 
       '1000', // default minimum interval between swaps
       this.weth.address, // tokenSpent
       this.fei.address, // tokenReceived

--- a/test/pcv/UniswapPCVController.test.js
+++ b/test/pcv/UniswapPCVController.test.js
@@ -44,6 +44,7 @@ describe('UniswapPCVController', function () {
     this.pcvController = await UniswapPCVController.new(
       this.core.address, 
       this.pcvDeposit.address, 
+      this.oracle.address,
       this.oracle.address, 
       '100000000000000000000',
       '100',

--- a/test/pcv/UniswapPCVDeposit.test.js
+++ b/test/pcv/UniswapPCVDeposit.test.js
@@ -39,7 +39,7 @@ describe('EthUniswapPCVDeposit', function () {
     this.oracle = await MockOracle.new(400); // 400:1 oracle price
     this.router = await MockRouter.new(this.pair.address);
     this.router.setWETH(this.weth.address);
-    this.pcvDeposit = await UniswapPCVDeposit.new(this.core.address, this.pair.address, this.router.address, this.oracle.address, '100');
+    this.pcvDeposit = await UniswapPCVDeposit.new(this.core.address, this.pair.address, this.router.address, this.oracle.address, this.oracle.address, '100');
 
     await this.core.grantMinter(this.pcvDeposit.address, {from: governorAddress});
 

--- a/test/refs/OracleRef.test.js
+++ b/test/refs/OracleRef.test.js
@@ -21,8 +21,12 @@ describe('OracleRef', function () {
     this.oracle = await MockOracle.new(500); // 500 USD per ETH exchange rate 
     this.backupOracle = await MockOracle.new(505); // 505 USD per ETH exchange rate 
 
-    this.oracleRef = await ReserveStabilizer.new(this.core.address, this.oracle.address, userAddress, 10000);
-    await this.oracleRef.setBackupOracle(this.backupOracle.address, {from: governorAddress});
+    this.oracleRef = await ReserveStabilizer.new(
+      this.core.address, 
+      this.oracle.address, 
+      this.backupOracle.address, 
+      userAddress, 10000
+    );
   });
   
   describe('Init', function() {

--- a/test/stablizer/EthReserveStabilizer.test.js
+++ b/test/stablizer/EthReserveStabilizer.test.js
@@ -35,7 +35,7 @@ describe('EthReserveStabilizer', function () {
     this.oracle = await MockOracle.new(400); // 400:1 oracle price
     this.pcvDeposit = await MockPCVDeposit.new(userAddress);
 
-    this.reserveStabilizer = await EthReserveStabilizer.new(this.core.address, this.oracle.address, '9000', this.weth.address);
+    this.reserveStabilizer = await EthReserveStabilizer.new(this.core.address, this.oracle.address, this.oracle.address, '9000', this.weth.address);
 
     await this.core.grantBurner(this.reserveStabilizer.address, {from: governorAddress});
 

--- a/test/stablizer/ReserveStabilizer.test.js
+++ b/test/stablizer/ReserveStabilizer.test.js
@@ -33,7 +33,7 @@ describe('ReserveStabilizer', function () {
     this.oracle = await MockOracle.new(400); // 400:1 oracle price
     this.pcvDeposit = await MockPCVDeposit.new(userAddress);
 
-    this.reserveStabilizer = await ReserveStabilizer.new(this.core.address, this.oracle.address, this.token.address, '9000');
+    this.reserveStabilizer = await ReserveStabilizer.new(this.core.address, this.oracle.address, this.oracle.address, this.token.address, '9000');
 
     await this.core.grantBurner(this.reserveStabilizer.address, {from: governorAddress});
 

--- a/test/stablizer/TribeReserveStabilizer.test.js
+++ b/test/stablizer/TribeReserveStabilizer.test.js
@@ -33,7 +33,7 @@ describe('TribeReserveStabilizer', function () {
     this.feiOracle = await MockOracle.new(1);
     this.pcvDeposit = await MockPCVDeposit.new(userAddress);
 
-    this.reserveStabilizer = await TribeReserveStabilizer.new(this.core.address, this.oracle.address, '9000', this.feiOracle.address, '10000');
+    this.reserveStabilizer = await TribeReserveStabilizer.new(this.core.address, this.oracle.address, this.oracle.address, '9000', this.feiOracle.address, '10000');
 
     await this.core.grantBurner(this.reserveStabilizer.address, {from: governorAddress});
 


### PR DESCRIPTION
This PR adds the backup oracle to OracleRef constructor. Resolves OZ Audit issue L05

It saves a governance action, instead of requiring the governor to call setBackupOracle this can be done at construction.