### PR TITLE
Add Compound PCV Deposits

### DIFF
--- a/contract-addresses/mainnetAddresses.json
+++ b/contract-addresses/mainnetAddresses.json
@@ -27,5 +27,10 @@
     "communalFarmAddress" : { "address":  "0x0639076265e9f88542C91DCdEda65127974A5CA5"},
     "uniswapRouterAddress": { "address":  "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"},
     "chainlinkEthUsdOracleAddress": { "address":  "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419"},
-    "chainlinkFeiEthOracleAddress": { "address":  "0x7F0D2c2838c6AC24443d13e23d99490017bDe370"}
+    "chainlinkFeiEthOracleAddress": { "address":  "0x7F0D2c2838c6AC24443d13e23d99490017bDe370"},
+    "rariPool8ComptrollerAddress": { "address":  "0xc54172e34046c1653d1920d40333dd358c7a1af4"},
+    "rariPool8FeiAddress": { "address":  "0xd8553552f8868C1Ef160eEdf031cF0BCf9686945"},
+    "rariPool8TribeAddress": { "address":  "0xFd3300A9a74b3250F1b2AbC12B47611171910b07"},
+    "rariPool8EthAddress": { "address":  "0xbB025D470162CC5eA24daF7d4566064EE7f5F111"},
+    "rariPool8DaiAddress": { "address":  "0x7e9cE3CAa9910cc048590801e64174957Ed41d43" }
 }

--- a/contracts/pcv/compound/CompoundPCVDepositBase.sol
+++ b/contracts/pcv/compound/CompoundPCVDepositBase.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "../PCVDeposit.sol";
+import "../../refs/CoreRef.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface CToken {
+    function redeemUnderlying(uint redeemAmount) external returns (uint);
+    function exchangeRateStored() external view returns (uint);
+    function balanceOf(address account) external view returns (uint);
+    function isCToken() external view returns(bool);
+    function isCEther() external view returns(bool);
+}
+
+/// @title base class for a Compound PCV Deposit
+/// @author Fei Protocol
+abstract contract CompoundPCVDepositBase is PCVDeposit {
+
+    CToken public cToken;
+
+    uint256 private constant EXCHANGE_RATE_SCALE = 1e18;
+
+    /// @notice Compound PCV Deposit constructor
+    /// @param _core Fei Core for reference
+    /// @param _cToken Compound cToken to deposit
+    constructor(
+        address _core,
+        address _cToken
+    ) CoreRef(_core) {
+        cToken = CToken(_cToken);
+        require(cToken.isCToken(), "CompoundPCVDeposit: Not a cToken");
+    }
+
+    /// @notice withdraw tokens from the PCV allocation
+    /// @param amountUnderlying of tokens withdrawn
+    /// @param to the address to send PCV to
+    function withdraw(address to, uint256 amountUnderlying)
+        external
+        override
+        onlyPCVController
+        whenNotPaused
+    {
+        require(
+            cToken.redeemUnderlying(amountUnderlying) == 0,
+            "CompoundPCVDeposit: redeem error"
+        );
+        _transferUnderlying(to, amountUnderlying);
+        emit Withdrawal(msg.sender, to, amountUnderlying);
+    }
+
+    /// @notice returns total balance of PCV in the Deposit excluding the FEI
+    /// @dev returns stale values from Compound if the market hasn't been updated
+    function balance() public view override returns (uint256) {
+        uint256 exchangeRate = cToken.exchangeRateStored();
+        return cToken.balanceOf(address(this)) * exchangeRate / EXCHANGE_RATE_SCALE;
+    }
+
+    function _transferUnderlying(address to, uint256 amount) internal virtual;
+}

