### PR TITLE
Add new Scripts to proposal flow

### DIFF
--- a/end-to-end/setup/index.ts
+++ b/end-to-end/setup/index.ts
@@ -10,8 +10,6 @@ import {
   ProposalConfig
 } from './types'
 import { sudo } from '../../scripts/utils/sudo'
-import { exec } from '../../proposals/dao/exec'
-import getProposalCalldata from '../../proposals/utils/getProposalCalldata';
 import constructProposal from '../../proposals/utils/constructProposal';
 
 /**
@@ -87,16 +85,10 @@ export class TestEndtoEndCoordinator implements TestCoordinator {
     // setup the DAO proposal
     await setup(contractAddresses, existingContracts, contracts, this.config.logging);
 
-    // Run the DAO proposal
-    // If the `exec` flag is activated, then run the upgrade directly from tx calldata
+    // Simulate the DAO proposal
     if (config.exec) {
-      const addresses = { 
-        proposerAddress: config.proposerAddress,
-        voterAddress: config.voterAddress,
-        governorAlphaAddress: contracts.governorAlpha.address,
-      }
-      const calldata = await getProposalCalldata(await constructProposal(proposalName, this.config.logging), this.config.logging);
-      await exec(calldata, config.totalValue, addresses);
+      const proposal = await constructProposal(proposalName, this.config.logging);
+      await proposal.simulate();
     } else {
       await run(contractAddresses, existingContracts, contracts, this.config.logging)
     }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -30,7 +30,7 @@ const config: HardhatUserConfig = {
       chainId: 5777, // Any network (default: none)
       forking: {
         url: `https://eth-mainnet.alchemyapi.io/v2/${mainnetAlchemyApiKey}`,
-        blockNumber: 13135475
+        blockNumber: 13147150
       }
     },
     localhost: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "deploy:main": "npx hardhat run --network mainnet deploy/migrations.js",
     "deploy:ropsten": "npx hardhat run --network ropsten deploy/migrations.js",
     "deploy:rinkeby": "npx hardhat run --network rinkeby deploy/migrations.js",
-    "abis": "node scripts/abis.js"
+    "abis": "node scripts/abis.js",
+    "calldata": "npx hardhat run proposals/utils/getProposalCalldata.js",
+    "check-proposal": "npx hardhat run proposals/utils/checkProposal.js"
   },
   "author": "joeysantoro",
   "license": "AGPL-3.0-only",

--- a/proposals/dao/upgrade.js
+++ b/proposals/dao/upgrade.js
@@ -1,3 +1,5 @@
+import hre from 'hardhat';
+
 async function setup(addresses, oldContracts, contracts, logging) {}
 
 async function run(addresses, oldContracts, contracts, logging = false) {
@@ -34,6 +36,11 @@ async function run(addresses, oldContracts, contracts, logging = false) {
 
   // special role
   // check via tribe contract
+  await hre.network.provider.request({
+    method: 'hardhat_impersonateAccount',
+    params: [timelockAddress]
+  });
+
   logging ? console.log('Transferring TRIBE Minter role to TribeReserveStabilizer') : undefined;
   await tribe.setMinter(tribeReserveStabilizer.address, {from: timelockAddress});
 

--- a/proposals/description/fip_x.json
+++ b/proposals/description/fip_x.json
@@ -1,6 +1,5 @@
 {
     "proposal_title": "FIP-X: Title",
-    "proposal_description_link": "",
     "proposal_commands": [
         {
             "address": "",
@@ -9,7 +8,6 @@
             "arguments": [],
             "description": ""
         }
-    ],
-    "proposal_calldata": "0x..."
+    ]
 }
 

--- a/proposals/utils/checkProposal.js
+++ b/proposals/utils/checkProposal.js
@@ -1,0 +1,91 @@
+import { getMainnetContracts, getContractAddresses } from '../../end-to-end/setup/loadContracts.ts';
+
+const hre = require('hardhat');
+const { time } = require('@openzeppelin/test-helpers');
+
+// Multisig
+const voterAddress = '0xB8f482539F2d3Ae2C9ea6076894df36D1f632775';
+
+require('dotenv').config();
+
+/**
+ * Take in a hardhat proposal object and output the proposal calldatas
+ * See `proposals/utils/getProposalCalldata.js` on how to construct the proposal calldata
+ */ 
+async function checkProposal() {
+  const proposalName = process.env.DEPLOY_FILE;
+
+  if (!proposalName) {
+    throw new Error('DEPLOY_FILE env variable not set');
+  }
+
+  const contracts = await getMainnetContracts();
+  const { governorAlpha } = contracts;
+
+  const proposalNo = process.env.PROPOSAL_NUMBER ? process.env.PROPOSAL_NUMBER : await governorAlpha.proposalCount();
+
+  await hre.network.provider.request({
+    method: 'hardhat_impersonateAccount',
+    params: [voterAddress]
+  });
+
+  console.log(`Proposal Number: ${proposalNo}`);
+
+  let proposal = await governorAlpha.proposals(proposalNo);
+  const {startBlock} = proposal;
+
+  // Advance to vote start
+  if (await time.latestBlock() < startBlock) {
+    console.log(`Advancing To: ${startBlock}`);
+    await time.advanceBlockTo(startBlock);
+  } else {
+    console.log('Vote already began');
+  }
+
+  try {
+    await governorAlpha.castVote(proposalNo, true, {from: voterAddress});
+    console.log('Casted vote');
+  } catch {
+    console.log('Already voted');
+  }
+
+  proposal = await governorAlpha.proposals(proposalNo);
+  const {endBlock} = proposal;
+
+  // Advance to after vote completes and queue the transaction
+  if (await time.latestBlock() < endBlock) {
+    console.log(`Advancing To: ${endBlock}`);
+    await time.advanceBlockTo(endBlock);
+
+    console.log('Queuing');
+    await governorAlpha.queue(proposalNo);
+  } else {
+    console.log('Already queued');
+  }
+
+  // Increase beyond the timelock delay
+  console.log('Increasing Time');
+  await time.increase(86400); // 1 day in seconds
+
+  console.log('Executing');
+  await governorAlpha.execute(proposalNo);
+  console.log('Success');
+      
+  // Get the upgrade setup, run and teardown scripts
+  const { teardown, validate } = await import(`../dao/${proposalName}`);
+
+  const contractAddresses = await getContractAddresses(contracts);
+  
+  console.log('Teardown');
+  await teardown(contractAddresses, contracts, contracts);
+  
+  console.log('Validate');
+  await validate(contractAddresses, contracts, contracts);
+}
+
+checkProposal()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.log(err);
+    process.exit(1);
+  });

