### PR TITLE
Add Mint Cap to Bonding Curve

### DIFF
--- a/contracts/bondingcurve/BondingCurve.sol
+++ b/contracts/bondingcurve/BondingCurve.sol
@@ -32,6 +32,9 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
     /// @notice the discount applied on top of peg before at Scale
     uint256 public override discount;
 
+    /// @notice the cap on how much FEI can be minted by the bonding curve
+    uint256 public override mintCap;
+
     uint256 public constant BASIS_POINTS_GRANULARITY = 10_000;
 
     /// @notice constructor
@@ -64,6 +67,7 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
         Timed(_duration)
         Incentivized(_incentive)
     {
+        _setMintCap(_scale); // default mint cap is scale
         _setScale(_scale);
         token = _token;
 
@@ -142,6 +146,11 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
         _setDuration(_frequency);
     }
 
+    /// @notice sets the mint cap for the bonding curve
+    function setMintCap(uint256 _mintCap) external override onlyGovernor {
+        _setMintCap(_mintCap);
+    }
+
     /// @notice sets the allocation of incoming PCV
     function setAllocation(
         address[] calldata allocations,
@@ -174,6 +183,11 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
     /// @notice a boolean signalling whether Scale has been reached
     function atScale() public view override returns (bool) {
         return totalPurchased >= scale;
+    }
+
+    /// @notice returns how close to the minting cap we are
+    function availableToMint() public view override returns (uint256) {
+        return mintCap - totalPurchased;
     }
 
     /// @notice return current instantaneous bonding curve price
@@ -229,6 +243,8 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
 
         amountOut = getAmountOut(amountIn);
 
+        require(availableToMint() >= amountOut, "BondingCurve: exceeds mint cap");
+
         _incrementTotalPurchased(amountOut);
         fei().mint(to, amountOut);
 
@@ -247,6 +263,15 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
         uint256 oldScale = scale;
         scale = newScale;
         emit ScaleUpdate(oldScale, newScale);
+    }
+
+    function _setMintCap(uint256 newMintCap) internal {
+        require(newMintCap != 0, "BondingCurve: zero mint cap");
+
+        uint256 oldMintCap = mintCap;
+        mintCap = newMintCap;
+
+        emit MintCapUpdate(oldMintCap, newMintCap);
     }
 
     /// @notice the bonding curve price multiplier used before Scale

--- a/contracts/bondingcurve/IBondingCurve.sol
+++ b/contracts/bondingcurve/IBondingCurve.sol
@@ -9,6 +9,8 @@ interface IBondingCurve {
 
     event ScaleUpdate(uint256 oldScale, uint256 newScale);
 
+    event MintCapUpdate(uint256 oldMint, uint256 newMint);
+
     event BufferUpdate(uint256 oldBuffer, uint256 newBuffer);
 
     event DiscountUpdate(uint256 oldDiscount, uint256 newDiscount);
@@ -45,6 +47,8 @@ interface IBondingCurve {
 
     function setIncentiveFrequency(uint256 newFrequency) external;
 
+    function setMintCap(uint256 newMintCap) external;
+
     // ----------- Getters -----------
 
     function getCurrentPrice() external view returns (Decimal.D256 memory);
@@ -68,4 +72,7 @@ interface IBondingCurve {
 
     function token() external view returns (IERC20);
 
+    function mintCap() external view returns (uint256);
+
+    function availableToMint() external view returns (uint256);
 }

--- a/test/bondingcurve/BondingCurve.test.js
+++ b/test/bondingcurve/BondingCurve.test.js
@@ -61,6 +61,8 @@ describe('BondingCurve', function () {
 
     await this.token.mint(userAddress, '1000000000000000000000000');
     await this.core.grantMinter(this.bondingCurve.address, {from: governorAddress});
+
+    await this.bondingCurve.setMintCap(this.scale.mul(new BN('10')), {from: governorAddress});
   });
   
   describe('Init', function() {
@@ -270,7 +272,16 @@ describe('BondingCurve', function () {
           });
         });
       });
-        
+      describe('Exceeding cap', function() {
+        it('reverts', async function() {
+          this.purchaseAmount = new BN('4000000000');
+          await this.token.approve(this.bondingCurve.address, this.purchaseAmount, {from: userAddress});
+          await expectRevert(
+            this.bondingCurve.purchase(userAddress, this.purchaseAmount, {from: userAddress}),
+            'BondingCurve: exceeds mint cap'
+          );
+        });
+      });
       describe('Crossing Scale', function() {
         beforeEach(async function() {
           this.purchaseAmount = new BN('400000000');

--- a/test/bondingcurve/EthBondingCurve.test.js
+++ b/test/bondingcurve/EthBondingCurve.test.js
@@ -48,6 +48,8 @@ describe('EthBondingCurve', function () {
       scale: '100000000000', buffer: '100', discount: '100', duration: this.incentiveDuration.toString(), incentive: this.incentiveAmount.toString(), pcvDeposits: [this.pcvDeposit1.address, this.pcvDeposit2.address], ratios: [9000, 1000]
     });
     await this.core.grantMinter(this.bondingCurve.address, {from: governorAddress});
+
+    await this.bondingCurve.setMintCap(this.scale.mul(new BN('10')), {from: governorAddress});
   });
 
   describe('Init', function() {
@@ -260,6 +262,15 @@ describe('EthBondingCurve', function () {
         });
       });
       
+      describe('Exceeding cap', function() {
+        it('reverts', async function() {
+          this.purchaseAmount = new BN('4000000000');
+          await expectRevert(
+            this.bondingCurve.purchase(userAddress, this.purchaseAmount, {from: userAddress, value: this.purchaseAmount}),
+            'BondingCurve: exceeds mint cap'
+          );
+        });
+      });
       describe('Crossing Scale', function() {
         beforeEach(async function() {
           this.purchaseAmount =  new BN('200000000');


### PR DESCRIPTION
Adds a cap on the amount of FEI minted by a bonding curve to mitigate the damage from infinite minting attacks and oracle malfunctions