--- a/contracts/pcv/compound/ERC20CompoundPCVDeposit.sol
+++ b/contracts/pcv/compound/ERC20CompoundPCVDeposit.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "./CompoundPCVDepositBase.sol";
+
+interface CErc20 {
+    function mint(uint256 amount) external returns (uint256);
+}
+
+/// @title ERC-20 implementation for a Compound PCV Deposit
+/// @author Fei Protocol
+contract ERC20CompoundPCVDeposit is CompoundPCVDepositBase {
+
+    /// @notice the token underlying the cToken
+    IERC20 public token;
+
+    /// @notice Compound ERC20 PCV Deposit constructor
+    /// @param _core Fei Core for reference
+    /// @param _cToken Compound cToken to deposit
+    /// @param _token the token underlying the cToken
+    constructor(
+        address _core,
+        address _cToken,
+        IERC20 _token
+    ) CompoundPCVDepositBase(_core, _cToken) {
+        token = _token;
+        require(!cToken.isCEther(), "ERC20CompoundPCVDeposit: Not a CErc20");
+    }
+
+    /// @notice deposit ERC-20 tokens to Compound
+    function deposit()
+        external
+        override
+        whenNotPaused
+    {
+        uint256 amount = token.balanceOf(address(this));
+
+        token.approve(address(cToken), amount);
+
+        // Compound returns non-zero when there is an error
+        require(CErc20(address(cToken)).mint(amount) == 0, "ERC20CompoundPCVDeposit: deposit error");
+        
+        emit Deposit(msg.sender, amount);
+    }
+
+    function _transferUnderlying(address to, uint256 amount) internal override {
+        SafeERC20.safeTransfer(token, to, amount);
+    }
+}

--- a/contracts/pcv/compound/EthCompoundPCVDeposit.sol
+++ b/contracts/pcv/compound/EthCompoundPCVDeposit.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "./CompoundPCVDepositBase.sol";
+
+interface CEther {
+    function mint() external payable;
+}
+
+/// @title ETH implementation for a Compound PCV Deposit
+/// @author Fei Protocol
+contract EthCompoundPCVDeposit is CompoundPCVDepositBase {
+
+    /// @notice Compound ETH PCV Deposit constructor
+    /// @param _core Fei Core for reference
+    /// @param _cToken Compound cToken to deposit
+    constructor(
+        address _core,
+        address _cToken
+    ) CompoundPCVDepositBase(_core, _cToken) {
+        require(cToken.isCEther(), "EthCompoundPCVDeposit: Not a CEther");
+    }
+
+    receive() external payable {}
+
+    /// @notice deposit ETH to Compound
+    function deposit()
+        external
+        override
+        whenNotPaused
+    {
+        uint256 amount = address(this).balance;
+
+        // CEth deposits revert on failure
+        CEther(address(cToken)).mint{value: amount}();
+        emit Deposit(msg.sender, amount);
+    }
+
+    function _transferUnderlying(address to, uint256 amount) internal override {
+        Address.sendValue(payable(to), amount);
+    }
+}

--- a/end-to-end/e2e.spec.ts
+++ b/end-to-end/e2e.spec.ts
@@ -207,6 +207,36 @@ describe('e2e', function () {
     })
   })
 
