### PR TITLE
Pcv deposit wrapper

### DIFF
--- a/contracts/pcv/utils/PCVDepositWrapper.sol
+++ b/contracts/pcv/utils/PCVDepositWrapper.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.8.4;
+
+import "../IPCVDeposit.sol";
+
+/**
+  @notice a lightweight contract to wrap old PCV deposits to use the new interface 
+  @author Fei Protocol
+  When upgrading the PCVDeposit interface, there are many old contracts which do not support it.
+  The main use case for the new interface is to add read methods for the Collateralization Oracle.
+  Most PCVDeposits resistant balance method is simply returning the balance as a pass-through
+  If the PCVDeposit holds FEI it may be considered as protocol FEI
+
+  This wrapper can be used in the CR oracle which reduces the number of contract upgrades and reduces the complexity and risk of the upgrade
+*/
+contract PCVDepositWrapper {
+   
+    /// @notice the referenced PCV Deposit
+    IPCVDeposit public pcvDeposit;
+
+    /// @notice the balance reported in token
+    address public token;
+
+    /// @notice a flag for whether to report the balance as protocol owned FEI
+    bool public isProtocolFeiDeposit;
+
+    constructor(IPCVDeposit _pcvDeposit, address _token, bool _isProtocolFeiDeposit) {
+        pcvDeposit = _pcvDeposit;
+        token = _token;
+        isProtocolFeiDeposit = _isProtocolFeiDeposit;
+    }
+
+    /// @notice returns total balance of PCV in the Deposit
+    function balance() public view returns (uint256) {
+        return pcvDeposit.balance();
+    }
+
+    /// @notice returns the resistant balance and FEI in the deposit
+    function resistantBalanceAndFei() public view returns (uint256, uint256) {
+        uint256 resistantBalance = balance();
+        uint256 reistantFei = isProtocolFeiDeposit ? resistantBalance : 0;
+        return (resistantBalance, reistantFei);
+    }
+
+    /// @notice display the related token of the balance reported
+    function balanceReportedIn() public view returns (address) {
+        return token;
+    }
+}

--- a/test/pcv/PCVDepositWrapper.test.js
+++ b/test/pcv/PCVDepositWrapper.test.js
@@ -7,7 +7,7 @@ const PCVDepositWrapper = artifacts.require('PCVDepositWrapper');
 const MockPCVDepositV2 = artifacts.require('MockPCVDepositV2');
 const MockERC20 = artifacts.require('MockERC20');
 
-describe.only('PCVDepositWrapper', function () {
+describe('PCVDepositWrapper', function () {
   beforeEach(async function () {
     this.balance = '2000';
     this.core = await getCore();

--- a/test/pcv/PCVDepositWrapper.test.js
+++ b/test/pcv/PCVDepositWrapper.test.js
@@ -1,0 +1,52 @@
+const {
+  expect,
+  getCore,
+} = require('../helpers');
+
+const PCVDepositWrapper = artifacts.require('PCVDepositWrapper');
+const MockPCVDepositV2 = artifacts.require('MockPCVDepositV2');
+const MockERC20 = artifacts.require('MockERC20');
+
+describe.only('PCVDepositWrapper', function () {
+  beforeEach(async function () {
+    this.balance = '2000';
+    this.core = await getCore();
+    this.token = await MockERC20.new();
+    this.deposit = await MockPCVDepositV2.new(
+      this.core.address,
+      this.token.address,
+      this.balance,
+      '0' // ignoted protocol FEI
+    );
+  });
+
+  it('normal PCV deposit', async function() {
+    const pcvDepositWrapper = await PCVDepositWrapper.new(
+      this.deposit.address,
+      this.token.address,
+      false
+    );
+
+    expect(await pcvDepositWrapper.balanceReportedIn()).to.be.equal(this.token.address);
+    expect(await pcvDepositWrapper.balance()).to.be.bignumber.equal(this.balance);
+    const resistantBalances = await pcvDepositWrapper.resistantBalanceAndFei();
+
+    expect(resistantBalances[0]).to.be.bignumber.equal(this.balance);
+    expect(resistantBalances[1]).to.be.bignumber.equal('0');
+  });
+
+  it('Protocol owned FEI PCV deposit', async function() {
+    const pcvDepositWrapper = await PCVDepositWrapper.new(
+      this.deposit.address,
+      this.token.address,
+      true
+    );
+
+    expect(await pcvDepositWrapper.balanceReportedIn()).to.be.equal(this.token.address);
+    expect(await pcvDepositWrapper.balance()).to.be.bignumber.equal(this.balance);
+    const resistantBalances = await pcvDepositWrapper.resistantBalanceAndFei();
+
+    expect(resistantBalances[0]).to.be.bignumber.equal(this.balance);
+    expect(resistantBalances[1]).to.be.bignumber.equal(this.balance);
+  });
+});


### PR DESCRIPTION
A wrapper to simplify the v2 upgrade to CR oracle that adapts old PCV Deposits to the new interface