### PR TITLE
Update cached values

### DIFF
--- a/contracts/oracle/CollateralizationOracle.sol
+++ b/contracts/oracle/CollateralizationOracle.sol
@@ -59,6 +59,9 @@ contract CollateralizationOracle is ICollateralizationOracle, CoreRef {
     ) CoreRef(_core) {
         _setOracles(_tokens, _oracles);
         _addDeposits(_deposits);
+
+        // Shared admin with other oracles
+        _setContractAdminRole(keccak256("ORACLE_ADMIN_ROLE"));
     }
 
     // ----------- Convenience getters -----------

--- a/contracts/oracle/CollateralizationOracleWrapper.sol
+++ b/contracts/oracle/CollateralizationOracleWrapper.sol
@@ -83,6 +83,9 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
         _setDuration(_validityDuration);
         collateralizationOracle = _collateralizationOracle;
         deviationThresholdBasisPoints = _deviationThresholdBasisPoints;
+
+        // Shared admin with other oracles
+        _setContractAdminRole(keccak256("ORACLE_ADMIN_ROLE"));    
     }
 
     // ----------- Setter methods ----------------------------------------------
@@ -126,6 +129,16 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
         _setDuration(_validityDuration);
     }
 
+    /// @notice governor or admin override to directly write to the cache
+    /// @dev used in emergencies where the underlying oracle is compromised or failing
+    function setCache(
+        uint256 _cachedProtocolControlledValue,
+        uint256 _cachedUserCirculatingFei,
+        int256 _cachedProtocolEquity
+    ) external onlyGovernorOrAdmin {
+        _setCache(_cachedProtocolControlledValue, _cachedUserCirculatingFei, _cachedProtocolEquity);
+    }
+
     // ----------- IOracle override methods ------------------------------------
     /// @notice update reading of the CollateralizationOracle
     function update() external override whenNotPaused {
@@ -155,10 +168,22 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
         // only update if valid
         require(_validityStatus, "CollateralizationOracleWrapper: CollateralizationOracle is invalid");
 
+        _setCache(_protocolControlledValue, _userCirculatingFei, _protocolEquity);
+
+        return outdated 
+            || _isExceededDeviationThreshold(cachedProtocolControlledValue, _protocolControlledValue)
+            || _isExceededDeviationThreshold(cachedUserCirculatingFei, _userCirculatingFei);
+    }
+
+    function _setCache(
+        uint256 _cachedProtocolControlledValue,
+        uint256 _cachedUserCirculatingFei,
+        int256 _cachedProtocolEquity
+    ) internal {
         // set cache variables
-        cachedProtocolControlledValue = _protocolControlledValue;
-        cachedUserCirculatingFei = _userCirculatingFei;
-        cachedProtocolEquity = _protocolEquity;
+        cachedProtocolControlledValue = _cachedProtocolControlledValue;
+        cachedUserCirculatingFei = _cachedUserCirculatingFei;
+        cachedProtocolEquity = _cachedProtocolEquity;
 
         // reset time
         _initTimed();
@@ -170,10 +195,6 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
             cachedUserCirculatingFei,
             cachedProtocolEquity
         );
-
-        return outdated 
-            || _isExceededDeviationThreshold(cachedProtocolControlledValue, _protocolControlledValue)
-            || _isExceededDeviationThreshold(cachedUserCirculatingFei, _userCirculatingFei);
     }
 
     // @notice returns true if the cached values are outdated.

--- a/contracts/oracle/CollateralizationOracleWrapper.sol
+++ b/contracts/oracle/CollateralizationOracleWrapper.sol
@@ -165,14 +165,16 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
             bool _validityStatus
         ) = ICollateralizationOracle(collateralizationOracle).pcvStats();
 
+        outdated = outdated 
+            || _isExceededDeviationThreshold(cachedProtocolControlledValue, _protocolControlledValue)
+            || _isExceededDeviationThreshold(cachedUserCirculatingFei, _userCirculatingFei);
+        
         // only update if valid
         require(_validityStatus, "CollateralizationOracleWrapper: CollateralizationOracle is invalid");
 
         _setCache(_protocolControlledValue, _userCirculatingFei, _protocolEquity);
 
-        return outdated 
-            || _isExceededDeviationThreshold(cachedProtocolControlledValue, _protocolControlledValue)
-            || _isExceededDeviationThreshold(cachedUserCirculatingFei, _userCirculatingFei);
+        return outdated;
     }
 
     function _setCache(

--- a/test/unit/oracle/CollateralizationOracle.test.ts
+++ b/test/unit/oracle/CollateralizationOracle.test.ts
@@ -98,7 +98,7 @@ describe('CollateralizationOracle', function () {
         [this.oracle1.address, this.oracle2.address]
       );
     });
-  
+
     it('tokenToOracle(address) => address', async function () {
       expect(await this.oracle.tokenToOracle(this.token1.address)).to.be.equal(this.oracle1.address);
     });

--- a/test/unit/oracle/CollateralizationOracle.test.ts
+++ b/test/unit/oracle/CollateralizationOracle.test.ts
@@ -5,7 +5,7 @@ import { Signer } from 'ethers';
 
 const e18 = '000000000000000000';
 
-describe.only('CollateralizationOracle', function () {
+describe('CollateralizationOracle', function () {
   let userAddress: string;
   let guardianAddress: string;
   let governorAddress: string;

--- a/test/unit/oracle/CollateralizationOracleWrapper.test.ts
+++ b/test/unit/oracle/CollateralizationOracleWrapper.test.ts
@@ -166,22 +166,15 @@ describe('CollateralizationOracleWrapper', function () {
 
   describe.only('setCache()', function () {
     it('should emit CachedValueUpdate', async function () {
-      await expect(
-        await this.oracleWrapper
-          .connect(impersonatedSigners[governorAddress])
-          .setCache('1', '2', '3')
-      )
+      await expect(await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).setCache('1', '2', '3'))
         .to.emit(this.oracleWrapper, 'CachedValueUpdate')
         .withArgs(governorAddress, '1', '2', '3');
     });
     it('should update maps & array properties', async function () {
-      await this.oracleWrapper
-        .connect(impersonatedSigners[governorAddress])
-        .setCache('1', '2', '3')
+      await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).setCache('1', '2', '3');
       expect((await this.oracleWrapper.cachedProtocolControlledValue()).toString()).to.be.equal('1');
       expect((await this.oracleWrapper.cachedUserCirculatingFei()).toString()).to.be.equal('2');
       expect((await this.oracleWrapper.cachedProtocolEquity()).toString()).to.be.equal('3');
-
     });
     it('should revert if not governor or admin', async function () {
       await expectRevert(


### PR DESCRIPTION
Add a method for an admin to update cached values in the CR oracle.

Also fixes a logic bug in how the deviation threshold is calculated for updates