### PR TITLE
Collateralization Oracle (v2)

### DIFF
--- a/contracts/mock/MockCollateralizationOracle.sol
+++ b/contracts/mock/MockCollateralizationOracle.sol
@@ -9,7 +9,7 @@ contract MockCollateralizationOracle is MockOracle {
 
     uint256 public pcvValue = 5e20;
 
-    constructor(uint256 exchangeRate) 
+    constructor(uint256 exchangeRate)
         MockOracle(exchangeRate)
     {
     }

--- a/contracts/mock/MockOracleCoreRef.sol
+++ b/contracts/mock/MockOracleCoreRef.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "./MockOracle.sol";
+import "./MockCoreRef.sol";
+
+contract MockOracleCoreRef is MockOracle, MockCoreRef {
+    constructor(address core, uint256 usdPerEth) MockCoreRef(core) MockOracle(usdPerEth) {}
+}

--- a/contracts/mock/MockPCVDepositV2.sol
+++ b/contracts/mock/MockPCVDepositV2.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "../pcv/IPCVDepositV2.sol";
+
+contract MockPCVDepositV2 is IPCVDepositV2 {
+
+    address public override balanceReportedIn;
+    uint256 public override resistantBalance;
+    uint256 public override resistantProtocolOwnedFei;
+
+    constructor(address _token, uint256 _resistantBalance, uint256 _resistantProtocolOwnedFei) {
+        balanceReportedIn = _token;
+        resistantBalance = _resistantBalance;
+        resistantProtocolOwnedFei = _resistantProtocolOwnedFei;
+    }
+
+    function set(uint256 _resistantBalance, uint256 _resistantProtocolOwnedFei) public {
+        resistantBalance = _resistantBalance;
+        resistantProtocolOwnedFei = _resistantProtocolOwnedFei;
+    }
+
+    // IPCVDeposit V1
+    function deposit() external override {}
+    function withdraw(address to, uint256 amount) external override {}
+    function withdrawERC20(address token, address to, uint256 amount) external override {}
+    function withdrawETH(address payable to, uint256 amount) external override {}
+    function balance() external override view returns (uint256) {
+        return resistantBalance;
+    }
+}

--- a/contracts/mock/MockPCVDepositV2.sol
+++ b/contracts/mock/MockPCVDepositV2.sol
@@ -1,15 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.4;
 
+import "../refs/CoreRef.sol";
 import "../pcv/IPCVDepositV2.sol";
 
-contract MockPCVDepositV2 is IPCVDepositV2 {
+contract MockPCVDepositV2 is IPCVDepositV2, CoreRef {
 
     address public override balanceReportedIn;
-    uint256 public override resistantBalance;
-    uint256 public override resistantProtocolOwnedFei;
 
-    constructor(address _token, uint256 _resistantBalance, uint256 _resistantProtocolOwnedFei) {
+    uint256 private resistantBalance;
+    uint256 private resistantProtocolOwnedFei;
+
+    constructor(
+      address _core,
+      address _token,
+      uint256 _resistantBalance,
+      uint256 _resistantProtocolOwnedFei
+    ) CoreRef(_core) {
         balanceReportedIn = _token;
         resistantBalance = _resistantBalance;
         resistantProtocolOwnedFei = _resistantProtocolOwnedFei;
@@ -18,6 +25,11 @@ contract MockPCVDepositV2 is IPCVDepositV2 {
     function set(uint256 _resistantBalance, uint256 _resistantProtocolOwnedFei) public {
         resistantBalance = _resistantBalance;
         resistantProtocolOwnedFei = _resistantProtocolOwnedFei;
+    }
+
+    // gets the resistant token balance and protocol owned fei of this deposit
+    function balanceAndFei() external view override returns (uint256, uint256) {
+        return (resistantBalance, resistantProtocolOwnedFei);
     }
 
     // IPCVDeposit V1

--- a/contracts/mock/MockPCVDepositV2.sol
+++ b/contracts/mock/MockPCVDepositV2.sol
@@ -28,7 +28,7 @@ contract MockPCVDepositV2 is IPCVDepositV2, CoreRef {
     }
 
     // gets the resistant token balance and protocol owned fei of this deposit
-    function balanceAndFei() external view override returns (uint256, uint256) {
+    function resistantBalanceAndFei() external view override returns (uint256, uint256) {
         return (resistantBalance, resistantProtocolOwnedFei);
     }
 

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -308,8 +308,9 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     ///         Controlled Value) than the circulating (user-owned) FEI, i.e.
     ///         a positive Protocol Equity.
     ///         Note: the validity status is ignored in this function.
-    function isOvercollateralized() external view override whenNotPaused returns (bool) {
-        (,, uint256 _protocolEquity,) = pcvStats();
+    function isOvercollateralized() external override view whenNotPaused returns (bool) {
+        (,, uint256 _protocolEquity, bool _valid) = pcvStats();
+        require(_valid, "CollateralizationOracle: reading is invalid");
         return _protocolEquity > 0;
     }
 }

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -42,7 +42,7 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     address[] public tokensInPcv;
     /// @notice Map to know if a given token is in the PCV. Used like an indexed
     ///         version of the tokensInPcv array.
-    mapping(address => uint8) public isTokenInPcv;
+    mapping(address => bool) public isTokenInPcv;
 
     // ----------- Constructor -----------
 
@@ -75,8 +75,8 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
         // update maps & arrays for faster access
         depositToToken[_deposit] = _token;
         tokenToDeposits[_token].push(_deposit);
-        if (isTokenInPcv[_token] == 0) {
-          isTokenInPcv[_token] = 1;
+        if (isTokenInPcv[_token] == false) {
+          isTokenInPcv[_token] = true;
           tokensInPcv.push(_token);
         }
 
@@ -110,7 +110,7 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
         // if it was the last deposit to have this token, remove this token from
         // the arrays also
         if (tokenToDeposits[_token].length == 0) {
-          isTokenInPcv[_token] = 0;
+          isTokenInPcv[_token] = false;
           uint256 _nTokensInPcv = tokensInPcv.length;
           found = false;
           for (uint256 i = 0; !found && i < _nTokensInPcv; i++) {

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "./IOracle.sol";
+import "../refs/CoreRef.sol";
+import "../pcv/IPCVDepositV2.sol";
+
+/// @title Fei Protocol's Collateralization Oracle
+/// @author eswak
+/// @notice Reads a list of PCVDeposit that report their amount of collateral
+///         and the amount of protocol-owned FEI they manage, to deduce the
+///         protocol-wide collateralization ratio.
+///         The protocol collateralization ratio is defined as the total USD
+///         value of assets held in the PCV, minus the circulating FEI.
+///         The circulating FEI is defined as the total FEI supply, minus the
+///         protocol-owned FEI managed by the various deposits.
+contract CollateralizationOracle is CoreRef {
+    using Decimal for Decimal.D256;
+
+    // ----------- Events -----------
+
+    event DepositAdd(address indexed _from, address _deposit);
+    event DepositRemove(address indexed _from, address _deposit);
+    event OracleSet(address indexed _from, address _token, address _oracle);
+
+    // ----------- Properties -----------
+
+    /// @notice array of PCVDeposits to inspect
+    address[] public pcvDeposits;
+
+    /// @notice map of oracles to use to get USD values of assets held in
+    ///         PCV deposits. This map is used to get the oracle address from
+    ///         and ERC20 address.
+    mapping(address => address) public oracles;
+
+    // ----------- Constructor -----------
+
+    /// @notice CollateralizationOracle constructor
+    /// @param _core Fei Core for reference
+    constructor(
+        address _core
+    ) CoreRef(_core) {}
+
+    // ----------- State-changing methods -----------
+
+    /// @notice Add a PCVDeposit to the list of deposits inspected by the
+    ///         collateralization ratio oracle.
+    ///         note : this function reverts of the deposit is already in the list.
+    /// @param _deposit : the PCVDeposit to add t othe list.
+    function addDeposit(address _deposit) external onlyGovernor {
+        // flag to indicate of the given _deposit has been found in the list
+        // of PCVdeposits declared in this contract.
+        bool found = false;
+        for (uint256 i = 0; i < pcvDeposits.length; i++) {
+            if (pcvDeposits[i] == _deposit) {
+                found = true;
+            }
+        }
+
+        // if the PCVDeposit is already listed, revert.
+        require(!found, "CollateralizationOracle: add _deposit duplicate");
+
+        // add the PCVDeposit to the list
+        pcvDeposits.push(_deposit);
+
+        // emit event
+        emit DepositAdd(msg.sender, _deposit);
+    }
+
+    /// @notice Remove a PCVDeposit from the list of deposits inspected by
+    ///         the collateralization ratio oracle.
+    ///         note : this function reverts if the input deposit is not found.
+    /// @param _deposit : the PCVDeposit address to remove from the list.
+    function removeDeposit(address _deposit) external onlyGovernor {
+        // flag to indicate of the given _deposit has been found in the list
+        // of PCVdeposits declared in this contract.
+        bool found = false;
+
+        // If the PCVDeposit to remove is last in the array, no need to loop.
+        if (pcvDeposits[pcvDeposits.length - 1] == _deposit) {
+            found = true;
+        }
+        // loop through PCVDeposits to find the given deposit, and remove it
+        // from the array if found
+        else {
+            for (uint256 i = 0; i < pcvDeposits.length; i++) {
+                if (pcvDeposits[i] == _deposit) {
+                    found = true;
+                }
+
+                if (found) {
+                    pcvDeposits[i] = pcvDeposits[i + 1];
+                }
+            }
+        }
+
+        // revert if the deposit has not been found
+        require(found, "CollateralizationOracle: remove _deposit not found");
+
+        // remove last element from the array of deposits
+        pcvDeposits.pop();
+
+        // emit event
+        emit DepositRemove(msg.sender, _deposit);
+    }
+
+    /// @notice Set the price feed oracle (in USD) for a given asset.
+    /// @param _token : the asset to add price oracle for
+    /// @param _oracle : price feed oracle for the given asset
+    function setOracle(address _token, address _oracle) external onlyGovernor {
+        // add oracle to the map(ERC20Address) => OracleAddress
+        oracles[_token] = _oracle;
+
+        // emit event
+        emit OracleSet(msg.sender, _token, _oracle);
+    }
+
+    // ----------- View/Pure methods -----------
+
+    /// @notice Get the current collateralization ratio of the protocol.
+    /// @return _collateralRatio the current collateral ratio of the protocol,
+    ///         expressed on a 1e18 basis.
+    /// @return _protocolControlledValue the total USD value of all assets held
+    ///         by the protocol, expressed on a 1e18 basis.
+    /// @return _circulatingFei the total amount of FEI circulating (i.e. not
+    ///         owned by the protocol).
+    function read() external view returns (uint256, uint256, uint256) {
+        // The total amount of FEI controlled (owned) by the protocol
+        uint256 _protocolControlledFei = 0;
+        // The total USD value of assets held in the PCV
+        uint256 _protocolControlledValue = 0;
+
+        // For each PCVDeposit...
+        for (uint256 i = 0; i < pcvDeposits.length; i++) {
+            IPCVDepositV2 _deposit = IPCVDepositV2(pcvDeposits[i]);
+
+            // Get the asset this PCVDeposit reports its balance, and read a
+            // price feed to get the USD value of this asset.
+            address _token = _deposit.balanceReportedIn();
+            require(oracles[_token] != address(0), "CollateralizationOracle: oracle not found");
+            (Decimal.D256 memory _price, bool _valid) = IOracle(oracles[_token]).read();
+            require(_valid, "CollateralizationOracle: oracle invalid");
+
+            // Increment the total protocol controlled value by the USD value of
+            // the asset held in this PCVDeposit
+            _protocolControlledValue += _price.mul(_deposit.resistantBalance()).asUint256();
+
+            // Increment the total protocol controlled FEI by the amount of FEI
+            // held by this PCVDeposit
+            _protocolControlledFei += _deposit.resistantProtocolOwnedFei();
+        }
+
+        // The circulating FEI is defined as the total FEI supply, minus the
+        // protocol-owned FEI managed by the various deposits.
+        uint256 _circulatingFei = fei().totalSupply() - _protocolControlledFei;
+
+        // The protocol collateralization ratio is defined as the total USD
+        // value of assets held in the PCV, minus the circulating FEI.
+        uint256 _collateralRatio = _protocolControlledValue * 1e18 / _circulatingFei;
+
+        // return values
+        return (_collateralRatio, _protocolControlledValue, _circulatingFei);
+    }
+}

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -266,13 +266,6 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
             bool _oracleValid = false; // validity flag of oracle.read()
             Decimal.D256 memory _oraclePrice = Decimal.zero();
 
-            // Use a price of 0 for FEI, because the deposits that report their
-            // balance in FEI should add 0$ to the Protocol-controlled value.
-            if (_token == _fei) {
-              _oracleRead = true;
-              _oracleValid = true;
-            }
-
             // For each deposit...
             uint256 _nTokens = 0;
             for (uint256 j = 0; j < tokenToDeposits[_token].length; j++) {

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -287,7 +287,7 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
                     }
 
                     // read the deposit
-                    (uint256 _depositBalance, uint256 _depositFei) = IPCVDepositV2(_deposit).balanceAndFei();
+                    (uint256 _depositBalance, uint256 _depositFei) = IPCVDepositV2(_deposit).resistantBalanceAndFei();
                     _totalTokenBalance += _depositBalance;
                     _protocolControlledFei += _depositFei;
                 }

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -125,9 +125,9 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
             if (pcvDeposits[i] == _deposit) {
                 found = true;
                 pcvDeposits[i] = pcvDeposits[pcvDeposits.length - 1];
+                pcvDeposits.pop();
             }
         }
-        pcvDeposits.pop();
 
         // emit event
         emit DepositRemove(msg.sender, _deposit);

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -26,9 +26,6 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
 
     // ----------- Properties -----------
 
-    /// @notice Array of PCVDeposits to inspect
-    address[] public pcvDeposits;
-
     /// @notice List of PCVDeposits to exclude from calculations
     mapping(address => bool) public excludedDeposits;
 
@@ -85,9 +82,6 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
         // revert if there is no oracle of this deposit's token
         require(tokenToOracle[_token] != address(0), "CollateralizationOracle: no oracle");
 
-        // add the PCVDeposit to the list
-        pcvDeposits.push(_deposit);
-
         // update maps & arrays for faster access
         depositToToken[_deposit] = _token;
         tokenToDeposits[_token].push(_deposit);
@@ -135,15 +129,6 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
               }
           }
         }
-        // remove from the main array
-        found = false;
-        for (uint256 i = 0; !found; i++) {
-            if (pcvDeposits[i] == _deposit) {
-                found = true;
-                pcvDeposits[i] = pcvDeposits[pcvDeposits.length - 1];
-                pcvDeposits.pop();
-            }
-        }
 
         // emit event
         emit DepositRemove(msg.sender, _deposit);
@@ -167,19 +152,10 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
         // revert if token is different
         require(_token == _newToken, "CollateralizationOracle: deposit has different token");
 
-        // swap the PCVDeposit in the list
-        bool found = false;
-        for (uint256 i = 0; !found; i++) {
-            if (pcvDeposits[i] == _oldDeposit) {
-                found = true;
-                pcvDeposits[i] = _newDeposit;
-            }
-        }
-
         // update maps & arrays for faster access
         depositToToken[_oldDeposit] = address(0);
         depositToToken[_newDeposit] = _token;
-        found = false;
+        bool found = false;
         for (uint256 i = 0; !found; i++) {
             if (tokenToDeposits[_token][i] == _oldDeposit) {
                 found = true;

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -298,9 +298,7 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
         }
 
         userCirculatingFei = fei().totalSupply() - _protocolControlledFei;
-        if (protocolControlledValue > userCirculatingFei) {
-            protocolEquity = protocolControlledValue - userCirculatingFei;
-        }
+        protocolEquity = int256(protocolControlledValue) - int256(userCirculatingFei);
 
         userCirculatingFei = fei().totalSupply() - _protocolControlledFei;
     }
@@ -311,7 +309,7 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     ///         a positive Protocol Equity.
     ///         Note: the validity status is ignored in this function.
     function isOvercollateralized() external override view whenNotPaused returns (bool) {
-        (,, uint256 _protocolEquity, bool _valid) = pcvStats();
+        (,, int256 _protocolEquity, bool _valid) = pcvStats();
         require(_valid, "CollateralizationOracle: reading is invalid");
         return _protocolEquity > 0;
     }

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -158,13 +158,8 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     /// @param _oldDeposit : the PCVDeposit to remove from the list.
     /// @param _newDeposit : the PCVDeposit to add to the list.
     function swapDeposit(address _oldDeposit, address _newDeposit) external onlyGovernor {
-        address _oldToken = depositToToken[_oldDeposit];
         removeDeposit(_oldDeposit);
         addDeposit(_newDeposit);
-        address _newToken = depositToToken[_newDeposit];
-
-        // revert if token is different
-        require(_oldToken == _newToken, "CollateralizationOracle: deposit has different token");
     }
 
     /// @notice Set the price feed oracle (in USD) for a given asset.

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -16,9 +16,9 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
 
     // ----------- Events -----------
 
-    event DepositAdd(address indexed _from, address _deposit, address _token);
-    event DepositRemove(address indexed _from, address _deposit);
-    event OracleSet(address indexed _from, address _token, address _oracle);
+    event DepositAdd(address from, address indexed deposit, address indexed token);
+    event DepositRemove(address from, address indexed deposit);
+    event OracleUpdate(address from, address indexed token, address indexed oldOracle, address indexed newOracle);
 
     // ----------- Properties -----------
 
@@ -138,13 +138,14 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
 
     /// @notice Set the price feed oracle (in USD) for a given asset.
     /// @param _token : the asset to add price oracle for
-    /// @param _oracle : price feed oracle for the given asset
-    function setOracle(address _token, address _oracle) external onlyGovernor {
+    /// @param _newOracle : price feed oracle for the given asset
+    function setOracle(address _token, address _newOracle) external onlyGovernor {
         // add oracle to the map(ERC20Address) => OracleAddress
-        token2oracle[_token] = _oracle;
+        address _oldOracle = token2oracle[_token];
+        token2oracle[_token] = _newOracle;
 
         // emit event
-        emit OracleSet(msg.sender, _token, _oracle);
+        emit OracleUpdate(msg.sender, _token, _oldOracle, _newOracle);
     }
 
     // ----------- IOracle override methods -----------

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -171,6 +171,9 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     /// @param _token : the asset to add price oracle for
     /// @param _newOracle : price feed oracle for the given asset
     function setOracle(address _token, address _newOracle) external onlyGovernor {
+        require(_token != address(0), "CollateralizationOracle: token must be != 0x0");
+        require(_newOracle != address(0), "CollateralizationOracle: oracle must be != 0x0");
+
         // add oracle to the map(ERC20Address) => OracleAddress
         address _oldOracle = tokenToOracle[_token];
         tokenToOracle[_token] = _newOracle;

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -258,7 +258,6 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
       bool validityStatus
     ) {
         uint256 _protocolControlledFei = 0;
-        address _fei = address(fei());
         validityStatus = !paused();
 
         // For each token...
@@ -299,8 +298,6 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
 
         userCirculatingFei = fei().totalSupply() - _protocolControlledFei;
         protocolEquity = int256(protocolControlledValue) - int256(userCirculatingFei);
-
-        userCirculatingFei = fei().totalSupply() - _protocolControlledFei;
     }
 
     /// @notice returns true if the protocol is overcollateralized. Overcollateralization

--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -98,36 +98,33 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
         // update maps & arrays for faster access
         // deposits array for the deposit's token
         depositToToken[_deposit] = address(0);
-        uint256 _nDepositsWithToken = tokenToDeposits[_token].length;
         bool found = false;
-        for (uint256 i = 0; !found && i < _nDepositsWithToken; i++) {
+        for (uint256 i = 0; !found; i++) {
             if (tokenToDeposits[_token][i] == _deposit) {
                 found = true;
-                tokenToDeposits[_token][i] = tokenToDeposits[_token][_nDepositsWithToken - 1];
+                tokenToDeposits[_token][i] = tokenToDeposits[_token][tokenToDeposits[_token].length - 1];
+                tokenToDeposits[_token].pop();
             }
         }
-        tokenToDeposits[_token].pop();
         // if it was the last deposit to have this token, remove this token from
         // the arrays also
         if (tokenToDeposits[_token].length == 0) {
           isTokenInPcv[_token] = false;
-          uint256 _nTokensInPcv = tokensInPcv.length;
           found = false;
-          for (uint256 i = 0; !found && i < _nTokensInPcv; i++) {
+          for (uint256 i = 0; !found; i++) {
               if (tokensInPcv[i] == _token) {
                   found = true;
-                  tokensInPcv[i] = tokensInPcv[_nTokensInPcv - 1];
+                  tokensInPcv[i] = tokensInPcv[tokensInPcv.length - 1];
+                  tokensInPcv.pop();
               }
           }
-          tokensInPcv.pop();
         }
         // remove from the main array
-        uint256 _nDeposits = pcvDeposits.length;
         found = false;
-        for (uint256 i = 0; !found && i < _nDeposits; i++) {
+        for (uint256 i = 0; !found; i++) {
             if (pcvDeposits[i] == _deposit) {
                 found = true;
-                pcvDeposits[i] = pcvDeposits[_nDeposits - 1];
+                pcvDeposits[i] = pcvDeposits[pcvDeposits.length - 1];
             }
         }
         pcvDeposits.pop();

--- a/contracts/oracle/ICollateralizationOracle.sol
+++ b/contracts/oracle/ICollateralizationOracle.sol
@@ -9,11 +9,10 @@ interface ICollateralizationOracle is IOracle {
 
     // ----------- Getters -----------
 
+    // returns the PCV value, User-circulating FEI, and Protocol Equity, as well
+    // as a validity status.
+    function pcvStats() external view returns (uint256, uint256, uint256, bool);
+
+    // true if Protocol Equity > 0
     function isOvercollateralized() external view returns (bool);
-
-    function userCirculatingFei() external view returns (uint256);
-
-    function pcvValue() external view returns (uint256);
-
-    function pcvEquityValue() external view returns (uint256);
 }

--- a/contracts/oracle/ICollateralizationOracle.sol
+++ b/contracts/oracle/ICollateralizationOracle.sol
@@ -15,5 +15,5 @@ interface ICollateralizationOracle is IOracle {
 
     function pcvValue() external view returns (uint256);
 
-    function pcvEquityValue() external view returns (uint256); 
+    function pcvEquityValue() external view returns (uint256);
 }

--- a/contracts/oracle/ICollateralizationOracle.sol
+++ b/contracts/oracle/ICollateralizationOracle.sol
@@ -11,7 +11,12 @@ interface ICollateralizationOracle is IOracle {
 
     // returns the PCV value, User-circulating FEI, and Protocol Equity, as well
     // as a validity status.
-    function pcvStats() external view returns (uint256, uint256, int256, bool);
+    function pcvStats() external view returns (
+        uint256 protocolControlledValue,
+        uint256 userCirculatingFei,
+        int256 protocolEquity,
+        bool validityStatus
+    );
 
     // true if Protocol Equity > 0
     function isOvercollateralized() external view returns (bool);

--- a/contracts/oracle/ICollateralizationOracle.sol
+++ b/contracts/oracle/ICollateralizationOracle.sol
@@ -11,7 +11,7 @@ interface ICollateralizationOracle is IOracle {
 
     // returns the PCV value, User-circulating FEI, and Protocol Equity, as well
     // as a validity status.
-    function pcvStats() external view returns (uint256, uint256, uint256, bool);
+    function pcvStats() external view returns (uint256, uint256, int256, bool);
 
     // true if Protocol Equity > 0
     function isOvercollateralized() external view returns (bool);

--- a/contracts/pcv/IPCVDepositV2.sol
+++ b/contracts/pcv/IPCVDepositV2.sol
@@ -12,5 +12,5 @@ interface IPCVDepositV2 is IPCVDeposit {
     function balanceReportedIn() external view returns (address);
 
     // gets the resistant token balance and protocol owned fei of this deposit
-    function balanceAndFei() external view returns (uint256, uint256);
+    function resistantBalanceAndFei() external view returns (uint256, uint256);
 }

--- a/contracts/pcv/IPCVDepositV2.sol
+++ b/contracts/pcv/IPCVDepositV2.sol
@@ -8,8 +8,9 @@ import "./IPCVDeposit.sol";
 interface IPCVDepositV2 is IPCVDeposit {
     // ----------- Getters -----------
 
+    // gets the token address in which this deposit returns its balance
     function balanceReportedIn() external view returns (address);
 
-    function resistantBalance() external view returns (uint256);
-    function resistantProtocolOwnedFei() external view returns (uint256);
+    // gets the resistant token balance and protocol owned fei of this deposit
+    function balanceAndFei() external view returns (uint256, uint256);
 }

--- a/contracts/pcv/IPCVDepositV2.sol
+++ b/contracts/pcv/IPCVDepositV2.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "./IPCVDeposit.sol";
+
+/// @title a PCV Deposit interface for Fei V2
+/// @author eswak
+interface IPCVDepositV2 is IPCVDeposit {
+    // ----------- Getters -----------
+
+    function balanceReportedIn() external view returns (address);
+
+    function resistantBalance() external view returns (uint256);
+    function resistantProtocolOwnedFei() external view returns (uint256);
+}

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -274,10 +274,12 @@ describe('CollateralizationOracle', function () {
       );
     });
     it('should revert if new deposit is already found', async function() {
+      await this.oracle.setOracle(this.token2.address, this.oracle2.address, { from: governorAddress });
+      await this.oracle.addDeposit(this.deposit2.address, { from: governorAddress });
       await expectRevert(
         this.oracle.swapDeposit(
           this.deposit1.address,
-          this.deposit1.address,
+          this.deposit2.address,
           { from: governorAddress }
         ),
         'CollateralizationOracle: deposit duplicate'

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -452,8 +452,7 @@ describe('CollateralizationOracle', function () {
         await this.oracle2.setExchangeRate(4000); // 3000 -> 4000
         expect((await this.oracle.pcvStats()).protocolEquity).to.be.bignumber.equal(`1000${e18}`);
         await this.fei.mint(userAddress, `5000${e18}`);
-        // expect 0 for negative equity, too
-        expect((await this.oracle.pcvStats()).protocolEquity).to.be.bignumber.equal('0');
+        expect((await this.oracle.pcvStats()).protocolEquity).to.be.bignumber.equal(`-4000${e18}`);
       });
       it('should be invalid if an oracle is invalid', async function() {
         await this.oracle1.setValid(false);

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -1,0 +1,300 @@
+const {
+  ZERO_ADDRESS,
+  expect,
+  getCore,
+  getAddresses,
+  expectRevert,
+  expectEvent
+} = require('../helpers');
+
+const CollateralizationOracle = artifacts.require('CollateralizationOracle');
+const MockPCVDepositV2 = artifacts.require('MockPCVDepositV2');
+const MockOracle = artifacts.require('MockOracle');
+const MockERC20 = artifacts.require('MockERC20');
+const IFei = artifacts.require('IFei');
+
+const e18 = '000000000000000000';
+
+describe('CollateralizationOracle', function () {
+  let userAddress;
+  let governorAddress;
+
+  beforeEach(async function () {
+    ({ userAddress, governorAddress } = await getAddresses());
+    this.core = await getCore(true);
+    await this.core.grantMinter(userAddress, {from: governorAddress});
+    this.fei = await IFei.at(await this.core.fei());
+
+    // fake stablecoin
+    this.oracle1 = await MockOracle.new(1);
+    this.token1 = await MockERC20.new();
+    this.deposit1 = await MockPCVDepositV2.new(
+      this.token1.address,
+      `2000${e18}`,// balance
+      `1000${e18}`// protocol FEI
+    );
+    await this.fei.mint(this.deposit1.address, `1000${e18}`);
+    // fake ETH
+    this.oracle2 = await MockOracle.new(3000);
+    this.token2 = await MockERC20.new();
+    this.deposit2 = await MockPCVDepositV2.new(
+      this.token2.address,
+      `1${e18}`,// balance
+      `1000${e18}`// protocol FEI
+    );
+    await this.fei.mint(this.deposit2.address, `1000${e18}`);
+
+    // user circulating fei
+    await this.fei.mint(userAddress, `2500${e18}`);
+
+    // PCV overview :
+    //   PCVDepost 1 : stablecoin
+    //     - 2000$ PCV
+    //     - 1000 protocol FEI
+    //   PCVDeposit 2 : some token (e.g. ETH)
+    //     - 3000$ PCV
+    //     - 1000 protocol FEI
+    //   Circulating :
+    //     - 2500 FEI
+    // create oracle
+    this.oracle = await CollateralizationOracle.new(this.core.address);
+  });
+
+  describe('addDeposit()', function() {
+    it('should emit DepositAdd', async function() {
+      await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+      expectEvent(
+        await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress }),
+        'DepositAdd',
+        {
+          _from: governorAddress,
+          _deposit: this.deposit1.address,
+          _token: this.token1.address
+        }
+      );
+    });
+    it('should update maps & array properties', async function() {
+      await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+      await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+      expect(await this.oracle.pcvDeposits('0')).to.be.equal(this.deposit1.address);
+      expect(await this.oracle.token2deposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
+      expect(await this.oracle.deposit2token(this.deposit1.address)).to.be.equal(this.token1.address);
+      expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
+      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('1');
+    });
+    it('should revert if not governor', async function() {
+      await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+      await expectRevert(
+        this.oracle.addDeposit(
+          this.deposit1.address,
+          { from: userAddress }
+        ),
+        'CoreRef: Caller is not a governor'
+      );
+    });
+    it('should revert if deposit is duplicate', async function() {
+      await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+      await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+      await expectRevert(
+        this.oracle.addDeposit(
+          this.deposit1.address,
+          { from: governorAddress }
+        ),
+        'CollateralizationOracle: deposit duplicate'
+      );
+    });
+    it('should revert if deposit has no oracle', async function() {
+      await expectRevert(
+        this.oracle.addDeposit(
+          this.deposit1.address,
+          { from: governorAddress }
+        ),
+        'CollateralizationOracle: no oracle'
+      );
+    });
+  });
+
+  describe('removeDeposit()', function() {
+    it('should emit DepositRemove', async function() {
+      await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+      await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+      expectEvent(
+        await this.oracle.removeDeposit(this.deposit1.address, { from: governorAddress }),
+        'DepositRemove',
+        {
+          _from: governorAddress,
+          _deposit: this.deposit1.address
+        }
+      );
+    });
+    it('should update maps & array properties', async function() {
+      // initial situation : 1 deposit
+      await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+      await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+      expect(await this.oracle.pcvDeposits('0')).to.be.equal(this.deposit1.address);
+      expect(await this.oracle.token2deposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
+      expect(await this.oracle.deposit2token(this.deposit1.address)).to.be.equal(this.token1.address);
+      expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
+      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('1');
+      // remove deposit
+      await this.oracle.removeDeposit(this.deposit1.address, { from: governorAddress })
+      // after remove
+      await expectRevert.unspecified(this.oracle.pcvDeposits('0'));
+      await expectRevert.unspecified(this.oracle.token2deposits(this.token1.address, '0'));
+      expect(await this.oracle.deposit2token(this.deposit1.address)).to.be.equal(ZERO_ADDRESS);
+      await expectRevert.unspecified(this.oracle.tokensInPcv('0'));
+      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('0');
+    });
+    it('should revert if not governor', async function() {
+      await expectRevert(
+        this.oracle.addDeposit(
+          this.deposit1.address,
+          { from: userAddress }
+        ),
+        'CoreRef: Caller is not a governor'
+      );
+    });
+    it('should revert if deposit is not found', async function() {
+      await expectRevert(
+        this.oracle.removeDeposit(
+          this.deposit2.address,
+          { from: governorAddress }
+        ),
+        'CollateralizationOracle: deposit not found'
+      );
+    });
+  });
+
+  describe('setOracle()', function() {
+    it('should emit OracleSet', async function() {
+      expectEvent(
+        await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress }),
+        'OracleSet',
+        {
+          _from: governorAddress,
+          _token: this.token1.address,
+          _oracle: this.oracle1.address
+        }
+      );
+    });
+    it('should update maps & array properties', async function() {
+      await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+      expect(await this.oracle.token2oracle(this.token1.address)).to.be.equal(this.oracle1.address);
+    });
+    it('should revert if not governor', async function() {
+      await expectRevert(
+        this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: userAddress }),
+        'CoreRef: Caller is not a governor'
+      );
+    });
+  });
+
+  describe('IOracle', function() {
+    describe('update()', function() {
+      it('should propagage update() calls', async function() {
+        expect(await this.oracle1.updated()).to.be.equal(false);
+        await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+        await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+        await this.oracle.update();
+        expect(await this.oracle1.updated()).to.be.equal(true);
+      });
+    });
+
+    describe('isOutdated()', function() {
+      it('should be outdated if one of the oracles is outdated', async function() {
+        expect(await this.oracle.isOutdated()).to.be.equal(false);
+        await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+        await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+        await this.oracle1.setOutdated(true);
+        expect(await this.oracle.isOutdated()).to.be.equal(true);
+      });
+    });
+
+    describe('read()', function() {
+      it('should return the global collateral ratio', async function() {
+        await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+        await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+        await this.oracle.setOracle(this.token2.address, this.oracle2.address, { from: governorAddress });
+        await this.oracle.addDeposit(this.deposit2.address, { from: governorAddress });
+        const val = await this.oracle.read();
+        expect(val[0].value).to.be.bignumber.equal(`2${e18}`); // collateral ratio
+        expect(val[1]).to.be.equal(true); // valid
+      });
+      it('should be invalid if the contract is paused', async function() {
+        await this.oracle.pause({ from: governorAddress });
+        await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+        await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+        const val = await this.oracle.read();
+        expect(val[1]).to.be.equal(false); // not valid
+      });
+    });
+  });
+
+  describe('ICollateralizationOracle', function() {
+    beforeEach(async function() {
+      await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
+      await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
+      await this.oracle.setOracle(this.token2.address, this.oracle2.address, { from: governorAddress });
+      await this.oracle.addDeposit(this.deposit2.address, { from: governorAddress });
+    });
+
+    describe('isOvercollateralized()', function() {
+      it('should revert if paused', async function() {
+        await this.oracle.pause({ from: governorAddress });
+        await expectRevert(this.oracle.isOvercollateralized(), 'Pausable: paused');
+      });
+      it('should return true/false if the protocol is overcollateralized or not', async function() {
+        expect(await this.oracle.isOvercollateralized()).to.be.equal(true);
+        await this.fei.mint(userAddress, `2499${e18}`);
+        expect(await this.oracle.isOvercollateralized()).to.be.equal(true);
+        await this.fei.mint(userAddress, `1${e18}`);
+        expect(await this.oracle.isOvercollateralized()).to.be.equal(false);
+        await this.fei.mint(userAddress, `5000${e18}`);
+        expect(await this.oracle.isOvercollateralized()).to.be.equal(false);
+      });
+    });
+
+    describe('userCirculatingFei()', function() {
+      it('should revert if paused', async function() {
+        await this.oracle.pause({ from: governorAddress });
+        await expectRevert(this.oracle.userCirculatingFei(), 'Pausable: paused');
+      });
+      it('should return the total amount of circulating fei', async function() {
+        expect(await this.oracle.userCirculatingFei()).to.be.bignumber.equal(`2500${e18}`);
+        await this.fei.mint(userAddress, `2500${e18}`);
+        expect(await this.oracle.userCirculatingFei()).to.be.bignumber.equal(`5000${e18}`);
+        await this.fei.mint(userAddress, `2500${e18}`);
+        expect(await this.oracle.userCirculatingFei()).to.be.bignumber.equal(`7500${e18}`);
+      });
+    });
+
+    describe('pcvValue()', function() {
+      it('should revert if paused', async function() {
+        await this.oracle.pause({ from: governorAddress });
+        await expectRevert(this.oracle.pcvValue(), 'Pausable: paused');
+      });
+      it('should return the PCV value in USD', async function() {
+        expect(await this.oracle.pcvValue()).to.be.bignumber.equal(`5000${e18}`);
+        await this.oracle2.setExchangeRate(5000); // 3000 -> 5000
+        expect(await this.oracle.pcvValue()).to.be.bignumber.equal(`7000${e18}`);
+      });
+    });
+
+    describe('pcvEquityValue()', function() {
+      it('should revert if paused', async function() {
+        await this.oracle.pause({ from: governorAddress });
+        await expectRevert(this.oracle.pcvEquityValue(), 'Pausable: paused');
+      });
+      it('should return the PCV equity in USD (PCV value - circulating FEI)', async function() {
+        expect(await this.oracle.pcvEquityValue()).to.be.bignumber.equal(`2500${e18}`);
+        await this.fei.mint(userAddress, `2500${e18}`);
+        expect(await this.oracle.pcvEquityValue()).to.be.bignumber.equal('0');
+        await this.oracle2.setExchangeRate(4000); // 3000 -> 4000
+        expect(await this.oracle.pcvEquityValue()).to.be.bignumber.equal(`1000${e18}`);
+        await this.fei.mint(userAddress, `5000${e18}`);
+        // expect 0 for negative equity, too
+        expect(await this.oracle.pcvEquityValue()).to.be.bignumber.equal('0');
+      });
+    });
+  });
+});

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -361,6 +361,11 @@ describe('CollateralizationOracle', function () {
         await this.oracle.pause({ from: governorAddress });
         await expectRevert(this.oracle.isOvercollateralized(), 'Pausable: paused');
       });
+      it('should revert if invalid', async function() {
+        expect(await this.oracle.isOvercollateralized()).to.be.equal(true);
+        await this.oracle1.setValid(false);
+        await expectRevert(this.oracle.isOvercollateralized(), 'CollateralizationOracle: reading is invalid');
+      });
       it('should return true/false if the protocol is overcollateralized or not', async function() {
         expect(await this.oracle.isOvercollateralized()).to.be.equal(true);
         await this.fei.mint(userAddress, `2499${e18}`);

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -330,6 +330,18 @@ describe('CollateralizationOracle', function () {
         'CoreRef: Caller is not a governor'
       );
     });
+    it('should revert if token = 0x0', async function() {
+      await expectRevert(
+        this.oracle.setOracle(ZERO_ADDRESS, this.oracle1.address, { from: governorAddress }),
+        'CollateralizationOracle: token must be != 0x0'
+      );
+    });
+    it('should revert if oracle = 0x0', async function() {
+      await expectRevert(
+        this.oracle.setOracle(this.token1.address, ZERO_ADDRESS, { from: governorAddress }),
+        'CollateralizationOracle: oracle must be != 0x0'
+      );
+    });
   });
 
   describe('IOracle', function() {

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -79,7 +79,6 @@ describe('CollateralizationOracle', function () {
     it('should update maps & array properties', async function() {
       await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
       await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
-      expect(await this.oracle.pcvDeposits('0')).to.be.equal(this.deposit1.address);
       expect(await this.oracle.tokenToDeposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
       expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(this.token1.address);
       expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
@@ -134,7 +133,6 @@ describe('CollateralizationOracle', function () {
       // initial situation : 1 deposit
       await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
       await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
-      expect(await this.oracle.pcvDeposits('0')).to.be.equal(this.deposit1.address);
       expect(await this.oracle.tokenToDeposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
       expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(this.token1.address);
       expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
@@ -142,7 +140,6 @@ describe('CollateralizationOracle', function () {
       // remove deposit
       await this.oracle.removeDeposit(this.deposit1.address, { from: governorAddress })
       // after remove
-      await expectRevert.unspecified(this.oracle.pcvDeposits('0'));
       await expectRevert.unspecified(this.oracle.tokenToDeposits(this.token1.address, '0'));
       expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(ZERO_ADDRESS);
       await expectRevert.unspecified(this.oracle.tokensInPcv('0'));
@@ -202,7 +199,6 @@ describe('CollateralizationOracle', function () {
     });
     it('should update maps & array properties', async function() {
       // initial situation : 1 deposit
-      expect(await this.oracle.pcvDeposits('0')).to.be.equal(this.deposit1.address);
       expect(await this.oracle.tokenToDeposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
       expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(this.token1.address);
       expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
@@ -210,8 +206,6 @@ describe('CollateralizationOracle', function () {
       // swap deposit
       await this.oracle.swapDeposit(this.deposit1.address, this.deposit1bis.address, { from: governorAddress });
       // after swap
-      expect(await this.oracle.pcvDeposits('0')).to.be.equal(this.deposit1bis.address);
-      await expectRevert.unspecified(this.oracle.pcvDeposits('1'));
       expect(await this.oracle.tokenToDeposits(this.token1.address, '0')).to.be.equal(this.deposit1bis.address);
       await expectRevert.unspecified(this.oracle.tokenToDeposits(this.token1.address, '1'));
       expect(await this.oracle.depositToToken(this.deposit1bis.address)).to.be.equal(this.token1.address);

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -80,7 +80,7 @@ describe('CollateralizationOracle', function () {
       expect(await this.oracle.tokenToDeposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
       expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(this.token1.address);
       expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
-      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('1');
+      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.equal(true);
     });
     it('should revert if not governor', async function() {
       await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
@@ -135,7 +135,7 @@ describe('CollateralizationOracle', function () {
       expect(await this.oracle.tokenToDeposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
       expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(this.token1.address);
       expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
-      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('1');
+      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.equal(true);
       // remove deposit
       await this.oracle.removeDeposit(this.deposit1.address, { from: governorAddress })
       // after remove
@@ -143,7 +143,7 @@ describe('CollateralizationOracle', function () {
       await expectRevert.unspecified(this.oracle.tokenToDeposits(this.token1.address, '0'));
       expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(ZERO_ADDRESS);
       await expectRevert.unspecified(this.oracle.tokensInPcv('0'));
-      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('0');
+      expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.equal(false);
     });
     it('should revert if not governor', async function() {
       await expectRevert(

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -67,9 +67,9 @@ describe('CollateralizationOracle', function () {
         await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress }),
         'DepositAdd',
         {
-          _from: governorAddress,
-          _deposit: this.deposit1.address,
-          _token: this.token1.address
+          from: governorAddress,
+          deposit: this.deposit1.address,
+          token: this.token1.address
         }
       );
     });
@@ -122,8 +122,8 @@ describe('CollateralizationOracle', function () {
         await this.oracle.removeDeposit(this.deposit1.address, { from: governorAddress }),
         'DepositRemove',
         {
-          _from: governorAddress,
-          _deposit: this.deposit1.address
+          from: governorAddress,
+          deposit: this.deposit1.address
         }
       );
     });
@@ -166,14 +166,15 @@ describe('CollateralizationOracle', function () {
   });
 
   describe('setOracle()', function() {
-    it('should emit OracleSet', async function() {
+    it('should emit OracleUpdate', async function() {
       expectEvent(
         await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress }),
-        'OracleSet',
+        'OracleUpdate',
         {
-          _from: governorAddress,
-          _token: this.token1.address,
-          _oracle: this.oracle1.address
+          from: governorAddress,
+          token: this.token1.address,
+          oldOracle: ZERO_ADDRESS,
+          newOracle: this.oracle1.address
         }
       );
     });

--- a/test/oracle/CollateralizationOracle.test.js
+++ b/test/oracle/CollateralizationOracle.test.js
@@ -77,8 +77,8 @@ describe('CollateralizationOracle', function () {
       await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
       await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
       expect(await this.oracle.pcvDeposits('0')).to.be.equal(this.deposit1.address);
-      expect(await this.oracle.token2deposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
-      expect(await this.oracle.deposit2token(this.deposit1.address)).to.be.equal(this.token1.address);
+      expect(await this.oracle.tokenToDeposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
+      expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(this.token1.address);
       expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
       expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('1');
     });
@@ -132,16 +132,16 @@ describe('CollateralizationOracle', function () {
       await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
       await this.oracle.addDeposit(this.deposit1.address, { from: governorAddress });
       expect(await this.oracle.pcvDeposits('0')).to.be.equal(this.deposit1.address);
-      expect(await this.oracle.token2deposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
-      expect(await this.oracle.deposit2token(this.deposit1.address)).to.be.equal(this.token1.address);
+      expect(await this.oracle.tokenToDeposits(this.token1.address, '0')).to.be.equal(this.deposit1.address);
+      expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(this.token1.address);
       expect(await this.oracle.tokensInPcv('0')).to.be.equal(this.token1.address);
       expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('1');
       // remove deposit
       await this.oracle.removeDeposit(this.deposit1.address, { from: governorAddress })
       // after remove
       await expectRevert.unspecified(this.oracle.pcvDeposits('0'));
-      await expectRevert.unspecified(this.oracle.token2deposits(this.token1.address, '0'));
-      expect(await this.oracle.deposit2token(this.deposit1.address)).to.be.equal(ZERO_ADDRESS);
+      await expectRevert.unspecified(this.oracle.tokenToDeposits(this.token1.address, '0'));
+      expect(await this.oracle.depositToToken(this.deposit1.address)).to.be.equal(ZERO_ADDRESS);
       await expectRevert.unspecified(this.oracle.tokensInPcv('0'));
       expect(await this.oracle.isTokenInPcv(this.token1.address)).to.be.bignumber.equal('0');
     });
@@ -180,7 +180,7 @@ describe('CollateralizationOracle', function () {
     });
     it('should update maps & array properties', async function() {
       await this.oracle.setOracle(this.token1.address, this.oracle1.address, { from: governorAddress });
-      expect(await this.oracle.token2oracle(this.token1.address)).to.be.equal(this.oracle1.address);
+      expect(await this.oracle.tokenToOracle(this.token1.address)).to.be.equal(this.oracle1.address);
     });
     it('should revert if not governor', async function() {
       await expectRevert(

--- a/test/pcv/ERC20Dripper.test.js
+++ b/test/pcv/ERC20Dripper.test.js
@@ -30,7 +30,7 @@ const dripAmount = new BN(4000000).mul(new BN(10).pow(new BN(18)));
 // this is 1 week in seconds
 const dripFrequency = 604800;
 
-describe.only('ERC20Dripper', () => {
+describe('ERC20Dripper', () => {
   before(async () => {
     ({
       userAddress,
@@ -112,7 +112,7 @@ describe.only('ERC20Dripper', () => {
       await expectRevert(
         this.dripper.drip(),
         'Timed: time not ended'
-      ); 
+      );
     });
   });
 
@@ -229,7 +229,7 @@ describe.only('ERC20Dripper', () => {
     it('should be able to call drip when enough time has passed through multiple periods', async function () {
       for (let i = 0; i < 11; i++) {
         await time.increase(dripFrequency);
-  
+
         expect(await this.dripper.isTimeEnded()).to.be.true;
 
         const tribalChiefStartingBalance = await this.tribe.balanceOf(this.tribalChief.address);


### PR DESCRIPTION
This PR adds the Collateralization Oracle required for the V2.

In short, this new oracle...

- Is configured by the DAO to follow a list of PCVDeposits (add, remove, swap are `onlyGovernor`)
- Has its own list of oracles (need to call `setOracle(token, address)`)
- Relies on an updated PCVDeposit interface, we will need to deploy wrappers for existing deposits

The new PCVDeposit interface has the following methods : 

- `balanceReportedIn()` the token address used for accounting in this deposit
- `balanceAndFei()` the resistant token balance & the protocol-owned FEI in this deposit

The CR Oracle has a function `pcvStats()` that returns :

- the Protocol Controlled Value 
- the User Circulating FEI
- the Protocol Equity
- a validity status