### PR TITLE
Contract Admins

### DIFF
--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -18,11 +18,6 @@ contract Core is ICore, Permissions, Initializable {
     /// @notice the address of the TRIBE contract
     IERC20 public override tribe;
 
-    /// @notice the address of the GenesisGroup contract
-    address public override genesisGroup;
-    /// @notice determines whether in genesis period or not
-    bool public override hasGenesisGroupCompleted;
-
     function init() external override initializer {
         _setupGovernor(msg.sender);
         
@@ -45,17 +40,6 @@ contract Core is ICore, Permissions, Initializable {
         _setTribe(token);
     }
 
-    /// @notice sets Genesis Group address
-    /// @param _genesisGroup new genesis group address
-    function setGenesisGroup(address _genesisGroup)
-        external
-        override
-        onlyGovernor
-    {
-        genesisGroup = _genesisGroup;
-        emit GenesisGroupUpdate(_genesisGroup);
-    }
-
     /// @notice sends TRIBE tokens from treasury to an address
     /// @param to the address to send TRIBE to
     /// @param amount the amount of TRIBE to send
@@ -73,23 +57,6 @@ contract Core is ICore, Permissions, Initializable {
         _tribe.transfer(to, amount);
 
         emit TribeAllocation(to, amount);
-    }
-
-    /// @notice marks the end of the genesis period
-    /// @dev can only be called once
-    function completeGenesisGroup() external override {
-        require(
-            !hasGenesisGroupCompleted,
-            "Core: Genesis Group already complete"
-        );
-        require(
-            msg.sender == genesisGroup,
-            "Core: Caller is not Genesis Group"
-        );
-
-        hasGenesisGroupCompleted = true;
-
-        emit GenesisPeriodComplete(block.timestamp);
     }
 
     function _setFei(address token) internal {

--- a/contracts/core/ICore.sol
+++ b/contracts/core/ICore.sol
@@ -25,21 +25,11 @@ interface ICore is IPermissions {
 
     function setTribe(address token) external;
 
-    function setGenesisGroup(address _genesisGroup) external;
-
     function allocateTribe(address to, uint256 amount) external;
-
-    // ----------- Genesis Group only state changing api -----------
-
-    function completeGenesisGroup() external;
 
     // ----------- Getters -----------
 
     function fei() external view returns (IFei);
 
     function tribe() external view returns (IERC20);
-
-    function genesisGroup() external view returns (address);
-
-    function hasGenesisGroupCompleted() external view returns (bool);
 }

--- a/contracts/core/IPermissions.sol
+++ b/contracts/core/IPermissions.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.4;
 
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
 /// @title Permissions interface
 /// @author Fei Protocol
-interface IPermissions {
+interface IPermissions is IAccessControl {
     // ----------- Governor only state changing api -----------
 
     function createRole(bytes32 role, bytes32 adminRole) external;
@@ -43,4 +45,15 @@ interface IPermissions {
     function isGuardian(address _address) external view returns (bool);
 
     function isPCVController(address _address) external view returns (bool);
+
+    function GUARDIAN_ROLE() external view returns (bytes32);
+
+    function GOVERN_ROLE() external view returns (bytes32);
+
+    function BURNER_ROLE() external view returns (bytes32);
+
+    function MINTER_ROLE() external view returns (bytes32);
+
+    function PCV_CONTROLLER_ROLE() external view returns (bytes32);
+
 }

--- a/contracts/core/Permissions.sol
+++ b/contracts/core/Permissions.sol
@@ -7,11 +7,11 @@ import "./IPermissions.sol";
 /// @title Access control module for Core
 /// @author Fei Protocol
 contract Permissions is IPermissions, AccessControlEnumerable {
-    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
-    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-    bytes32 public constant PCV_CONTROLLER_ROLE = keccak256("PCV_CONTROLLER_ROLE");
-    bytes32 public constant GOVERN_ROLE = keccak256("GOVERN_ROLE");
-    bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
+    bytes32 public constant override BURNER_ROLE = keccak256("BURNER_ROLE");
+    bytes32 public constant override MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant override PCV_CONTROLLER_ROLE = keccak256("PCV_CONTROLLER_ROLE");
+    bytes32 public constant override GOVERN_ROLE = keccak256("GOVERN_ROLE");
+    bytes32 public constant override GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
 
     constructor() {
         // Appointed as a governor so guardian can have indirect access to revoke ability

--- a/contracts/mock/MockCoreRef.sol
+++ b/contracts/mock/MockCoreRef.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.4;
 import "../refs/CoreRef.sol";
 
 contract MockCoreRef is CoreRef {
-	constructor(address core) CoreRef(core) {}
+	constructor(address core) CoreRef(core) {
+		_setContractAdminRole(keccak256("MOCK_CORE_REF_ADMIN"));
+	}
 
 	function testMinter() public view onlyMinter {}
 
@@ -13,5 +15,7 @@ contract MockCoreRef is CoreRef {
 	function testPCVController() public view onlyPCVController {}
 
 	function testGovernor() public view onlyGovernor {}
+
+	function testOnlyGovernorOrAdmin() public view onlyGovernorOrAdmin {}
 }
 

--- a/contracts/refs/ICoreRef.sol
+++ b/contracts/refs/ICoreRef.sol
@@ -10,9 +10,15 @@ interface ICoreRef {
 
     event CoreUpdate(address indexed oldCore, address indexed newCore);
 
+    event ContractAdminRoleUpdate(bytes32 indexed oldContractAdminRole, bytes32 indexed newContractAdminRole);
+
     // ----------- Governor only state changing api -----------
 
     function setCore(address newCore) external;
+
+    function setContractAdminRole(bytes32 newContractAdminRole) external;
+
+    // ----------- Governor or Guardian only state changing api -----------
 
     function pause() external;
 
@@ -29,4 +35,8 @@ interface ICoreRef {
     function feiBalance() external view returns (uint256);
 
     function tribeBalance() external view returns (uint256);
+
+    function CONTRACT_ADMIN_ROLE() external view returns (bytes32);
+
+    function isContractAdmin(address admin) external view returns (bool);
 }

--- a/test/core/Core.test.js
+++ b/test/core/Core.test.js
@@ -476,6 +476,16 @@ describe('Core', function () {
           await expectRevert(this.core.revokeOverride(this.governorRole, governorAddress, {from: guardianAddress}), 'Permissions: Guardian cannot revoke governor');
           expect(await this.core.isGovernor(governorAddress)).to.be.equal(true);
         });
+
+        it('can revoke contract admin', async function() {
+          this.role = await this.coreRef.CONTRACT_ADMIN_ROLE();
+          await this.core.createRole(this.role, await this.core.GOVERN_ROLE(), {from: governorAddress});
+          await this.core.grantRole(this.role, guardianAddress, {from: governorAddress});
+          expect(await this.core.hasRole(this.role, guardianAddress)).to.be.equal(true);
+
+          await this.core.revokeOverride(this.role, guardianAddress, {from: guardianAddress});
+          expect(await this.core.hasRole(this.role, guardianAddress)).to.be.equal(false);
+        });
       });
     });
   });
@@ -531,9 +541,9 @@ describe('Core', function () {
         await expectRevert(this.coreRef.testGovernor({from: guardianAddress}), 'CoreRef: Caller is not a governor');
       });
 
-	  it('onlyGovernorOrAdmin succeeds', async function() {
+      it('onlyGovernorOrAdmin succeeds', async function() {
         await this.coreRef.testOnlyGovernorOrAdmin({from: guardianAddress});
-	  });
+      });
 
       it('onlyPCVController reverts', async function() {
         await expectRevert(this.coreRef.testPCVController({from: guardianAddress}), 'CoreRef: Caller is not a PCV controller');

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -58,7 +58,6 @@ async function getAddresses() {
 async function getCore(complete) {
   const {
     governorAddress,
-    genesisGroup,
     pcvControllerAddress,
     minterAddress,
     burnerAddress,
@@ -66,11 +65,6 @@ async function getCore(complete) {
   } = await getAddresses();
   const core = await Core.new({ from: governorAddress });
   await core.init({ from: governorAddress });
-
-  await core.setGenesisGroup(genesisGroup, { from: governorAddress });
-  if (complete) {
-    await core.completeGenesisGroup({ from: genesisGroup });
-  }
 
   await core.grantMinter(minterAddress, { from: governorAddress });
   await core.grantBurner(burnerAddress, { from: governorAddress });


### PR DESCRIPTION
This PR adds a new access control role and modifier available to every contract in the system called the Contract Admin

The Contract Admin is a role grantable by the Governor through the same Core access control module. The intention is for it to be used in "optimistic governance". The security assumptions will be different from the Guardian. The Guardian is intended to act instantly and only pause functionality.

Contract Admins should be either a multisig gated by a timelock or an autonomous smart contract.

For the former case, they can act without explicit DAO approval but the DAO can reject any proposal.

The first use case for optimistic governance will be the TribalChief, and future use cases can include FeiRari, portfolio composition/rebalancing, and parameterization changes.