+  describe('Compound', async () => {
+    it('should be able to deposit and withdraw ERC20 tokens',  async function () {
+      const erc20CompoundPCVDeposit = contracts.rariPool8FeiPCVDeposit;
+      const fei = contracts.fei;
+      const amount = '100000000000000000000000000'
+      await fei.mint(erc20CompoundPCVDeposit.address, amount);
+
+      const balanceBefore = await erc20CompoundPCVDeposit.balance();
+
+      await erc20CompoundPCVDeposit.deposit();
+      expect((await erc20CompoundPCVDeposit.balance()).sub(balanceBefore)).to.be.bignumber.greaterThan(amount);
+
+      await erc20CompoundPCVDeposit.withdraw(deployAddress, amount);
+      expect((await erc20CompoundPCVDeposit.balance()).sub(balanceBefore)).to.be.bignumber.lessThan(amount);
+    })
+  
+    it('should be able to deposit and withdraw ETH',  async function () {
+      const ethCompoundPCVDeposit = contracts.rariPool8EthPCVDeposit;
+      const amount = tenPow18.mul(toBN(200));
+      await web3.eth.sendTransaction({from: deployAddress, to: ethCompoundPCVDeposit.address, value: amount });
+
+      const balanceBefore = await ethCompoundPCVDeposit.balance();
+
+      await ethCompoundPCVDeposit.deposit();
+      expect((await ethCompoundPCVDeposit.balance()).sub(balanceBefore)).to.be.bignumber.greaterThan(amount);
+
+      await ethCompoundPCVDeposit.withdraw(deployAddress, amount);
+      expect((await ethCompoundPCVDeposit.balance()).sub(balanceBefore)).to.be.bignumber.lessThan(amount);
+    })
+  })
   describe('Access control', async () => {
     before(async () => {
       // Revoke deploy address permissions, so that does not erroneously

--- a/proposals/config.json
+++ b/proposals/config.json
@@ -4,5 +4,11 @@
         "exec" : false,
         "proposerAddress" : "",
         "voterAddress" : ""
+    },
+    "compoundPCVDeposit" : {
+        "deploy" : true,
+        "exec" : false,
+        "proposerAddress" : "",
+        "voterAddress" : ""
     }
 }

--- a/proposals/dao/compoundPCVDeposit.js
+++ b/proposals/dao/compoundPCVDeposit.js
@@ -4,7 +4,8 @@ const e18 = '000000000000000000';
 
 async function setup(addresses, oldContracts, contracts, logging) {}
 
-// The DAO steps for FIP-9, these must be done with Governor access control privileges
+// The DAO steps for updating the existing FEI deployment to Fuse and adding an example ETH deposit
+// Note: this is an example DAO flow and not tied to an existing FIP
 async function run(addresses, oldContracts, contracts, logging = false) {
   const {
     rariPool8FeiAddress,
@@ -19,8 +20,10 @@ async function run(addresses, oldContracts, contracts, logging = false) {
   const rariPool8Fei = await IERC20.at(rariPool8FeiAddress);
   const balanceOfRariFei = await rariPool8Fei.balanceOf(timelockAddress);
 
+  // The timelock currently owns some fFEI, so we should transfer this balance to the PCV deposit
   await rariPool8Fei.transfer(rariPool8FeiPCVDeposit.address, balanceOfRariFei, {from: timelockAddress});
 
+  // Withdraw 1000 ETH to send to fETH pool
   await ethPCVDripper.withdrawETH(rariPool8EthPCVDeposit.address, `1000${e18}`);
   
   await rariPool8EthPCVDeposit.deposit();

--- a/proposals/dao/compoundPCVDeposit.js
+++ b/proposals/dao/compoundPCVDeposit.js
@@ -1,0 +1,31 @@
+const IERC20 = artifacts.require('IERC20');
+
+const e18 = '000000000000000000';
+
+async function setup(addresses, oldContracts, contracts, logging) {}
+
+// The DAO steps for FIP-9, these must be done with Governor access control privileges
+async function run(addresses, oldContracts, contracts, logging = false) {
+  const {
+    rariPool8FeiAddress,
+    timelockAddress
+  } = addresses;
+
+  const {
+    rariPool8FeiPCVDeposit,
+    rariPool8EthPCVDeposit,
+    ethPCVDripper
+  } = contracts;
+  const rariPool8Fei = await IERC20.at(rariPool8FeiAddress);
+  const balanceOfRariFei = await rariPool8Fei.balanceOf(timelockAddress);
+
+  await rariPool8Fei.transfer(rariPool8FeiPCVDeposit.address, balanceOfRariFei, {from: timelockAddress});
+
+  await ethPCVDripper.withdrawETH(rariPool8EthPCVDeposit.address, `1000${e18}`);
+  
+  await rariPool8EthPCVDeposit.deposit();
+}
+
+async function teardown(addresses, oldContractAddresses, logging) {}
+
+module.exports = { setup, run, teardown };

--- a/test/pcv/ERC20CompoundPCVDeposit.test.js
+++ b/test/pcv/ERC20CompoundPCVDeposit.test.js
@@ -1,0 +1,119 @@
+const {
+  BN,
+  expectRevert,
+  expect,
+  getAddresses,
+  getCore,
+} = require('../helpers');
+      
+const ERC20CompoundPCVDeposit = artifacts.require('ERC20CompoundPCVDeposit');
+const MockCToken = artifacts.require('MockCToken');
+const MockERC20 = artifacts.require('MockERC20');
+
+describe('ERC20CompoundPCVDeposit', function () {
+  let userAddress;
+  let pcvControllerAddress;
+  let governorAddress;
+      
+  beforeEach(async function () {
+    ({
+      userAddress,
+      pcvControllerAddress,
+      governorAddress
+    } = await getAddresses());
+    
+    this.core = await getCore(true);
+  
+    this.token = await MockERC20.new();
+    this.cToken = await MockCToken.new(this.token.address, false);
+        
+    this.compoundPCVDeposit = await ERC20CompoundPCVDeposit.new(this.core.address, this.cToken.address, this.token.address);
+    this.depositAmount = new BN('1000000000000000000');
+  });
+      
+  describe('Deposit', function() {
+    describe('Paused', function() {
+      it('reverts', async function() {
+        await this.compoundPCVDeposit.pause({from: governorAddress});
+        await expectRevert(this.compoundPCVDeposit.deposit(), 'Pausable: paused');
+      });
+    });
+    
+    describe('Not Paused', function() {
+      beforeEach(async function() {
+        await this.token.mint(this.compoundPCVDeposit.address, this.depositAmount);
+      });
+  
+      it('succeeds', async function() {
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(new BN('0'));
+        await this.compoundPCVDeposit.deposit();
+        // Balance should increment with the new deposited cTokens underlying
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(this.depositAmount);
+        
+        // Held balance should be 0, now invested into Compound
+        expect(await this.token.balanceOf(this.compoundPCVDeposit.address)).to.be.bignumber.equal(new BN('0'));
+      });
+    });
+  });
+  
+  describe('Withdraw', function() {
+    describe('Paused', function() {
+      it('reverts', async function() {
+        await this.compoundPCVDeposit.pause({from: governorAddress});
+        await expectRevert(this.compoundPCVDeposit.withdraw(userAddress, this.depositAmount, {from: pcvControllerAddress}), 'Pausable: paused');
+      });
+    });
+  
+    describe('Not PCVController', function() {
+      it('reverts', async function() {
+        await expectRevert(this.compoundPCVDeposit.withdraw(userAddress, this.depositAmount, {from: userAddress}), 'CoreRef: Caller is not a PCV controller');
+      });
+    });
+  
+    describe('Not Paused', function() {
+      beforeEach(async function() {
+        await this.token.mint(this.compoundPCVDeposit.address, this.depositAmount);
+        await this.compoundPCVDeposit.deposit();
+      });
+  
+      it('succeeds', async function() {
+        const userBalanceBefore = await this.token.balanceOf(userAddress);
+        
+        // withdrawing should take balance back to 0
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(this.depositAmount);
+        await this.compoundPCVDeposit.withdraw(userAddress, this.depositAmount, {from: pcvControllerAddress});
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(new BN('0'));
+        
+        const userBalanceAfter = await this.token.balanceOf(userAddress);
+  
+        expect(userBalanceAfter.sub(userBalanceBefore)).to.be.bignumber.equal(this.depositAmount);
+      });
+    });
+  });
+  
+  describe('WithdrawERC20', function() {
+    describe('Not PCVController', function() {
+      it('reverts', async function() {
+        await expectRevert(this.compoundPCVDeposit.withdrawERC20(this.cToken.address, userAddress, this.depositAmount, {from: userAddress}), 'CoreRef: Caller is not a PCV controller');
+      });
+    });
+  
+    describe('From PCVController', function() {
+      beforeEach(async function() {
+        await this.token.mint(this.compoundPCVDeposit.address, this.depositAmount);
+        await this.compoundPCVDeposit.deposit();
+      });
+  
+      it('succeeds', async function() {
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(this.depositAmount);
+        // cToken exchange rate is 2 in the mock, so this would withdraw half of the cTokens
+        await this.compoundPCVDeposit.withdrawERC20(this.cToken.address, userAddress, this.depositAmount.div(new BN('4')), {from: pcvControllerAddress});        
+
+        // balance should also get cut in half
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(this.depositAmount.div(new BN('2')));
+  
+        expect(await this.cToken.balanceOf(userAddress)).to.be.bignumber.equal(this.depositAmount.div(new BN('4')));
+      });
+    });
+  });
+});

--- a/test/pcv/EthCompoundPCVDeposit.test.js
+++ b/test/pcv/EthCompoundPCVDeposit.test.js
@@ -1,0 +1,120 @@
+const {
+  web3,
+  BN,
+  expectRevert,
+  balance,
+  expect,
+  getAddresses,
+  getCore,
+} = require('../helpers');
+    
+const EthCompoundPCVDeposit = artifacts.require('EthCompoundPCVDeposit');
+const MockCToken = artifacts.require('MockCToken');
+  
+describe('EthCompoundPCVDeposit', function () {
+  let userAddress;
+  let pcvControllerAddress;
+  let governorAddress;
+    
+  beforeEach(async function () {
+    ({
+      userAddress,
+      pcvControllerAddress,
+      governorAddress
+    } = await getAddresses());
+  
+    this.core = await getCore(true);
+
+    this.cToken = await MockCToken.new(userAddress, true);
+      
+    this.compoundPCVDeposit = await EthCompoundPCVDeposit.new(this.core.address, this.cToken.address);
+
+    this.depositAmount = new BN('1000000000000000000');
+  });
+    
+  describe('Deposit', function() {
+    describe('Paused', function() {
+      it('reverts', async function() {
+        await this.compoundPCVDeposit.pause({from: governorAddress});
+        await expectRevert(this.compoundPCVDeposit.deposit(), 'Pausable: paused');
+      });
+    });
+  
+    describe('Not Paused', function() {
+      beforeEach(async function() {
+        await web3.eth.sendTransaction({from: userAddress, to: this.compoundPCVDeposit.address, value: this.depositAmount});
+      });
+
+      it('succeeds', async function() {
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(new BN('0'));
+        await this.compoundPCVDeposit.deposit();
+        // Balance should increment with the new deposited cTokens underlying
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(this.depositAmount);
+        
+        // Held balance should be 0, now invested into Compound
+        expect(await balance.current(this.compoundPCVDeposit.address)).to.be.bignumber.equal(new BN('0'));
+      });
+    });
+  });
+
+  describe('Withdraw', function() {
+    describe('Paused', function() {
+      it('reverts', async function() {
+        await this.compoundPCVDeposit.pause({from: governorAddress});
+        await expectRevert(this.compoundPCVDeposit.withdraw(userAddress, this.depositAmount, {from: pcvControllerAddress}), 'Pausable: paused');
+      });
+    });
+
+    describe('Not PCVController', function() {
+      it('reverts', async function() {
+        await expectRevert(this.compoundPCVDeposit.withdraw(userAddress, this.depositAmount, {from: userAddress}), 'CoreRef: Caller is not a PCV controller');
+      });
+    });
+
+    describe('Not Paused', function() {
+      beforeEach(async function() {
+        await web3.eth.sendTransaction({from: userAddress, to: this.compoundPCVDeposit.address, value: this.depositAmount});
+        await this.compoundPCVDeposit.deposit();
+      });
+
+      it('succeeds', async function() {
+        const userBalanceBefore = await balance.current(userAddress);
+        
+        // withdrawing should take balance back to 0
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(this.depositAmount);
+        await this.compoundPCVDeposit.withdraw(userAddress, this.depositAmount, {from: pcvControllerAddress});
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(new BN('0'));
+        
+        const userBalanceAfter = await balance.current(userAddress);
+
+        expect(userBalanceAfter.sub(userBalanceBefore)).to.be.bignumber.equal(this.depositAmount);
+      });
+    });
+  });
+
+  describe('WithdrawERC20', function() {
+    describe('Not PCVController', function() {
+      it('reverts', async function() {
+        await expectRevert(this.compoundPCVDeposit.withdrawERC20(this.cToken.address, userAddress, this.depositAmount, {from: userAddress}), 'CoreRef: Caller is not a PCV controller');
+      });
+    });
+
+    describe('From PCVController', function() {
+      beforeEach(async function() {
+        await web3.eth.sendTransaction({from: userAddress, to: this.compoundPCVDeposit.address, value: this.depositAmount});
+        await this.compoundPCVDeposit.deposit();
+      });
+
+      it('succeeds', async function() {
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(this.depositAmount);
+        // cToken exchange rate is 2 in the mock, so this would withdraw half of the cTokens
+        await this.compoundPCVDeposit.withdrawERC20(this.cToken.address, userAddress, this.depositAmount.div(new BN('4')), {from: pcvControllerAddress});        
+        
+        // balance should also get cut in half
+        expect(await this.compoundPCVDeposit.balance()).to.be.bignumber.equal(this.depositAmount.div(new BN('2')));
+
+        expect(await this.cToken.balanceOf(userAddress)).to.be.bignumber.equal(this.depositAmount.div(new BN('4')));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds 3 contracts to allow PCV Deposits and withdrawals into and from Compound-like protocols, including Rari Capital Fuse and CREAM:
* CompoundPCVDepositBase
* EthCompoundPCVDeposit
* ERC20CompoundPCVDeposit

