### PR TITLE
V2 Tribe Reserve Stabilizer

### DIFF
--- a/contracts/pcv/PCVDeposit.sol
+++ b/contracts/pcv/PCVDeposit.sol
@@ -18,7 +18,7 @@ abstract contract PCVDeposit is IPCVDeposit, CoreRef {
       address token, 
       address to, 
       uint256 amount
-    ) public override onlyPCVController {
+    ) public virtual override onlyPCVController {
         _withdrawERC20(token, to, amount);
     }
 

--- a/contracts/stabilizer/ITribeReserveStabilizer.sol
+++ b/contracts/stabilizer/ITribeReserveStabilizer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.4;
 
-import "../oracle/IOracle.sol";
+import "../oracle/ICollateralizationOracle.sol";
 
 /// @title a Tribe Reserve Stabilizer interface
 /// @author Fei Protocol
@@ -9,9 +9,9 @@ interface ITribeReserveStabilizer {
 
     // ----------- Events -----------
 
-    event FeiOracleUpdate(address indexed oldFeiOracle, address indexed newFeiOracle);
+    event CollateralizationOracleUpdate(address indexed oldCollateralizationOracle, address indexed newCollateralizationOracle);
 
-    event FeiPriceThresholdUpdate(uint256 oldFeiPriceThresholdBasisPoints, uint256 newFeiPriceThresholdBasisPoints);
+    event CollateralizationThresholdUpdate(uint256 oldCollateralizationThresholdBasisPoints, uint256 newCollateralizationThresholdBasisPoints);
 
     // ----------- Governor only state changing api -----------
 
@@ -19,15 +19,15 @@ interface ITribeReserveStabilizer {
 
     function mint(address to, uint256 amount) external;
 
-    function setFeiOracle(IOracle newFeiOracle) external;
+    function setCollateralizationOracle(ICollateralizationOracle newCollateralizationOracle) external;
 
-    function setFeiPriceThreshold(uint256 newFeiPriceThresholdBasisPoints) external;
+    function setCollateralizationThreshold(uint256 newCollateralizationThresholdBasisPoints) external;
 
     // ----------- Getters -----------
 
-    function isFeiBelowThreshold() external view returns (bool);
+    function isCollateralizationAboveThreshold() external view returns (bool);
 
-    function feiOracle() external view returns (IOracle);
+    function collateralizationOracle() external view returns (ICollateralizationOracle);
 
-    function feiPriceThreshold() external view returns (Decimal.D256 calldata);
+    function collateralizationThreshold() external view returns (Decimal.D256 calldata);
 }

--- a/contracts/stabilizer/ITribeReserveStabilizer.sol
+++ b/contracts/stabilizer/ITribeReserveStabilizer.sol
@@ -25,7 +25,7 @@ interface ITribeReserveStabilizer {
 
     // ----------- Getters -----------
 
-    function isCollateralizationAboveThreshold() external view returns (bool);
+    function isCollateralizationBelowThreshold() external view returns (bool);
 
     function collateralizationOracle() external view returns (ICollateralizationOracle);
 

--- a/contracts/stabilizer/ReserveStabilizer.sol
+++ b/contracts/stabilizer/ReserveStabilizer.sol
@@ -18,7 +18,6 @@ contract ReserveStabilizer is OracleRef, IReserveStabilizer, PCVDeposit {
     uint256 public constant BASIS_POINTS_GRANULARITY = 10_000;
 
     /// @notice the ERC20 token exchanged on this stablizer
-    /// @dev left as 0x0 address for ETH and TRIBE stabilizers
     IERC20 public token;
 
     /// @notice ERC20 Reserve Stabilizer constructor

--- a/contracts/stabilizer/TribeReserveStabilizer.sol
+++ b/contracts/stabilizer/TribeReserveStabilizer.sol
@@ -54,12 +54,13 @@ contract TribeReserveStabilizer is ITribeReserveStabilizer, ReserveStabilizer {
 
     /// @dev reverts. Held TRIBE should only be released by exchangeFei or mint
     function withdraw(address, uint256) external pure override {
-        revert("TribeReserveStabilizer: can't withdraw");
+        revert("TribeReserveStabilizer: can't withdraw TRIBE");
     }
 
-    /// @dev reverts. Held TRIBE should only be released by exchangeFei or mint
-    function withdrawERC20(address, address, uint256) public pure override {
-        revert("TribeReserveStabilizer: can't withdraw");
+    /// @dev reverts if _token is TRIBE. Held TRIBE should only be released by exchangeFei or mint
+    function withdrawERC20(address _token, address _to, uint256 _amount) public override {
+        require(_token != address(token), "TribeReserveStabilizer: can't withdraw TRIBE");
+        super.withdrawERC20(_token, _to, _amount);
     }
 
     /// @notice check whether collateralization ratio is below the threshold set

--- a/contracts/stabilizer/TribeReserveStabilizer.sol
+++ b/contracts/stabilizer/TribeReserveStabilizer.sol
@@ -42,6 +42,7 @@ contract TribeReserveStabilizer is ITribeReserveStabilizer, ReserveStabilizer {
         emit CollateralizationThresholdUpdate(0, _collateralizationThresholdBasisPoints);
         
         // Setting token here because it isn't available until after CoreRef is constructed
+        // This does skip the _setDecimalsNormalizerFromToken call in ReserveStabilizer constructor, but it isn't needed because TRIBE is 18 decimals
         token = tribe();
     }
 

--- a/contracts/stabilizer/TribeReserveStabilizer.sol
+++ b/contracts/stabilizer/TribeReserveStabilizer.sol
@@ -125,7 +125,7 @@ contract TribeReserveStabilizer is ITribeReserveStabilizer, ReserveStabilizer {
     }
 
     function _mint(address to, uint256 amount) internal {
-        ITribe _tribe = ITribe(address(tribe()));
+        ITribe _tribe = ITribe(address(token));
         _tribe.mint(to, amount);
     }
 }

--- a/contracts/stabilizer/TribeReserveStabilizer.sol
+++ b/contracts/stabilizer/TribeReserveStabilizer.sol
@@ -14,37 +14,37 @@ interface ITribe is IERC20 {
 contract TribeReserveStabilizer is ITribeReserveStabilizer, ReserveStabilizer {
     using Decimal for Decimal.D256;
 
-    /// @notice a FEI oracle reporting USD per FEI
-    IOracle public override feiOracle;
+    /// @notice a collateralization oracle
+    ICollateralizationOracle public override collateralizationOracle;
 
-    Decimal.D256 private _feiPriceThreshold;
+    Decimal.D256 private _collateralizationThreshold;
 
     /// @notice Tribe Reserve Stabilizer constructor
     /// @param _core Fei Core to reference
     /// @param _tribeOracle the TRIBE price oracle to reference
     /// @param _backupOracle the backup oracle to reference
     /// @param _usdPerFeiBasisPoints the USD price per FEI to sell TRIBE at
-    /// @param _feiOracle the FEI price oracle to reference
-    /// @param _feiPriceThresholdBasisPoints the FEI price below which the stabilizer becomes active. Reported in basis points (1/10000)
+    /// @param _collateralizationOracle the collateralization oracle to reference
+    /// @param _collateralizationThresholdBasisPoints the collateralization ratio below which the stabilizer becomes active. Reported in basis points (1/10000)
     constructor(
         address _core,
         address _tribeOracle,
         address _backupOracle,
         uint256 _usdPerFeiBasisPoints,
-        IOracle _feiOracle,
-        uint256 _feiPriceThresholdBasisPoints
+        ICollateralizationOracle _collateralizationOracle,
+        uint256 _collateralizationThresholdBasisPoints
     ) ReserveStabilizer(_core, _tribeOracle, _backupOracle, IERC20(address(0)), _usdPerFeiBasisPoints) {
-        feiOracle = _feiOracle;
-        emit FeiOracleUpdate(address(0), address(_feiOracle));
+        collateralizationOracle = _collateralizationOracle;
+        emit CollateralizationOracleUpdate(address(0), address(_collateralizationOracle));
     
-        _feiPriceThreshold = Decimal.ratio(_feiPriceThresholdBasisPoints, BASIS_POINTS_GRANULARITY);
-        emit FeiPriceThresholdUpdate(0, _feiPriceThresholdBasisPoints);
+        _collateralizationThreshold = Decimal.ratio(_collateralizationThresholdBasisPoints, BASIS_POINTS_GRANULARITY);
+        emit CollateralizationThresholdUpdate(0, _collateralizationThresholdBasisPoints);
     }
 
     /// @notice exchange FEI for minted TRIBE
-    /// @dev FEI oracle price must be below threshold
+    /// @dev Collateralization oracle price must be above threshold
     function exchangeFei(uint256 feiAmount) public override returns(uint256) {
-        require(isFeiBelowThreshold(), "TribeReserveStabilizer: FEI price too high");
+        require(isCollateralizationAboveThreshold(), "TribeReserveStabilizer: Collateralization ratio too low");
         return super.exchangeFei(feiAmount);
     }
 
@@ -58,34 +58,32 @@ contract TribeReserveStabilizer is ITribeReserveStabilizer, ReserveStabilizer {
         return tribeBalance();
     }
 
-    /// @notice check whether FEI price is below the threshold set relative to USD
-    /// @dev returns false if the FEI oracle is invalid
-    function isFeiBelowThreshold() public override view returns(bool) {
-        (Decimal.D256 memory price, bool valid) = feiOracle.read();
+    /// @notice check whether collateralization ratio is above the threshold set
+    /// @dev returns false if the oracle is invalid
+    function isCollateralizationAboveThreshold() public override view returns(bool) {
+        (Decimal.D256 memory price, bool valid) = collateralizationOracle.read();
 
-        return valid && price.lessThanOrEqualTo(_feiPriceThreshold);
+        return valid && price.lessThanOrEqualTo(_collateralizationThreshold);
     }
 
-    /// @notice set the FEI oracle
-    function setFeiOracle(IOracle newFeiOracle) external override onlyGovernor {
-        require(address(newFeiOracle) != address(0), "TribeReserveStabilizer: zero address");
-        address oldFeiOracle = address(feiOracle);
-        feiOracle = newFeiOracle;
-        emit FeiOracleUpdate(oldFeiOracle, address(newFeiOracle));
+    /// @notice set the Collateralization oracle
+    function setCollateralizationOracle(ICollateralizationOracle newCollateralizationOracle) external override onlyGovernor {
+        require(address(newCollateralizationOracle) != address(0), "TribeReserveStabilizer: zero address");
+        address oldCollateralizationOracle = address(collateralizationOracle);
+        collateralizationOracle = newCollateralizationOracle;
+        emit CollateralizationOracleUpdate(oldCollateralizationOracle, address(newCollateralizationOracle));
     }
     
-    /// @notice set the FEI price threshold below which exchanging becomes active
-    function setFeiPriceThreshold(uint256 newFeiPriceThresholdBasisPoints) external override onlyGovernor {
-        require(newFeiPriceThresholdBasisPoints <= BASIS_POINTS_GRANULARITY, "TribeReserveStabilizer: fei price threshold too high");
-        
-        uint256 oldFeiPriceThresholdBasisPoints = _feiPriceThreshold.mul(BASIS_POINTS_GRANULARITY).asUint256();
-        _feiPriceThreshold = Decimal.ratio(newFeiPriceThresholdBasisPoints, BASIS_POINTS_GRANULARITY);
-        emit FeiPriceThresholdUpdate(oldFeiPriceThresholdBasisPoints, newFeiPriceThresholdBasisPoints);
+    /// @notice set the collateralization threshold below which exchanging becomes active
+    function setCollateralizationThreshold(uint256 newCollateralizationThresholdBasisPoints) external override onlyGovernor {        
+        uint256 oldCollateralizationThresholdBasisPoints = _collateralizationThreshold.mul(BASIS_POINTS_GRANULARITY).asUint256();
+        _collateralizationThreshold = Decimal.ratio(newCollateralizationThresholdBasisPoints, BASIS_POINTS_GRANULARITY);
+        emit CollateralizationThresholdUpdate(oldCollateralizationThresholdBasisPoints, newCollateralizationThresholdBasisPoints);
     }
 
-    /// @notice the FEI price threshold below which exchanging becomes active
-    function feiPriceThreshold() external view override returns(Decimal.D256 memory) {
-        return _feiPriceThreshold;
+    /// @notice the collateralization threshold below which exchanging becomes active
+    function collateralizationThreshold() external view override returns(Decimal.D256 memory) {
+        return _collateralizationThreshold;
     }
 
     /// @notice mints TRIBE to the target address

--- a/test/stablizer/TribeReserveStabilizer.test.js
+++ b/test/stablizer/TribeReserveStabilizer.test.js
@@ -115,8 +115,21 @@ describe('TribeReserveStabilizer', function () {
   });
 
   describe('WithdrawERC20', function() {
-    it('reverts', async function() {
-      await expectRevert(this.reserveStabilizer.withdrawERC20(userAddress, userAddress, '1000000000', {from: pcvControllerAddress}), 'TribeReserveStabilizer: can\'t withdraw');
+    it('tribe token reverts', async function() {
+      await expectRevert(this.reserveStabilizer.withdrawERC20(this.tribe.address, userAddress, '1000000000', {from: pcvControllerAddress}), 'TribeReserveStabilizer: can\'t withdraw');
+    });
+
+    it('non-tribe token succeeds', async function() {
+      await this.fei.mint(this.reserveStabilizer.address, 1000, {from: minterAddress});  
+
+      await this.reserveStabilizer.withdrawERC20(this.fei.address, userAddress, '1000', {from: pcvControllerAddress});
+      expect(await this.fei.balanceOf(userAddress)).to.be.bignumber.equal('40001000');
+    });
+
+    it('non-pcv controller reverts', async function() {
+      await this.fei.mint(this.reserveStabilizer.address, 1000, {from: minterAddress});  
+
+      await expectRevert(this.reserveStabilizer.withdrawERC20(this.fei.address, userAddress, '1000', {from: userAddress}), 'CoreRef: Caller is not a PCV controller');
     });
   });
 


### PR DESCRIPTION
Part of Fei V2 Phase 1 that handles the inflation of TRIBE when the collateralization ratio is low.

Replaces the logic regarding the FEI peg/oracle with collateralization ratio logic. If the CR is below the configured threshold, then exchanging FEI for minted TRIBE becomes possible.

Any TRIBE held by the contract is transferred first before performing a direct mint.

Also restricts TRIBE withdrawals from the contract so TRIBE held is effectively burned barring a mint operation.

Uses the RateLimited utility to put a cap on how much TRIBE can be minted at once.