### PR TITLE
Collateralization Oracle Wrapper Proxy

### DIFF
--- a/contracts/oracle/CollateralizationOracleWrapper.sol
+++ b/contracts/oracle/CollateralizationOracleWrapper.sol
@@ -59,16 +59,27 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracle, Core
 
     /// @notice CollateralizationOracleWrapper constructor
     /// @param _core Fei Core for reference.
+    /// @param _validityDuration the duration after which a reading becomes outdated.
+    constructor(
+        address _core,
+        uint256 _validityDuration
+    ) CoreRef(_core) Timed(_validityDuration) {}
+
+    /// @notice CollateralizationOracleWrapper initializer
+    /// @param _core Fei Core for reference.
     /// @param _collateralizationOracle the CollateralizationOracle to inspect.
     /// @param _validityDuration the duration after which a reading becomes outdated.
     /// @param _deviationThresholdBasisPoints threshold for deviation after which
     ///        keepers should call the update() function.
-    constructor(
+    function initialize(
         address _core,
         address _collateralizationOracle,
         uint256 _validityDuration,
         uint256 _deviationThresholdBasisPoints
-    ) CoreRef(_core) Timed(_validityDuration) {
+    ) public {
+        require(collateralizationOracle == address(0), "CollateralizationOracleWrapper: initialized");
+        CoreRef._initialize(_core);
+        _setDuration(_validityDuration);
         collateralizationOracle = _collateralizationOracle;
         deviationThresholdBasisPoints = _deviationThresholdBasisPoints;
     }


### PR DESCRIPTION
Refactor the constructor so that the CollateralizationOracleWrapper can be initialized through a Proxy.