### PR TITLE
Add Admin support on contract level for Fei Protocol

### DIFF
--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -117,12 +117,12 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     ///         note : this function reverts if the deposit is already in the list.
     ///         note : this function reverts if the deposit's token has no oracle.
     /// @param _deposit : the PCVDeposit to add to the list.
-    function addDeposit(address _deposit) public onlyGovernor {
+    function addDeposit(address _deposit) public onlyGovernorOrAdmin {
         _addDeposit(_deposit);
     }
 
     /// @notice adds a list of multiple PCV deposits. See addDeposit.
-    function addDeposits(address[] memory _deposits) public onlyGovernor {
+    function addDeposits(address[] memory _deposits) public onlyGovernorOrAdmin {
         _addDeposits(_deposits);
     }
 
@@ -155,12 +155,12 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     ///         the collateralization ratio oracle.
     ///         note : this function reverts if the input deposit is not found.
     /// @param _deposit : the PCVDeposit address to remove from the list.
-    function removeDeposit(address _deposit) public onlyGovernor {
+    function removeDeposit(address _deposit) public onlyGovernorOrAdmin {
         _removeDeposit(_deposit);
     }
 
     /// @notice removes a list of multiple PCV deposits. See removeDeposit.
-    function removeDeposits(address[] memory _deposits) public onlyGovernor {
+    function removeDeposits(address[] memory _deposits) public onlyGovernorOrAdmin {
         for (uint256 i = 0; i < _deposits.length; i++) {
             _removeDeposit(_deposits[i]);
         }
@@ -192,7 +192,7 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     ///         of a deposit (holding the same token) is deployed.
     /// @param _oldDeposit : the PCVDeposit to remove from the list.
     /// @param _newDeposit : the PCVDeposit to add to the list.
-    function swapDeposit(address _oldDeposit, address _newDeposit) external onlyGovernor {
+    function swapDeposit(address _oldDeposit, address _newDeposit) external onlyGovernorOrAdmin {
         removeDeposit(_oldDeposit);
         addDeposit(_newDeposit);
     }
@@ -200,12 +200,12 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     /// @notice Set the price feed oracle (in USD) for a given asset.
     /// @param _token : the asset to add price oracle for
     /// @param _newOracle : price feed oracle for the given asset
-    function setOracle(address _token, address _newOracle) external onlyGovernor {
+    function setOracle(address _token, address _newOracle) external onlyGovernorOrAdmin {
         _setOracle(_token, _newOracle);
     }
 
     /// @notice adds a list of token oracles. See setOracle.
-    function setOracles(address[] memory _tokens, address[] memory _oracles) public onlyGovernor {
+    function setOracles(address[] memory _tokens, address[] memory _oracles) public onlyGovernorOrAdmin {
         _setOracles(_tokens, _oracles);
     }
 

--- a/contracts/oracle/CollateralizationOracleWrapper.sol
+++ b/contracts/oracle/CollateralizationOracleWrapper.sol
@@ -106,7 +106,7 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
     /// @notice set the deviation threshold in basis points, used to detect if the
     /// cached value deviated significantly from the actual fresh readings.
     /// @param _newDeviationThresholdBasisPoints the new value to set.
-    function setDeviationThresholdBasisPoints(uint256 _newDeviationThresholdBasisPoints) external override onlyGovernor {
+    function setDeviationThresholdBasisPoints(uint256 _newDeviationThresholdBasisPoints) external override onlyGovernorOrAdmin {
         require(_newDeviationThresholdBasisPoints > 0 && _newDeviationThresholdBasisPoints <= 10_000, "CollateralizationOracleWrapper: invalid basis points");
         uint256 _oldDeviationThresholdBasisPoints = deviationThresholdBasisPoints;
 
@@ -122,7 +122,7 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
     /// @notice set the validity duration of the cached collateralization values.
     /// @param _validityDuration the new validity duration
     /// This function will emit a DurationUpdate event from Timed.sol
-    function setValidityDuration(uint256 _validityDuration) external override onlyGovernor {
+    function setValidityDuration(uint256 _validityDuration) external override onlyGovernorOrAdmin {
         _setDuration(_validityDuration);
     }
 

--- a/contracts/oracle/UniswapOracle.sol
+++ b/contracts/oracle/UniswapOracle.sol
@@ -111,7 +111,7 @@ contract UniswapOracle is IUniswapOracle, CoreRef {
     }
 
     /// @notice set a new duration for the TWAP window
-    function setDuration(uint256 _duration) external override onlyGovernor {
+    function setDuration(uint256 _duration) external override onlyGovernorOrAdmin {
         require(_duration != 0, "UniswapOracle: zero duration");
 
         duration = _duration;

--- a/contracts/pcv/curve/StableSwapOperatorV1.sol
+++ b/contracts/pcv/curve/StableSwapOperatorV1.sol
@@ -95,17 +95,17 @@ contract StableSwapOperatorV1 is PCVDeposit {
 
 
     /// @notice set the minimum ratio threshold for a valid reading of restistant balances
-    function setMinRatio(uint256 _minimumRatioThreshold) public onlyGovernor {
+    function setMinRatio(uint256 _minimumRatioThreshold) public onlyGovernorOrAdmin {
         _setMinRatioThreshold(_minimumRatioThreshold);
     }
 
     /// @notice set the maximum ratio threshold for a valid reading of resistant balances
-    function setMaxRatio(uint256 _maximumRatioThreshold) public onlyGovernor {
+    function setMaxRatio(uint256 _maximumRatioThreshold) public onlyGovernorOrAdmin {
         _setMaxRatioThreshold(_maximumRatioThreshold);
     }
 
     /// @notice set both min & max ratios
-    function setRatios(uint256 _minimumRatioThreshold, uint256 _maximumRatioThreshold) public onlyGovernor {
+    function setRatios(uint256 _minimumRatioThreshold, uint256 _maximumRatioThreshold) public onlyGovernorOrAdmin {
         _setMinRatioThreshold(_minimumRatioThreshold);
         _setMaxRatioThreshold(_maximumRatioThreshold);
     }

--- a/contracts/pcv/lido/EthLidoPCVDeposit.sol
+++ b/contracts/pcv/lido/EthLidoPCVDeposit.sol
@@ -172,7 +172,7 @@ contract EthLidoPCVDeposit is PCVDeposit {
     // =======================================================================
     /// @notice Sets the maximum slippage vs 1:1 price accepted during withdraw.
     /// @param _maximumSlippageBasisPoints the maximum slippage expressed in basis points (1/10_000)
-    function setMaximumSlippage(uint256 _maximumSlippageBasisPoints) external onlyGovernor {
+    function setMaximumSlippage(uint256 _maximumSlippageBasisPoints) external onlyGovernorOrAdmin {
         require(_maximumSlippageBasisPoints <= Constants.BASIS_POINTS_GRANULARITY, "EthLidoPCVDeposit: Exceeds bp granularity.");
         maximumSlippageBasisPoints = _maximumSlippageBasisPoints;
         emit UpdateMaximumSlippage(_maximumSlippageBasisPoints);

--- a/contracts/pcv/uniswap/PCVSwapperUniswap.sol
+++ b/contracts/pcv/uniswap/PCVSwapperUniswap.sol
@@ -144,7 +144,7 @@ contract PCVSwapperUniswap is IPCVSwapper, WethPCVDeposit, OracleRef, Timed, Inc
 
     /// @notice Sets the maximum slippage vs Oracle price accepted during swaps
     /// @param newMaximumSlippageBasisPoints the maximum slippage expressed in basis points (1/10_000)
-    function setMaximumSlippage(uint256 newMaximumSlippageBasisPoints) external onlyGovernor {
+    function setMaximumSlippage(uint256 newMaximumSlippageBasisPoints) external onlyGovernorOrAdmin {
         uint256 oldMaxSlippage = maximumSlippageBasisPoints;
         require(newMaximumSlippageBasisPoints <= Constants.BASIS_POINTS_GRANULARITY, "PCVSwapperUniswap: Exceeds bp granularity.");
         maximumSlippageBasisPoints = newMaximumSlippageBasisPoints;
@@ -153,7 +153,7 @@ contract PCVSwapperUniswap is IPCVSwapper, WethPCVDeposit, OracleRef, Timed, Inc
 
     /// @notice Sets the maximum tokens spent on each swap
     /// @param newMaxSpentPerSwap the maximum number of tokens to be swapped on each call
-    function setMaxSpentPerSwap(uint256 newMaxSpentPerSwap) external onlyGovernor {
+    function setMaxSpentPerSwap(uint256 newMaxSpentPerSwap) external onlyGovernorOrAdmin {
         uint256 oldMaxSpentPerSwap = maxSpentPerSwap;
         require(newMaxSpentPerSwap != 0, "PCVSwapperUniswap: Cannot swap 0.");
         maxSpentPerSwap = newMaxSpentPerSwap;
@@ -162,7 +162,7 @@ contract PCVSwapperUniswap is IPCVSwapper, WethPCVDeposit, OracleRef, Timed, Inc
 
     /// @notice sets the minimum time between swaps
 		/// @param _duration minimum time between swaps in seconds
-    function setSwapFrequency(uint256 _duration) external onlyGovernor {
+    function setSwapFrequency(uint256 _duration) external onlyGovernorOrAdmin {
        _setDuration(_duration);
     }
 

--- a/contracts/pcv/uniswap/UniswapPCVDeposit.sol
+++ b/contracts/pcv/uniswap/UniswapPCVDeposit.sol
@@ -105,7 +105,7 @@ contract UniswapPCVDeposit is IUniswapPCVDeposit, PCVDeposit, UniRef {
     function setMaxBasisPointsFromPegLP(uint256 _maxBasisPointsFromPegLP)
         public
         override
-        onlyGovernor
+        onlyGovernorOrAdmin
     {
         require(
             _maxBasisPointsFromPegLP <= Constants.BASIS_POINTS_GRANULARITY,

--- a/contracts/pcv/utils/PCVDripController.sol
+++ b/contracts/pcv/utils/PCVDripController.sol
@@ -103,7 +103,7 @@ contract PCVDripController is IPCVDripController, Timed, RateLimitedMinter, Ince
     function setDripAmount(uint256 newDripAmount)
         external
         override
-        onlyGovernor
+        onlyGovernorOrAdmin
     {
         require(newDripAmount != 0, "PCVDripController: zero drip amount");
 

--- a/contracts/pcv/utils/StaticPCVDepositWrapper.sol
+++ b/contracts/pcv/utils/StaticPCVDepositWrapper.sol
@@ -29,14 +29,14 @@ contract StaticPCVDepositWrapper is IPCVDepositBalances, CoreRef {
     }
 
     /// @notice set the PCV balance
-    function setBalance(uint256 newBalance) external onlyGovernor {
+    function setBalance(uint256 newBalance) external onlyGovernorOrAdmin {
         uint256 oldBalance = balance;
         balance = newBalance;
         emit BalanceUpdate(oldBalance, newBalance);
     }
 
     /// @notice set the protocol owned FEI amount
-    function setFeiReportBalance(uint256 newFeiBalance) external onlyGovernor {
+    function setFeiReportBalance(uint256 newFeiBalance) external onlyGovernorOrAdmin {
         uint256 oldFeiBalance = feiReportBalance;
         feiReportBalance = newFeiBalance;
         emit BalanceUpdate(oldFeiBalance, newFeiBalance);

--- a/contracts/refs/OracleRef.sol
+++ b/contracts/refs/OracleRef.sol
@@ -58,7 +58,7 @@ abstract contract OracleRef is IOracleRef, CoreRef {
     }
     /// @notice sets the referenced backup oracle
     /// @param newBackupOracle the new backup oracle to reference
-    function setBackupOracle(address newBackupOracle) external override onlyGovernor {
+    function setBackupOracle(address newBackupOracle) external override onlyGovernorOrAdmin {
         _setBackupOracle(newBackupOracle);
     }
 

--- a/contracts/stabilizer/ReserveStabilizer.sol
+++ b/contracts/stabilizer/ReserveStabilizer.sol
@@ -92,7 +92,7 @@ contract ReserveStabilizer is OracleRef, IReserveStabilizer, PCVDeposit {
 
     /// @notice sets the USD per FEI exchange rate rate
     /// @param newUsdPerFeiBasisPoints the USD per FEI exchange rate denominated in basis points (1/10000)
-    function setUsdPerFeiRate(uint256 newUsdPerFeiBasisPoints) external override onlyGovernor {
+    function setUsdPerFeiRate(uint256 newUsdPerFeiBasisPoints) external override onlyGovernorOrAdmin {
         require(newUsdPerFeiBasisPoints <= Constants.BASIS_POINTS_GRANULARITY, "ReserveStabilizer: Exceeds bp granularity");
         uint256 oldUsdPerFeiBasisPoints = usdPerFeiBasisPoints;
         usdPerFeiBasisPoints = newUsdPerFeiBasisPoints;


### PR DESCRIPTION
We introduced the concept of a "contract admin" with OA for TribalChief.

This PR adds admin support to contracts throughout the repo following the below general rule of thumb:
* integer parameters and flags OK
* Address changes NOT OK

Notable exceptions:
* CR oracle constituents have admin enabled
* TribeReserveStabilizer parameters do NOT have admin

NOTE: This PR will not affect any existing on-chain contracts. And future contracts will explicitly need to define an admin role and have this role granted to a multisig timelock through the DAO. By itself these contract changes are effectively a no-op