### PR TITLE
remove excluded deposits

### DIFF
--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -28,9 +28,6 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
 
     // ----------- Properties -----------
 
-    /// @notice List of PCVDeposits to exclude from calculations
-    mapping(address => bool) public excludedDeposits;
-
     /// @notice Map of oracles to use to get USD values of assets held in
     ///         PCV deposits. This map is used to get the oracle address from
     ///         and ERC20 address.
@@ -102,15 +99,6 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     }
 
     // ----------- State-changing methods -----------
-
-    /// @notice Guardians can exclude & re-include some PCVDeposits from the list,
-    ///         because a faulty deposit or a paused oracle that prevents reading
-    ///         from certain deposits could be problematic.
-    /// @param _deposit : the deposit to exclude or re-enable.
-    /// @param _excluded : the new exclusion flag for this deposit.
-    function setDepositExclusion(address _deposit, bool _excluded) external onlyGuardianOrGovernor {
-        excludedDeposits[_deposit] = _excluded;
-    }
 
     /// @notice Add a PCVDeposit to the list of deposits inspected by the
     ///         collateralization ratio oracle.
@@ -303,13 +291,10 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
             for (uint256 j = 0; j < tokenToDeposits[_token].length(); j++) {
                 address _deposit = tokenToDeposits[_token].at(j);
 
-                // ignore deposits that are excluded by the Guardian
-                if (!excludedDeposits[_deposit]) {
-                    // read the deposit, and increment token balance/protocol fei
-                    (uint256 _depositBalance, uint256 _depositFei) = IPCVDepositBalances(_deposit).resistantBalanceAndFei();
-                    _totalTokenBalance += _depositBalance;
-                    _protocolControlledFei += _depositFei;
-                }
+                // read the deposit, and increment token balance/protocol fei
+                (uint256 _depositBalance, uint256 _depositFei) = IPCVDepositBalances(_deposit).resistantBalanceAndFei();
+                _totalTokenBalance += _depositBalance;
+                _protocolControlledFei += _depositFei;
             }
 
             // If the protocol holds non-zero balance of tokens, fetch the oracle price to

--- a/test/unit/oracle/CollateralizationOracle.test.ts
+++ b/test/unit/oracle/CollateralizationOracle.test.ts
@@ -1,17 +1,11 @@
 import { ZERO_ADDRESS, getCore, getAddresses, expectRevert } from '../../helpers';
 import { expect } from 'chai';
-import hre, { ethers, artifacts } from 'hardhat';
+import hre, { ethers } from 'hardhat';
 import { Signer } from 'ethers';
-
-const CollateralizationOracle = artifacts.readArtifactSync('CollateralizationOracle');
-const MockPCVDepositV2 = artifacts.readArtifactSync('MockPCVDepositV2');
-const MockOracleCoreRef = artifacts.readArtifactSync('MockOracleCoreRef');
-const MockERC20 = artifacts.readArtifactSync('MockERC20');
-const IFei = artifacts.readArtifactSync('IFei');
 
 const e18 = '000000000000000000';
 
-describe('CollateralizationOracle', function () {
+describe.only('CollateralizationOracle', function () {
   let userAddress: string;
   let guardianAddress: string;
   let governorAddress: string;
@@ -104,9 +98,7 @@ describe('CollateralizationOracle', function () {
         [this.oracle1.address, this.oracle2.address]
       );
     });
-    it('excludedDeposits(address) => bool', async function () {
-      expect(await this.oracle.excludedDeposits(this.deposit1.address)).to.be.equal(false);
-    });
+  
     it('tokenToOracle(address) => address', async function () {
       expect(await this.oracle.tokenToOracle(this.token1.address)).to.be.equal(this.oracle1.address);
     });
@@ -400,30 +392,6 @@ describe('CollateralizationOracle', function () {
           .connect(impersonatedSigners[governorAddress])
           .swapDeposit(this.deposit1.address, this.deposit2.address),
         'CollateralizationOracle: deposit duplicate'
-      );
-    });
-  });
-
-  describe('setDepositExclusion()', function () {
-    it('should allow guardian to exclude a deposit', async function () {
-      await this.oracle
-        .connect(impersonatedSigners[governorAddress])
-        .setOracle(this.token1.address, this.oracle1.address);
-      await this.oracle.connect(impersonatedSigners[governorAddress]).addDeposit(this.deposit1.address);
-      await this.oracle
-        .connect(impersonatedSigners[governorAddress])
-        .setOracle(this.token2.address, this.oracle2.address);
-      await this.oracle.connect(impersonatedSigners[governorAddress]).addDeposit(this.deposit2.address);
-
-      expect((await this.oracle.pcvStats()).protocolControlledValue).to.be.equal(`5000${e18}`);
-      await this.oracle.connect(impersonatedSigners[guardianAddress]).setDepositExclusion(this.deposit1.address, true);
-      expect((await this.oracle.pcvStats()).protocolControlledValue).to.be.equal(`3000${e18}`);
-      expect((await this.oracle.pcvStats()).validityStatus).to.be.equal(true);
-    });
-    it('should revert if not guardian', async function () {
-      await expectRevert(
-        this.oracle.connect(impersonatedSigners[userAddress]).setDepositExclusion(this.deposit1.address, true),
-        'CoreRef: Caller is not a guardian or governor'
       );
     });
   });


### PR DESCRIPTION
Excluded deposits provide too many edge cases and too much power to the guardian. This PR removes this ability. The next PR will provide an alternative which is simpler and less risky