### PR TITLE
Weth PCV Deposit

### DIFF
--- a/contracts/pcv/utils/WethPCVDeposit.sol
+++ b/contracts/pcv/utils/WethPCVDeposit.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
+import "../PCVDeposit.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+/// @title base class for a WethPCVDeposit PCV Deposit
+/// @author Fei Protocol
+abstract contract WethPCVDeposit is PCVDeposit {
+
+    /// @notice WETH9 address
+    IWETH public constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
+	/// @notice Empty callback on ETH reception	
+    receive() external virtual payable {}	
+
+    /// @notice Wraps all ETH held by the contract to WETH	
+    /// Anyone can call it	
+    function wrapETH() public {	
+        IWETH(WETH).deposit{value: address(this).balance}();	
+    }
+
+    /// @notice deposit
+    function deposit() external override virtual {
+      // wrap any ETH
+      if (address(this).balance != 0) {
+        wrapETH();
+      }
+    }
+
+    /// @notice withdraw ETH from the contract
+    /// @param to address to send ETH
+    /// @param amountOut amount of ETH to send
+    function withdrawETH(address payable to, uint256 amountOut) external override onlyPCVController {
+        IWETH(WETH).withdraw(amountOut);
+        Address.sendValue(to, amountOut);
+        emit WithdrawETH(msg.sender, to, amountOut);
+    }
+}

--- a/contracts/pcv/utils/WethPCVDeposit.sol
+++ b/contracts/pcv/utils/WethPCVDeposit.sol
@@ -18,15 +18,15 @@ abstract contract WethPCVDeposit is PCVDeposit {
     /// @notice Wraps all ETH held by the contract to WETH	
     /// Anyone can call it	
     function wrapETH() public {	
-        IWETH(WETH).deposit{value: address(this).balance}();	
+      uint256 ethBalance = address(this).balance;
+      if (ethBalance != 0) {
+        IWETH(WETH).deposit{value: ethBalance}();	
+      }
     }
 
     /// @notice deposit
-    function deposit() external override virtual {
-      // wrap any ETH
-      if (address(this).balance != 0) {
+    function deposit() external override virtual {      
         wrapETH();
-      }
     }
 
     /// @notice withdraw ETH from the contract

--- a/contracts/pcv/utils/WethPCVDeposit.sol
+++ b/contracts/pcv/utils/WethPCVDeposit.sol
@@ -8,31 +8,35 @@ import "@openzeppelin/contracts/utils/Address.sol";
 /// @title base class for a WethPCVDeposit PCV Deposit
 /// @author Fei Protocol
 abstract contract WethPCVDeposit is PCVDeposit {
-
     /// @notice WETH9 address
-    IWETH public constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    IWETH public constant WETH =
+        IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
-	/// @notice Empty callback on ETH reception	
-    receive() external virtual payable {}	
+    /// @notice Empty callback on ETH reception
+    receive() external payable virtual {}
 
-    /// @notice Wraps all ETH held by the contract to WETH	
-    /// Anyone can call it	
-    function wrapETH() public {	
-      uint256 ethBalance = address(this).balance;
-      if (ethBalance != 0) {
-        IWETH(WETH).deposit{value: ethBalance}();	
-      }
+    /// @notice Wraps all ETH held by the contract to WETH
+    /// Anyone can call it
+    function wrapETH() public {
+        uint256 ethBalance = address(this).balance;
+        if (ethBalance != 0) {
+            IWETH(WETH).deposit{value: ethBalance}();
+        }
     }
 
     /// @notice deposit
-    function deposit() external override virtual {      
+    function deposit() external virtual override {
         wrapETH();
     }
 
     /// @notice withdraw ETH from the contract
     /// @param to address to send ETH
     /// @param amountOut amount of ETH to send
-    function withdrawETH(address payable to, uint256 amountOut) external override onlyPCVController {
+    function withdrawETH(address payable to, uint256 amountOut)
+        external
+        override
+        onlyPCVController
+    {
         IWETH(WETH).withdraw(amountOut);
         Address.sendValue(to, amountOut);
         emit WithdrawETH(msg.sender, to, amountOut);

--- a/test/pcv/PCVSwapperUniswap.test.js
+++ b/test/pcv/PCVSwapperUniswap.test.js
@@ -38,7 +38,7 @@ describe('PCVSwapperUniswap', function () {
     } = await getAddresses());
 
     this.core = await getCore(true);
-    this.weth = await MockWeth.new();
+    this.weth = await MockWeth.at('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
     this.fei = await Fei.at(await this.core.fei());
     this.pair = await MockPair.new(this.fei.address, this.weth.address);
     await this.pair.setReserves(`62500000${e18}`, `25000${e18}`);
@@ -51,7 +51,6 @@ describe('PCVSwapperUniswap', function () {
     this.swapper = await PCVSwapperUniswap.new(
       this.core.address, // core
       this.pair.address, // pair
-      this.weth.address, // weth
       {
         _oracle: this.oracle.address, // oracle
         _backupOracle: this.oracle.address, // backup oracle
@@ -182,7 +181,7 @@ describe('PCVSwapperUniswap', function () {
           // to solve this situation, swapper.wrapETH() should be called before withdraw.
           await expectRevert(
             this.swapper.withdrawETH(userAddress, `15${e18}`, {from: pcvControllerAddress}),
-            'ERC20: burn amount exceeds balance'
+            'revert'
           );
         });
         it('withdrawERC20() emit WithdrawERC20', async function() {


### PR DESCRIPTION
Refactors some WETH-related code to allow for more modular PCV components where WETH is needed

This will be useful for an Aave ETH PCV deposit because Aave uses WETH