### PR TITLE
SnapshotDelegator

### DIFF
--- a/contract-addresses/mainnetAddresses.json
+++ b/contract-addresses/mainnetAddresses.json
@@ -29,6 +29,7 @@
     "wethERC20Address": { "artifact": "IERC20", "address":  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"},
     "stethAddress" : { "artifact": "IERC20", "address":  "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"},
     "indexAddress" : { "artifact": "IERC20", "address" : "0x0954906da0Bf32d5479e25f46056d22f08464cab" },
+    "snapshotDelegateRegistry" : { "artifact": "DelegateRegistry", "address" : "0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446" },
     "defiPulseOTCAddress" : { "address" : "0x5c29aa6761803bcfda7f683eaa0ff9bddda3649d" },
     "communalFarmAddress" : { "address":  "0x0639076265e9f88542C91DCdEda65127974A5CA5"},
     "uniswapRouterAddress": { "address":  "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"},

--- a/contracts/pcv/PCVDeposit.sol
+++ b/contracts/pcv/PCVDeposit.sol
@@ -19,6 +19,14 @@ abstract contract PCVDeposit is IPCVDeposit, CoreRef {
       address to, 
       uint256 amount
     ) public override onlyPCVController {
+        _withdrawERC20(token, to, amount);
+    }
+
+    function _withdrawERC20(
+      address token, 
+      address to, 
+      uint256 amount
+    ) internal {
         IERC20(token).safeTransfer(to, amount);
         emit WithdrawERC20(msg.sender, token, to, amount);
     }

--- a/contracts/pcv/snapshot/SnapshotDelegatorPCVDeposit.sol
+++ b/contracts/pcv/snapshot/SnapshotDelegatorPCVDeposit.sol
@@ -51,7 +51,6 @@ contract SnapshotDelegatorPCVDeposit is PCVDeposit {
         external
         override
         onlyPCVController
-        whenNotPaused
     {
         _withdrawERC20(address(token), to, amountUnderlying);
     }

--- a/contracts/pcv/snapshot/SnapshotDelegatorPCVDeposit.sol
+++ b/contracts/pcv/snapshot/SnapshotDelegatorPCVDeposit.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "../PCVDeposit.sol";
+
+interface DelegateRegistry {
+    function setDelegate(bytes32 id, address delegate) external;
+
+    function clearDelegate(bytes32 id) external;
+
+    function delegation(address delegator, bytes32 id) external view returns(address delegatee);
+}
+
+/// @title Snapshot Delegator PCV Deposit
+/// @author Fei Protocol
+contract SnapshotDelegatorPCVDeposit is PCVDeposit {
+
+    event DelegateUpdate(address indexed oldDelegate, address indexed newDelegate);
+
+    /// @notice the Gnosis delegate registry used by snapshot
+    DelegateRegistry public constant DELEGATE_REGISTRY = DelegateRegistry(0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446);
+    
+    /// @notice the token that is being used for snapshot
+    IERC20 public immutable token;
+
+    /// @notice the keccak encoded spaceId of the snapshot space
+    bytes32 public spaceId;
+    
+    /// @notice the snapshot delegate for the deposit
+    address public delegate;
+
+    /// @notice Snapshot Delegator PCV Deposit constructor
+    /// @param _core Fei Core for reference
+    /// @param _token snapshot token
+    /// @param _spaceId the id (or ENS name) of the snapshot space
+    constructor(
+        address _core,
+        IERC20 _token,
+        bytes32 _spaceId,
+        address _initialDelegate
+    ) CoreRef(_core) {
+        token = _token;
+        spaceId = _spaceId;
+        _delegate(_initialDelegate);
+    }
+
+    /// @notice withdraw tokens from the PCV allocation
+    /// @param amountUnderlying of tokens withdrawn
+    /// @param to the address to send PCV to
+    function withdraw(address to, uint256 amountUnderlying)
+        external
+        override
+        onlyPCVController
+        whenNotPaused
+    {
+        _withdrawERC20(address(token), to, amountUnderlying);
+    }
+
+    /// @notice no-op
+    function deposit() external override {}
+
+    /// @notice returns total balance of PCV in the Deposit
+    function balance() public view override returns (uint256) {
+        return token.balanceOf(address(this));
+    }
+
+    /// @notice sets the snapshot delegate
+    /// @dev callable by governor or admin
+    function setDelegate(address newDelegate) external onlyGovernorOrAdmin {
+        _delegate(newDelegate);
+    }
+
+    /// @notice clears the delegate from snapshot
+    /// @dev callable by governor or guardian
+    function clearDelegate() external onlyGuardianOrGovernor {
+        address oldDelegate = delegate;
+        DELEGATE_REGISTRY.clearDelegate(spaceId);
+
+        emit DelegateUpdate(oldDelegate, address(0));
+    }
+
+    function _delegate(address newDelegate) internal {
+        address oldDelegate = delegate;
+        DELEGATE_REGISTRY.setDelegate(spaceId, newDelegate);
+        delegate = newDelegate;
+
+        emit DelegateUpdate(oldDelegate, newDelegate);
+    }
+}

--- a/deploy/indexOTC.js
+++ b/deploy/indexOTC.js
@@ -6,7 +6,7 @@ const SnapshotDelegatorPCVDeposit = artifacts.require('SnapshotDelegatorPCVDepos
 const e18 = '000000000000000000';
 const e15 =    '000000000000000';
 const indexSpaceId = formatBytes32String('index-coop.eth');
-const indexDelegate = '0xe0ac4559739bD36f0913FB0A3f5bFC19BCBaCD52';
+const indexDelegate = '0xb647055A9915bF9c8021a684E175A353525b9890'; // Matthew Graham delegation
 
 async function deploy(deployAddress, addresses, logging = false) {
   const {

--- a/deploy/indexOTC.js
+++ b/deploy/indexOTC.js
@@ -1,10 +1,16 @@
+import { formatBytes32String } from '@ethersproject/strings';
+
 const OtcEscrow = artifacts.require('OtcEscrow');
+const SnapshotDelegatorPCVDeposit = artifacts.require('SnapshotDelegatorPCVDeposit');
 
 const e18 = '000000000000000000';
 const e15 =    '000000000000000';
+const indexSpaceId = formatBytes32String('index-coop.eth');
+const indexDelegate = '0xe0ac4559739bD36f0913FB0A3f5bFC19BCBaCD52';
 
 async function deploy(deployAddress, addresses, logging = false) {
   const {
+    coreAddress,
     feiAddress,
     wethAddress,
     tribeAddress,
@@ -14,7 +20,7 @@ async function deploy(deployAddress, addresses, logging = false) {
   } = addresses;
 
   if (
-    !wethAddress || !feiAddress || !tribeAddress || !indexAddress || !defiPulseOTCAddress
+    !coreAddress || !wethAddress || !feiAddress || !tribeAddress || !indexAddress || !defiPulseOTCAddress
   ) {
     throw new Error('An environment variable contract address is not set');
   }
@@ -52,10 +58,20 @@ async function deploy(deployAddress, addresses, logging = false) {
   );
   logging ? console.log('FEI OTC Escrow deployed to: ', feiOTCEscrow.address) : undefined;
   
+  const indexDelegator = await SnapshotDelegatorPCVDeposit.new(
+    coreAddress,
+    indexAddress,
+    indexSpaceId,
+    indexDelegate
+  );
+
+  logging ? console.log('Index Delegator deployed to: ', indexDelegator.address) : undefined;
+  
   return {
     ethOTCEscrow,
     tribeOTCEscrow,
-    feiOTCEscrow
+    feiOTCEscrow,
+    indexDelegator
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,6 +390,34 @@
         "@ethereumjs/tx": "^3.3.0",
         "ethereumjs-util": "^7.1.0",
         "merkle-patricia-tree": "^4.2.0"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "@ethereumjs/blockchain": {
@@ -408,6 +436,32 @@
         "semaphore-async-await": "^1.5.1"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -430,6 +484,34 @@
       "requires": {
         "crc-32": "^1.2.0",
         "ethereumjs-util": "^7.1.0"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "@ethereumjs/ethash": {
@@ -443,12 +525,38 @@
         "miller-rabin": "^4.0.0"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
         "buffer-xor": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
           "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
           "requires": {
             "safe-buffer": "^5.1.1"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
           }
         }
       }
@@ -460,6 +568,34 @@
       "requires": {
         "@ethereumjs/common": "^2.4.0",
         "ethereumjs-util": "^7.1.0"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "@ethereumjs/vm": {
@@ -480,6 +616,34 @@
         "merkle-patricia-tree": "^4.2.0",
         "rustbn.js": "~0.2.0",
         "util.promisify": "^1.0.1"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "@ethersproject/abi": {
@@ -5898,39 +6062,6 @@
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.3"
           }
-        }
-      }
-    },
-    "ethereumjs-util": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
-      "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
-      "requires": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.4"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "@types/node": {
-          "version": "16.3.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
-          "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA=="
-        },
-        "bn.js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
         }
       }
     },
@@ -15508,6 +15639,11 @@
             "@types/node": "*"
           }
         },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
         "commander": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
@@ -15519,6 +15655,19 @@
           "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
           }
         },
         "fs-extra": {
@@ -16846,6 +16995,34 @@
         "readable-stream": "^3.6.0",
         "rlp": "^2.2.4",
         "semaphore-async-await": "^1.5.1"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "methods": {
@@ -20865,6 +21042,32 @@
         "web3-utils": "1.4.0"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "AGPL-3.0-only",
   "dependencies": {
     "@chainlink/contracts": "^0.1.7",
+    "@ethersproject/strings": "^5.4.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-truffle5": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/proposals/description/indexOTC.json
+++ b/proposals/description/indexOTC.json
@@ -69,6 +69,16 @@
             "method": "swap()",
             "arguments": [],
             "description": "Swap TRIBE OTC"
+        },
+        {
+            "address": "0x0954906da0Bf32d5479e25f46056d22f08464cab",
+            "values": "0",
+            "method": "transfer(address,uint256)",
+            "arguments": [
+                "TBD",
+                "100000000000000000000000"
+            ],
+            "description": "Transfer 100k INDEX to snapshot delegator"
         }
     ],
     "proposal_calldata": ""


### PR DESCRIPTION
To vote on snapshot, you need a private key, therefore contracts are excluded.

In order to use the INDEX from the potential OTC deal, we'd need to use the snapshot delegate registry to appoint a proxy EOA. https://docs.snapshot.org/guides/delegation

This PR introduces a snapshot delegator PCV deposit with the following features:
- delegation
- Optimistic approval admin support for re-delegation
- Guardian support for undelegation

It also updates the indexOTC DAO proposal with a transfer of INDEX from the DAO to the snapshotDelegator