### PR TITLE
Rate limited FEI minter

### DIFF
--- a/contracts/bondingcurve/BondingCurve.sol
+++ b/contracts/bondingcurve/BondingCurve.sol
@@ -246,7 +246,7 @@ contract BondingCurve is IBondingCurve, OracleRef, PCVSplitter, Timed, Incentivi
         require(availableToMint() >= amountOut, "BondingCurve: exceeds mint cap");
 
         _incrementTotalPurchased(amountOut);
-        fei().mint(to, amountOut);
+        _mintFei(to, amountOut);
 
         emit Purchase(to, amountIn, amountOut);
 

--- a/contracts/mock/MockRateLimitedMinter.sol
+++ b/contracts/mock/MockRateLimitedMinter.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "../utils/RateLimitedMinter.sol";
+
+contract MockRateLimitedMinter is RateLimitedMinter {
+
+	constructor(
+        address _core, 
+        uint256 _feiLimitPerSecond, 
+        uint256 _mintingBufferCap, 
+        bool _doPartialMint
+    ) 
+        CoreRef(_core)
+        RateLimitedMinter(_feiLimitPerSecond, _mintingBufferCap, _doPartialMint)
+    {}
+
+	function setDoPartialMint(bool _doPartialMint) public {
+		doPartialMint = _doPartialMint;
+	}
+
+    function mint(address to, uint256 amount) public {
+        _mintFei(to, amount);
+    }
+}

