### PR TITLE
Add tribal chief admin

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -54,7 +54,7 @@ export default {
       forking: enableMainnetForking
         ? {
             url: `https://eth-mainnet.alchemyapi.io/v2/${mainnetAlchemyApiKey}`,
-            blockNumber: 13285992
+            blockNumber: 13303505
           }
         : undefined
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "console:ropsten": "npx hardhat console --network ropsten",
     "clean": "rm -rf build",
     "test": "npx hardhat test",
-    "test:e2e": "RUN_E2E_TESTS=true npx hardhat test",
+    "test:e2e": "ENABLE_MAINNET_FORKING=true RUN_E2E_TESTS=true npx hardhat test",
     "test:gas": "REPORT_GAS=true npx hardhat test",
     "test:all": "RUN_ALL_TESTS=true npx hardhat test",
     "lint": "eslint --config ./.eslintrc --ignore-path ./.eslintignore --ext .ts,.tsx .",

--- a/proposals/dao/fip_28.ts
+++ b/proposals/dao/fip_28.ts
@@ -46,10 +46,11 @@ const validate = async (addresses, oldContracts, contracts) => {
     rariPool8Tribe,
     rariPool8Eth,
     rariPool8Fei,
-    rariPool22FeiPCVDeposit
+    rariPool22FeiPCVDeposit,
+    tribalChief
   } = contracts;
 
-  const { optimisticTimelock } = addresses;
+  const { optimisticTimelock, tribalChiefOptimisticTimelock } = addresses;
 
   // Borrow disabled
   expect(await rariPool8Comptroller.borrowGuardianPaused(rariPool8Tribe.address)).to.be.equal(true);
@@ -60,12 +61,16 @@ const validate = async (addresses, oldContracts, contracts) => {
 
   expect((await rariPool22FeiPCVDeposit.balance()).toString()).to.be.equal(e18.mul(1_000_000).toString());
 
-  // admin transfer
+  // FeiRari admin transfer
   expect(await rariPool8Comptroller.admin()).to.be.equal(optimisticTimelock);
   expect(await rariPool8Dai.admin()).to.be.equal(optimisticTimelock);
   expect(await rariPool8Tribe.admin()).to.be.equal(optimisticTimelock);
   expect(await rariPool8Eth.admin()).to.be.equal(optimisticTimelock);
   expect(await rariPool8Fei.admin()).to.be.equal(optimisticTimelock);
+
+  // TribalChief admin transfer
+  expect(await tribalChief.isContractAdmin(optimisticTimelock)).to.be.true;
+  expect(await tribalChief.isContractAdmin(tribalChiefOptimisticTimelock)).to.be.true;
 };
 
 module.exports = {

--- a/proposals/dao/fip_28.ts
+++ b/proposals/dao/fip_28.ts
@@ -14,8 +14,7 @@ const run: RunUpgradeFunc = async (addresses, oldContracts, contracts, logging =
 
 const teardown: TeardownUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
   const { optimisticTimelock } = addresses;
-
-  const { rariPool8Comptroller, rariPool8Dai, rariPool8Tribe, rariPool8Eth, rariPool8Fei } = contracts;
+  const { rariPool8Comptroller, rariPool8Dai, rariPool8Tribe, rariPool8Eth, rariPool8Fei, rariPool22FeiPCVDeposit } = contracts;
 
   await hre.network.provider.request({
     method: 'hardhat_impersonateAccount',
@@ -36,6 +35,8 @@ const teardown: TeardownUpgradeFunc = async (addresses, oldContracts, contracts,
   await rariPool8Tribe.connect(optimisticTimelockSigner)._acceptAdmin();
   await rariPool8Eth.connect(optimisticTimelockSigner)._acceptAdmin();
   await rariPool8Fei.connect(optimisticTimelockSigner)._acceptAdmin();
+
+  await rariPool22FeiPCVDeposit.deposit();
 };
 
 const validate = async (addresses, oldContracts, contracts) => {
@@ -57,7 +58,7 @@ const validate = async (addresses, oldContracts, contracts) => {
 
   // minted FEI
   // 1M from before, 50M from proposal
-  expect((await fei.balanceOf(optimisticTimelock)).toString()).to.be.equal(e18.mul(51_000_000).toString());
+  expect((await fei.balanceOf(optimisticTimelock)).toString()).to.be.equal(e18.mul(50_000_000).toString());
 
   expect((await rariPool22FeiPCVDeposit.balance()).toString()).to.be.equal(e18.mul(1_000_000).toString());
 
@@ -70,7 +71,7 @@ const validate = async (addresses, oldContracts, contracts) => {
 
   // TribalChief admin transfer
   expect(await tribalChief.isContractAdmin(optimisticTimelock)).to.be.true;
-  expect(await tribalChief.isContractAdmin(tribalChiefOptimisticTimelock)).to.be.true;
+  expect(await tribalChief.isContractAdmin(tribalChiefOptimisticTimelock)).to.be.false;
 };
 
 module.exports = {

--- a/proposals/description/fip_28.json
+++ b/proposals/description/fip_28.json
@@ -77,11 +77,24 @@
             "description": "Mint 1m FEI to Fuse Pool 22"
         },
         {
-            "target": "rariPool22FeiPCVDeposit",
+            "target": "core",
             "values": "0",
-            "method": "deposit()",
-            "arguments": [],
-            "description": "Deposit pool 22 FEI"
+            "method": "grantRole(bytes32,address)",
+            "arguments": [
+                "0x23970cab3799b6876df4319661e6c03cc45bd59628799d92e988dd8cbdc90e31",
+                "0xbC9C084a12678ef5B516561df902fdc426d95483"
+            ],
+            "description": "Grant TribalChief admin to new OA timelock"
+        },
+        {
+            "target": "core",
+            "values": "0",
+            "method": "revokeRole(bytes32,address)",
+            "arguments": [
+                "0x23970cab3799b6876df4319661e6c03cc45bd59628799d92e988dd8cbdc90e31",
+                "0x27Fae9E49AD955A24bB578B66Cdc962b5029fbA9"
+            ],
+            "description": "Revoke TribalChief admin from old OA timelock"
         }
     ]
 }

--- a/proposals/description/fip_28.txt
+++ b/proposals/description/fip_28.txt
@@ -3,6 +3,7 @@ This proposal combines FIP-28 and FIP-29 related to Optimistic Approval and FeiR
 
 Specifically it:
 * gives the OA timelock admin control of all FeiRari components and parameters
+* gives OA timelock admin of TribalChief and revokes old timelock
 * blocks TRIBE borrowing from the pool in anticipation of single-sided TRIBE staking rewards
 * mints 50M FEI to the OA timelock for future lending deployments
 * mints 1M FEI to seed Fuse pool 22 (BadgerDAO)

--- a/test/integration/proposals_config.json
+++ b/test/integration/proposals_config.json
@@ -1,9 +1,4 @@
 {
-    "optimisticTimelock" : {
-        "deploy" : false,
-        "exec" : false,
-        "proposerAddress" : "0xe0ac4559739bD36f0913FB0A3f5bFC19BCBaCD52"
-    },
     "fip_28" : {
         "deploy" : false,
         "exec" : true,
@@ -12,11 +7,6 @@
     "v2Phase1": {
         "deploy" : true,
         "exec" : false,
-        "proposerAddress" : "0xe0ac4559739bD36f0913FB0A3f5bFC19BCBaCD52"
-    },
-    "fip_26": {
-        "deploy" : false,
-        "exec" : true,
         "proposerAddress" : "0xe0ac4559739bD36f0913FB0A3f5bFC19BCBaCD52"
     }
 }


### PR DESCRIPTION
FIP-28 json currently does not transition the TribalChief admin role over to the new OA timelock.

These changes grant the new role and deprecate the old role.

Removed the pool 22 deposit, since max 10 actions can be in the proposal and this action is publicly exposed.