--- a/proposals/utils/getProposalCalldata.js
+++ b/proposals/utils/getProposalCalldata.js
@@ -1,10 +1,20 @@
+import constructProposal from './constructProposal';
+
 const { web3 } = require('hardhat');
+require('dotenv').config();
 
 /**
  * Take in a hardhat proposal object and output the proposal calldatas
  * See `proposals/utils/getProposalCalldata.js` on how to construct the proposal calldata
  */ 
-export default async function getProposalCalldata(proposal, logging = false) {
+async function getProposalCalldata() {
+  const proposalName = process.env.DEPLOY_FILE;
+
+  if (!proposalName) {
+    throw new Error('DEPLOY_FILE env variable not set');
+  }
+  const proposal = await constructProposal(proposalName);
+
   const calldata = await web3.eth.abi.encodeFunctionCall({
     name: 'propose',
     type: 'function',
@@ -26,6 +36,12 @@ export default async function getProposalCalldata(proposal, logging = false) {
     }]
   }, [proposal.targets, proposal.values, proposal.signatures, proposal.calldatas, proposal.description]);
   
-  logging && console.log(`Calldata: ${calldata}`);
-  return calldata;
+  console.log(calldata);
 }
+
+getProposalCalldata()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.log(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Uses the proposals hardhat plugin to quickly simulate proposals in the existing e2e test flow.

Adds two new scripts for generating calldata and checking a live proposal against the validate script.