--- a/contracts/mock/MockRateLimitedMinter.sol
+++ b/contracts/mock/MockRateLimitedMinter.sol
@@ -16,7 +16,7 @@ contract MockRateLimitedMinter is RateLimitedMinter {
     {}
 
 	function setDoPartialMint(bool _doPartialMint) public {
-		doPartialMint = _doPartialMint;
+		doPartialAction = _doPartialMint;
 	}
 
     function mint(address to, uint256 amount) public {

--- a/contracts/pcv/uniswap/PCVSwapperUniswap.sol
+++ b/contracts/pcv/uniswap/PCVSwapperUniswap.sol
@@ -39,6 +39,7 @@ contract PCVSwapperUniswap is IPCVSwapper, WethPCVDeposit, OracleRef, Timed, Inc
     IUniswapV2Pair public immutable pair;
 
     struct OracleData {
+        address _core;
         address _oracle;
         address _backupOracle;
         // invert should be false if the oracle is reported in tokenSpent terms otherwise true
@@ -53,32 +54,35 @@ contract PCVSwapperUniswap is IPCVSwapper, WethPCVDeposit, OracleRef, Timed, Inc
       address _tokenReceivingAddress;
       uint256 _maxSpentPerSwap;
       uint256 _maximumSlippageBasisPoints;
+      IUniswapV2Pair _pair;
     }
 
+    struct MinterData {
+      uint256 _swapFrequency;
+      uint256 _swapIncentiveAmount;
+    }
     constructor(
-        address _core,
-        IUniswapV2Pair _pair,
         OracleData memory oracleData,
         PCVSwapperData memory pcvSwapperData,
-        uint256 _swapFrequency,
-        uint256 _swapIncentiveAmount
+        MinterData memory minterData
     ) 
-    OracleRef(
-        _core, 
+      OracleRef(
+        oracleData._core, 
         oracleData._oracle, 
         oracleData._backupOracle,
         oracleData._decimalsNormalizer,
         oracleData._invertOraclePrice
       ) 
-      Timed(_swapFrequency) 
-      Incentivized(_swapIncentiveAmount) 
-      RateLimitedMinter(_swapIncentiveAmount / _swapFrequency, _swapIncentiveAmount, false) 
+      Timed(minterData._swapFrequency) 
+      Incentivized(minterData._swapIncentiveAmount) 
+      RateLimitedMinter(minterData._swapIncentiveAmount / minterData._swapFrequency, minterData._swapIncentiveAmount, false) 
     {
         address _tokenSpent = pcvSwapperData._tokenSpent;
         address _tokenReceived = pcvSwapperData._tokenReceived;
         address _tokenReceivingAddress = pcvSwapperData._tokenReceivingAddress;
         uint256 _maxSpentPerSwap = pcvSwapperData._maxSpentPerSwap;
         uint256 _maximumSlippageBasisPoints = pcvSwapperData._maximumSlippageBasisPoints;
+        IUniswapV2Pair _pair = pcvSwapperData._pair;
 
         require(_pair.token0() == _tokenSpent || _pair.token1() == _tokenSpent, "PCVSwapperUniswap: token spent not in pair");
         require(_pair.token0() == _tokenReceived || _pair.token1() == _tokenReceived, "PCVSwapperUniswap: token received not in pair");

--- a/contracts/pcv/uniswap/UniswapPCVDeposit.sol
+++ b/contracts/pcv/uniswap/UniswapPCVDeposit.sol
@@ -159,7 +159,7 @@ contract UniswapPCVDeposit is IUniswapPCVDeposit, PCVDeposit, UniRef {
     }
 
     function _addLiquidity(uint256 tokenAmount, uint256 feiAmount) internal {
-        _mintFei(feiAmount);
+        _mintFei(address(this), feiAmount);
 
         uint256 endOfTime = type(uint256).max;
         // Deposit price gated by slippage parameter

--- a/contracts/pcv/utils/PCVDripController.sol
+++ b/contracts/pcv/utils/PCVDripController.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.4;
 
 import "./IPCVDripController.sol"; 
 import "../../utils/Incentivized.sol"; 
-import "../../refs/CoreRef.sol";
+import "../../utils/RateLimitedMinter.sol"; 
 import "../../utils/Timed.sol";
 
 /// @title a PCV dripping controller
 /// @author Fei Protocol
-contract PCVDripController is IPCVDripController, CoreRef, Timed, Incentivized {
+contract PCVDripController is IPCVDripController, Timed, RateLimitedMinter, Incentivized {
  
     /// @notice source PCV deposit to withdraw from
     IPCVDeposit public override source;
@@ -33,7 +33,12 @@ contract PCVDripController is IPCVDripController, CoreRef, Timed, Incentivized {
         uint256 _frequency,
         uint256 _dripAmount,
         uint256 _incentiveAmount
-    ) CoreRef(_core) Timed(_frequency) Incentivized(_incentiveAmount) {
+    ) 
+        CoreRef(_core) 
+        Timed(_frequency) 
+        Incentivized(_incentiveAmount)
+        RateLimitedMinter(_incentiveAmount / _frequency, _incentiveAmount, false) 
+    {
         target = _target;
         emit TargetUpdate(address(0), address(_target));
 
@@ -110,5 +115,9 @@ contract PCVDripController is IPCVDripController, CoreRef, Timed, Incentivized {
     /// @notice checks whether the target balance is less than the drip amount
     function dripEligible() public view virtual override returns(bool) {
         return target.balance() < dripAmount;
+    }
+
+    function _mintFei(address to, uint256 amountIn) internal override(CoreRef, RateLimitedMinter) {
+      RateLimitedMinter._mintFei(to, amountIn);
     }
 }

--- a/contracts/refs/CoreRef.sol
+++ b/contracts/refs/CoreRef.sol
@@ -149,8 +149,10 @@ abstract contract CoreRef is ICoreRef, Pausable {
         fei().burn(feiBalance());
     }
 
-    function _mintFei(uint256 amount) internal {
-        fei().mint(address(this), amount);
+    function _mintFei(address to, uint256 amount) internal virtual {
+        if (amount != 0) {
+            fei().mint(to, amount);
+        }
     }
 
     function _setContractAdminRole(bytes32 newContractAdminRole) internal {

--- a/contracts/utils/Incentivized.sol
+++ b/contracts/utils/Incentivized.sol
@@ -27,6 +27,6 @@ abstract contract Incentivized is CoreRef {
     /// @notice incentivize a call with incentiveAmount FEI rewards
     /// @dev no-op if the contract does not have Minter role
     function _incentivize() internal ifMinterSelf {
-        fei().mint(msg.sender, incentiveAmount);
+        _mintFei(msg.sender, incentiveAmount);
     }
 }

--- a/contracts/utils/RateLimited.sol
+++ b/contracts/utils/RateLimited.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "../refs/CoreRef.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
+/// @title abstract contract for putting a rate limit on how fast a contract can perform an action e.g. Minting
+/// @author Fei Protocol
+abstract contract RateLimited is CoreRef {
+
+    /// @notice maximum rate limit per second governance can set for this contract
+    uint256 public immutable MAX_RATE_LIMIT_PER_SECOND;
+
+    /// @notice the rate per second for this contract
+    uint256 public rateLimitPerSecond;
+
+    /// @notice the last time the buffer was used by the contract
+    uint256 public lastBufferUsedTime;
+
+    /// @notice the cap of the buffer that can be used at once
+    uint256 public bufferCap;
+
+    /// @notice a flag for whether to allow partial actions to complete if the buffer is less than amount
+    bool public doPartialAction;
+
+    uint256 private _bufferStored;
+
+    event BufferCapUpdate(uint256 oldBufferCap, uint256 newBufferCap);
+    event RateLimitPerSecondUpdate(uint256 oldRateLimitPerSecond, uint256 newRateLimitPerSecond);
+
+    constructor(uint256 _maxRateLimitPerSecond, uint256 _rateLimitPerSecond, uint256 _bufferCap, bool _doPartialAction) {
+        lastBufferUsedTime = block.timestamp;
+
+        _bufferStored = _bufferCap;
+        _setBufferCap(_bufferCap);
+
+        require(_rateLimitPerSecond <= _maxRateLimitPerSecond, "RateLimitedMinter: rateLimitPerSecond too high");
+        _setRateLimitPerSecond(_rateLimitPerSecond);
+        
+        MAX_RATE_LIMIT_PER_SECOND = _maxRateLimitPerSecond;
+        doPartialAction = _doPartialAction;
+    }
+
+    /// @notice set the rate limit per second
+    function setRateLimitPerSecond(uint256 newRateLimitPerSecond) external onlyGovernorOrAdmin {
+        require(newRateLimitPerSecond <= MAX_RATE_LIMIT_PER_SECOND, "RateLimitedMinter: rateLimitPerSecond too high");
+        _setRateLimitPerSecond(newRateLimitPerSecond);
+    }
+
+    /// @notice set the buffer cap
+    function setbufferCap(uint256 newBufferCap) external onlyGovernorOrAdmin {
+        _setBufferCap(newBufferCap);
+    }
+
+    /// @notice the amount of action used before hitting limit
+    /// @dev replenishes at rateLimitPerSecond per second up to bufferCap
+    function buffer() public view returns(uint256) { 
+        uint256 elapsed = block.timestamp - lastBufferUsedTime;
+        return Math.min(_bufferStored + (rateLimitPerSecond * elapsed), bufferCap);
+    }
+
+    function _depleteBuffer(uint256 amount) internal returns(uint256) {
+        uint256 newBuffer = buffer();
+        
+        uint256 usedAmount = amount;
+        if (doPartialAction && usedAmount > newBuffer) {
+            usedAmount = newBuffer;
+        }
+
+        require(usedAmount <= newBuffer, "RateLimitedMinter: rate limit hit");
+
+        _bufferStored = newBuffer - usedAmount;
+
+        lastBufferUsedTime = block.timestamp;
+
+        return usedAmount;
+    }
+
+    function _setRateLimitPerSecond(uint256 newRateLimitPerSecond) internal {
+
+        // Reset the stored buffer and last buffer used time using the prior RateLimitPerSecond
+        _bufferStored = buffer();
+        lastBufferUsedTime = block.timestamp;
+
+        uint256 oldRateLimitPerSecond = rateLimitPerSecond;
+        rateLimitPerSecond = newRateLimitPerSecond;
+
+        emit RateLimitPerSecondUpdate(oldRateLimitPerSecond, newRateLimitPerSecond);
+    }
+
+    function _setBufferCap(uint256 newBufferCap) internal {
+        uint256 oldBufferCap = bufferCap;
+        bufferCap = newBufferCap;
+
+        // Cap the existing stored buffer
+        if (_bufferStored > newBufferCap) {
+            _bufferStored = newBufferCap;
+        }
+
+        emit BufferCapUpdate(oldBufferCap, newBufferCap);
+    }
+}

--- a/contracts/utils/RateLimited.sol
+++ b/contracts/utils/RateLimited.sol
@@ -34,7 +34,7 @@ abstract contract RateLimited is CoreRef {
         _bufferStored = _bufferCap;
         _setBufferCap(_bufferCap);
 
-        require(_rateLimitPerSecond <= _maxRateLimitPerSecond, "RateLimitedMinter: rateLimitPerSecond too high");
+        require(_rateLimitPerSecond <= _maxRateLimitPerSecond, "RateLimited: rateLimitPerSecond too high");
         _setRateLimitPerSecond(_rateLimitPerSecond);
         
         MAX_RATE_LIMIT_PER_SECOND = _maxRateLimitPerSecond;
@@ -43,7 +43,7 @@ abstract contract RateLimited is CoreRef {
 
     /// @notice set the rate limit per second
     function setRateLimitPerSecond(uint256 newRateLimitPerSecond) external onlyGovernorOrAdmin {
-        require(newRateLimitPerSecond <= MAX_RATE_LIMIT_PER_SECOND, "RateLimitedMinter: rateLimitPerSecond too high");
+        require(newRateLimitPerSecond <= MAX_RATE_LIMIT_PER_SECOND, "RateLimited: rateLimitPerSecond too high");
         _setRateLimitPerSecond(newRateLimitPerSecond);
     }
 
@@ -67,7 +67,7 @@ abstract contract RateLimited is CoreRef {
             usedAmount = newBuffer;
         }
 
-        require(usedAmount <= newBuffer, "RateLimitedMinter: rate limit hit");
+        require(usedAmount <= newBuffer, "RateLimited: rate limit hit");
 
         _bufferStored = newBuffer - usedAmount;
 

--- a/contracts/utils/RateLimited.sol
+++ b/contracts/utils/RateLimited.sol
@@ -23,6 +23,7 @@ abstract contract RateLimited is CoreRef {
     /// @notice a flag for whether to allow partial actions to complete if the buffer is less than amount
     bool public doPartialAction;
 
+    /// @notice the buffer at the timestamp of lastBufferUsedTime
     uint256 private _bufferStored;
 
     event BufferCapUpdate(uint256 oldBufferCap, uint256 newBufferCap);
@@ -59,6 +60,13 @@ abstract contract RateLimited is CoreRef {
         return Math.min(_bufferStored + (rateLimitPerSecond * elapsed), bufferCap);
     }
 
+    /** 
+        @notice the method that enforces the rate limit. Decreases buffer by "amount". 
+        If buffer is <= amount either
+        1. Does a partial mint by the amount remaining in the buffer or
+        2. Reverts
+        Depending on whether doPartialAction is true or false
+    */
     function _depleteBuffer(uint256 amount) internal returns(uint256) {
         uint256 newBuffer = buffer();
         

--- a/contracts/utils/RateLimitedMinter.sol
+++ b/contracts/utils/RateLimitedMinter.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "../refs/CoreRef.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
+/// @title abstract contract for putting a rate limit on how fast a contract can mint FEI
+/// @author Fei Protocol
+abstract contract RateLimitedMinter is CoreRef {
+
+    /// @notice maximum amount of FEI per second governance can set for this contract
+    uint256 public constant MAX_FEI_LIMIT_PER_SECOND = 10_000e18; // 10000 FEI/s or ~860m FEI/day
+
+    /// @notice the FEI per second mintable by this contract
+    uint256 public feiLimitPerSecond;
+
+    /// @notice the last time FEI was minted by the contract
+    uint256 public lastMintTime;
+
+    /// @notice the cap of FEI that can be minted at once
+    uint256 public mintingBufferCap;
+
+    /// @notice a flag for whether to allow partial mints to complete if the buffer is less than mint amount
+    bool public doPartialMint;
+
+    uint256 private _mintingBufferStored;
+
+    event MintingBufferCapUpdate(uint256 oldMintingBufferCap, uint256 newMintingBufferCap);
+    event FeiLimitPerSecondUpdate(uint256 oldFeiLimitPerSecond, uint256 newFeiLimitPerSecond);
+
+    constructor(uint256 _feiLimitPerSecond, uint256 _mintingBufferCap, bool _doPartialMint) {
+        lastMintTime = block.timestamp;
+
+        _mintingBufferStored = _mintingBufferCap;
+        _setMintingBufferCap(_mintingBufferCap);
+
+        _setFeiLimitPerSecond(_feiLimitPerSecond);
+        
+        doPartialMint = _doPartialMint;
+    }
+
+    /// @notice set the FEI minting limit per second
+    function setFeiLimitPerSecond(uint256 newFeiLimitPerSecond) external onlyGovernorOrAdmin {
+        _setFeiLimitPerSecond(newFeiLimitPerSecond);
+    }
+
+    /// @notice set the minting buffer cap
+    function setMintingBufferCap(uint256 newMintingBufferCap) external onlyGovernorOrAdmin {
+        _setMintingBufferCap(newMintingBufferCap);
+    }
+
+    /// @notice the amount of FEI that can be minted before hitting limit
+    /// @dev replenishes at feiLimitPerSecond FEI per second up to mintingBufferCap
+    function mintingBuffer() public view returns(uint256) { 
+        uint256 elapsed = block.timestamp - lastMintTime;
+        return Math.min(_mintingBufferStored + (feiLimitPerSecond * elapsed), mintingBufferCap);
+    }
+
+    /// @notice override the FEI minting behavior to enfore a rate limit
+    function _mintFei(address to, uint256 amount) internal virtual override {
+        
+        uint256 newMintingBuffer = mintingBuffer();
+        
+        uint256 mintAmount = amount;
+        if (doPartialMint && mintAmount > newMintingBuffer) {
+            mintAmount = newMintingBuffer;
+        }
+
+        require(mintAmount <= newMintingBuffer, "RateLimitedMinter: rate limit hit");
+
+        _mintingBufferStored = newMintingBuffer - mintAmount;
+
+        lastMintTime = block.timestamp;
+
+        super._mintFei(to, mintAmount);
+    }
+
+    function _setFeiLimitPerSecond(uint256 newFeiLimitPerSecond) internal {
+        require(newFeiLimitPerSecond <= MAX_FEI_LIMIT_PER_SECOND, "RateLimitedMinter: feiLimitPerSecond too high");
+
+        // Reset the stored minting buffer and last mint time using the prior feiLimitPerSecond
+        _mintingBufferStored = mintingBuffer();
+        lastMintTime = block.timestamp;
+
+        uint256 oldFeiLimitPerSecond = feiLimitPerSecond;
+        feiLimitPerSecond = newFeiLimitPerSecond;
+
+        emit FeiLimitPerSecondUpdate(oldFeiLimitPerSecond, newFeiLimitPerSecond);
+    }
+
+    function _setMintingBufferCap(uint256 newMintingBufferCap) internal {
+        uint256 oldMintingBufferCap = mintingBufferCap;
+        mintingBufferCap = newMintingBufferCap;
+
+        // Cap the existing stored buffer
+        if (_mintingBufferStored > newMintingBufferCap) {
+            _mintingBufferStored = newMintingBufferCap;
+        }
+
+        emit MintingBufferCapUpdate(oldMintingBufferCap, newMintingBufferCap);
+    }
+}

--- a/contracts/utils/RateLimitedMinter.sol
+++ b/contracts/utils/RateLimitedMinter.sol
@@ -1,102 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.4;
 
-import "../refs/CoreRef.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
+import "./RateLimited.sol";
 
 /// @title abstract contract for putting a rate limit on how fast a contract can mint FEI
 /// @author Fei Protocol
-abstract contract RateLimitedMinter is CoreRef {
+abstract contract RateLimitedMinter is RateLimited {
 
-    /// @notice maximum amount of FEI per second governance can set for this contract
-    uint256 public constant MAX_FEI_LIMIT_PER_SECOND = 10_000e18; // 10000 FEI/s or ~860m FEI/day
-
-    /// @notice the FEI per second mintable by this contract
-    uint256 public feiLimitPerSecond;
-
-    /// @notice the last time FEI was minted by the contract
-    uint256 public lastMintTime;
-
-    /// @notice the cap of FEI that can be minted at once
-    uint256 public mintingBufferCap;
-
-    /// @notice a flag for whether to allow partial mints to complete if the buffer is less than mint amount
-    bool public doPartialMint;
-
-    uint256 private _mintingBufferStored;
-
-    event MintingBufferCapUpdate(uint256 oldMintingBufferCap, uint256 newMintingBufferCap);
-    event FeiLimitPerSecondUpdate(uint256 oldFeiLimitPerSecond, uint256 newFeiLimitPerSecond);
-
-    constructor(uint256 _feiLimitPerSecond, uint256 _mintingBufferCap, bool _doPartialMint) {
-        lastMintTime = block.timestamp;
-
-        _mintingBufferStored = _mintingBufferCap;
-        _setMintingBufferCap(_mintingBufferCap);
-
-        _setFeiLimitPerSecond(_feiLimitPerSecond);
-        
-        doPartialMint = _doPartialMint;
-    }
-
-    /// @notice set the FEI minting limit per second
-    function setFeiLimitPerSecond(uint256 newFeiLimitPerSecond) external onlyGovernorOrAdmin {
-        _setFeiLimitPerSecond(newFeiLimitPerSecond);
-    }
-
-    /// @notice set the minting buffer cap
-    function setMintingBufferCap(uint256 newMintingBufferCap) external onlyGovernorOrAdmin {
-        _setMintingBufferCap(newMintingBufferCap);
-    }
-
-    /// @notice the amount of FEI that can be minted before hitting limit
-    /// @dev replenishes at feiLimitPerSecond FEI per second up to mintingBufferCap
-    function mintingBuffer() public view returns(uint256) { 
-        uint256 elapsed = block.timestamp - lastMintTime;
-        return Math.min(_mintingBufferStored + (feiLimitPerSecond * elapsed), mintingBufferCap);
-    }
+    uint256 private constant MAX_FEI_LIMIT_PER_SECOND = 10_000e18; // 10000 FEI/s or ~860m FEI/day
+    
+    constructor(
+        uint256 _feiLimitPerSecond, 
+        uint256 _mintingBufferCap, 
+        bool _doPartialMint
+    ) 
+        RateLimited(MAX_FEI_LIMIT_PER_SECOND, _feiLimitPerSecond, _mintingBufferCap, _doPartialMint)
+    {}
 
     /// @notice override the FEI minting behavior to enfore a rate limit
     function _mintFei(address to, uint256 amount) internal virtual override {
-        
-        uint256 newMintingBuffer = mintingBuffer();
-        
-        uint256 mintAmount = amount;
-        if (doPartialMint && mintAmount > newMintingBuffer) {
-            mintAmount = newMintingBuffer;
-        }
-
-        require(mintAmount <= newMintingBuffer, "RateLimitedMinter: rate limit hit");
-
-        _mintingBufferStored = newMintingBuffer - mintAmount;
-
-        lastMintTime = block.timestamp;
-
+        uint256 mintAmount = _depleteBuffer(amount);
         super._mintFei(to, mintAmount);
-    }
-
-    function _setFeiLimitPerSecond(uint256 newFeiLimitPerSecond) internal {
-        require(newFeiLimitPerSecond <= MAX_FEI_LIMIT_PER_SECOND, "RateLimitedMinter: feiLimitPerSecond too high");
-
-        // Reset the stored minting buffer and last mint time using the prior feiLimitPerSecond
-        _mintingBufferStored = mintingBuffer();
-        lastMintTime = block.timestamp;
-
-        uint256 oldFeiLimitPerSecond = feiLimitPerSecond;
-        feiLimitPerSecond = newFeiLimitPerSecond;
-
-        emit FeiLimitPerSecondUpdate(oldFeiLimitPerSecond, newFeiLimitPerSecond);
-    }
-
-    function _setMintingBufferCap(uint256 newMintingBufferCap) internal {
-        uint256 oldMintingBufferCap = mintingBufferCap;
-        mintingBufferCap = newMintingBufferCap;
-
-        // Cap the existing stored buffer
-        if (_mintingBufferStored > newMintingBufferCap) {
-            _mintingBufferStored = newMintingBufferCap;
-        }
-
-        emit MintingBufferCapUpdate(oldMintingBufferCap, newMintingBufferCap);
     }
 }

--- a/test/pcv/ERC20Dripper.test.js
+++ b/test/pcv/ERC20Dripper.test.js
@@ -30,7 +30,7 @@ const dripAmount = new BN(4000000).mul(new BN(10).pow(new BN(18)));
 // this is 1 week in seconds
 const dripFrequency = 604800;
 
-describe.only('ERC20Dripper', () => {
+describe('ERC20Dripper', () => {
   before(async () => {
     ({
       userAddress,

--- a/test/pcv/PCVSwapperUniswap.test.js
+++ b/test/pcv/PCVSwapperUniswap.test.js
@@ -49,9 +49,8 @@ describe('PCVSwapperUniswap', function () {
     this.chainlinkOracleWrapper = await ChainlinkOracleWrapper.new(this.core.address, this.mockChainlinkOracle.address);
 
     this.swapper = await PCVSwapperUniswap.new(
-      this.core.address, // core
-      this.pair.address, // pair
       {
+        _core: this.core.address,
         _oracle: this.oracle.address, // oracle
         _backupOracle: this.oracle.address, // backup oracle
         _invertOraclePrice: false,
@@ -62,10 +61,14 @@ describe('PCVSwapperUniswap', function () {
         _tokenReceived: this.fei.address,
         _tokenReceivingAddress: userAddress,
         _maxSpentPerSwap: `100${e18}`,
-        _maximumSlippageBasisPoints: '300' 
+        _maximumSlippageBasisPoints: '300',
+        _pair: this.pair.address,
+
       },
-      '1000', // default minimum interval between swaps
-      `200${e18}` // swap incentive = 200 FEI
+      {
+        _swapFrequency: '1000',
+        _swapIncentiveAmount: `200${e18}` // swap incentive = 200 FEI
+      }       
     );
 
     await this.core.grantPCVController(pcvControllerAddress, {from: governorAddress});

--- a/test/pcv/PCVSwapperUniswap.test.js
+++ b/test/pcv/PCVSwapperUniswap.test.js
@@ -57,12 +57,14 @@ describe('PCVSwapperUniswap', function () {
         _invertOraclePrice: false,
         _decimalsNormalizer: 0,
       }, 
+      {
+        _tokenSpent: this.weth.address,
+        _tokenReceived: this.fei.address,
+        _tokenReceivingAddress: userAddress,
+        _maxSpentPerSwap: `100${e18}`,
+        _maximumSlippageBasisPoints: '300' 
+      },
       '1000', // default minimum interval between swaps
-      this.weth.address, // tokenSpent
-      this.fei.address, // tokenReceived
-      userAddress, // tokenReceivingAddress
-      `100${e18}`, // maxSpentPerSwap
-      '300', // maximumSlippageBasisPoints
       `200${e18}` // swap incentive = 200 FEI
     );
 

--- a/test/utils/RateLimitedMinter.test.js
+++ b/test/utils/RateLimitedMinter.test.js
@@ -1,0 +1,111 @@
+const {
+  BN,
+  time,
+  expectRevert,
+  expect,
+  expectApprox,
+  getAddresses,
+  getCore,
+} = require('../helpers');
+    
+const RateLimitedMinter = artifacts.require('MockRateLimitedMinter');
+const Fei = artifacts.require('Fei');
+  
+describe('RateLimitedMinter', function () {
+  let userAddress;
+  let governorAddress;
+  
+  beforeEach(async function () {
+    ({
+      userAddress,
+      governorAddress,
+    } = await getAddresses());
+      
+    this.core = await getCore(true);
+  
+    this.fei = await Fei.at(await this.core.fei());
+
+    this.feiLimitPerSecond = '1';
+    this.mintingBufferCap = '20000';
+    this.rateLimitedMinter = await RateLimitedMinter.new(
+      this.core.address, 
+      this.feiLimitPerSecond, 
+      this.mintingBufferCap, 
+      false
+    );
+
+    await this.core.grantMinter(this.rateLimitedMinter.address, {from: governorAddress});
+  });
+  
+  describe('Mint', function() {
+    describe('Full mint', function() {
+      beforeEach(async function () {
+        await this.rateLimitedMinter.mint(userAddress, this.mintingBufferCap);
+      });
+
+      it('clears out buffer', async function() {
+        expectApprox(await this.rateLimitedMinter.mintingBuffer(), '0');
+        expect(await this.fei.balanceOf(userAddress)).to.be.bignumber.equal(this.mintingBufferCap);
+      });
+
+      it('second mint reverts', async function() {
+        await expectRevert(this.rateLimitedMinter.mint(userAddress, this.mintingBufferCap), 'RateLimitedMinter: rate limit hit');
+      });
+
+      it('time increase refreshes buffer', async function() {
+        await time.increase('1000');
+        expectApprox(await this.rateLimitedMinter.mintingBuffer(), '1000');
+      });
+    });
+    describe('Partial Mint', function() {
+      beforeEach(async function () {
+        this.mintAmount = '10000';
+        await this.rateLimitedMinter.setDoPartialMint(true); // mock method
+        await this.rateLimitedMinter.mint(userAddress, this.mintAmount);
+      });
+    
+      it('partially clears out buffer', async function() {
+        expectApprox(await this.rateLimitedMinter.mintingBuffer(), '10000');
+        expect(await this.fei.balanceOf(userAddress)).to.be.bignumber.equal(this.mintAmount);
+      });
+    
+      it('second mint is partial', async function() {
+        await this.rateLimitedMinter.mint(userAddress, this.mintingBufferCap);
+        expectApprox(await this.fei.balanceOf(userAddress), this.mintingBufferCap);
+        expectApprox(await this.rateLimitedMinter.mintingBuffer(), '0');
+      });
+    
+      it('time increase refreshes buffer', async function() {
+        await time.increase('1000');
+        expectApprox(await this.rateLimitedMinter.mintingBuffer(), '11000');
+      });
+    });
+  });
+  
+  describe('Set Fei Limit Per Second', function() {
+    it('governor succeeds', async function() {
+      await this.rateLimitedMinter.setFeiLimitPerSecond('10000', {from: governorAddress});
+      expect(await this.rateLimitedMinter.feiLimitPerSecond()).to.be.bignumber.equal(new BN('10000'));
+    });
+  
+    it('non-governor reverts', async function() {
+      await expectRevert(this.rateLimitedMinter.setFeiLimitPerSecond('10000', {from: userAddress}), 'CoreRef: Caller is not a governor');
+    });
+  
+    it('too high fei rate reverts', async function() {
+      await expectRevert(this.rateLimitedMinter.setFeiLimitPerSecond(new BN('20000000000000000000000'), {from: governorAddress}), 'RateLimitedMinter: feiLimitPerSecond too high');
+    });
+  });
+
+  describe('Set Minting Buffer Cap', function() {
+    it('governor succeeds', async function() {
+      await this.rateLimitedMinter.setMintingBufferCap('10000', {from: governorAddress});
+      expect(await this.rateLimitedMinter.mintingBufferCap()).to.be.bignumber.equal(new BN('10000'));
+      expect(await this.rateLimitedMinter.mintingBuffer()).to.be.bignumber.equal(new BN('10000'));
+    });
+  
+    it('non-governor reverts', async function() {
+      await expectRevert(this.rateLimitedMinter.setMintingBufferCap('10000', {from: userAddress}), 'CoreRef: Caller is not a governor');
+    });
+  });
+});

--- a/test/utils/RateLimitedMinter.test.js
+++ b/test/utils/RateLimitedMinter.test.js
@@ -49,7 +49,7 @@ describe('RateLimitedMinter', function () {
       });
 
       it('second mint reverts', async function() {
-        await expectRevert(this.rateLimitedMinter.mint(userAddress, this.bufferCap), 'RateLimitedMinter: rate limit hit');
+        await expectRevert(this.rateLimitedMinter.mint(userAddress, this.bufferCap), 'RateLimited: rate limit hit');
       });
 
       it('time increase refreshes buffer', async function() {
@@ -93,7 +93,7 @@ describe('RateLimitedMinter', function () {
     });
   
     it('too high fei rate reverts', async function() {
-      await expectRevert(this.rateLimitedMinter.setRateLimitPerSecond(new BN('20000000000000000000000'), {from: governorAddress}), 'RateLimitedMinter: rateLimitPerSecond too high');
+      await expectRevert(this.rateLimitedMinter.setRateLimitPerSecond(new BN('20000000000000000000000'), {from: governorAddress}), 'RateLimited: rateLimitPerSecond too high');
     });
   });
 


### PR DESCRIPTION
Adds a helper abstract class which hard rate limits the speed with which FEI can be minted by a contract.

Uses a buffer that gets depleted as FEI is minted and replenishes over time up to the cap.

Does not use the Timed utility to allow extending contracts to use it for other use cases.

Extents the base _mintFei method of CoreRef so all minting operations are affected.

This class is intended to be used by the PCVEquityMinter once that is merged into the v2 branch