### PR TITLE
Tribe Rate Limit

### DIFF
--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -9,8 +9,6 @@ library Constants {
 
     uint256 public constant ONE_YEAR = 365.25 days;
 
-    bytes32 public constant NULL = 0x0;
-    
     /// @notice WETH9 address
     IWETH public constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 

--- a/contracts/Constants.sol
+++ b/contracts/Constants.sol
@@ -6,6 +6,10 @@ import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
 library Constants {
     /// @notice the denominator for basis points granularity (10,000)
     uint256 public constant BASIS_POINTS_GRANULARITY = 10_000;
+
+    uint256 public constant ONE_YEAR = 365.25 days;
+
+    bytes32 public constant NULL = 0x0;
     
     /// @notice WETH9 address
     IWETH public constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);

--- a/contracts/dao/ITribeMinter.sol
+++ b/contracts/dao/ITribeMinter.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ITribe is IERC20 {
+    function mint(address to, uint256 amount) external;
+    function setMinter(address newMinter) external;
+}
+
+/// @title TribeMinter interface
+/// @author Fei Protocol
+interface ITribeMinter {
+    // ----------- Events -----------
+    event AnnualMaxInflationUpdate(uint256 oldAnnualMaxInflationBasisPoints, uint256 newAnnualMaxInflationBasisPoints);
+    event AddLockedTribeAddress(address indexed lockedTribeAddress);
+    event RemoveLockedTribeAddress(address indexed lockedTribeAddress);
+
+    // ----------- Public state changing api -----------
+
+    function poke() external;
+
+    // ----------- Owner only state changing api -----------
+
+    function setMinter(address newMinter) external;
+
+    // ----------- Governor or Admin only state changing api -----------
+
+    function mint(address to, uint256 amount) external;
+
+    function addLockedTribeAddress(address lockedTribeAddress) external;
+
+    function removeLockedTribeAddress(address lockedTribeAddress) external;
+
+    function setAnnualMaxInflationBasisPoints(uint256 newAnnualMaxInflationBasisPoints) external;
+
+    // ----------- Getters -----------
+
+    function annualMaxInflationBasisPoints() external view returns (uint256);
+    
+    function idealBufferCap() external view returns (uint256);
+
+    function tribeCirculatingSupply() external view returns (uint256);
+
+    function totalSupply() external view returns (uint256);
+
+    function isPokeNeeded() external view returns (bool);
+
+    function lockedTribeAddresses() external view returns (address[] memory);
+}

--- a/contracts/dao/ITribeMinter.sol
+++ b/contracts/dao/ITribeMinter.sol
@@ -13,8 +13,8 @@ interface ITribe is IERC20 {
 interface ITribeMinter {
     // ----------- Events -----------
     event AnnualMaxInflationUpdate(uint256 oldAnnualMaxInflationBasisPoints, uint256 newAnnualMaxInflationBasisPoints);
-    event AddLockedTribeAddress(address indexed lockedTribeAddress);
-    event RemoveLockedTribeAddress(address indexed lockedTribeAddress);
+    event TribeTreasuryUpdate(address indexed oldTribeTreasury, address indexed newTribeTreasury);
+    event TribeRewardsDripperUpdate(address indexed oldTribeRewardsDripper, address indexed newTribeRewardsDripper);
 
     // ----------- Public state changing api -----------
 
@@ -28,9 +28,9 @@ interface ITribeMinter {
 
     function mint(address to, uint256 amount) external;
 
-    function addLockedTribeAddress(address lockedTribeAddress) external;
+    function setTribeTreasury(address newTribeTreasury) external;
 
-    function removeLockedTribeAddress(address lockedTribeAddress) external;
+    function setTribeRewardsDripper(address newTribeRewardsDripper) external;
 
     function setAnnualMaxInflationBasisPoints(uint256 newAnnualMaxInflationBasisPoints) external;
 
@@ -46,5 +46,7 @@ interface ITribeMinter {
 
     function isPokeNeeded() external view returns (bool);
 
-    function lockedTribeAddresses() external view returns (address[] memory);
+    function tribeTreasury() external view returns (address);
+
+    function tribeRewardsDripper() external view returns (address);
 }

--- a/contracts/dao/TribeMinter.sol
+++ b/contracts/dao/TribeMinter.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import "./ITribeMinter.sol";
+import "../utils/RateLimited.sol";
+import "../Constants.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+/** 
+  @title implementation for a TRIBE Minter Contract
+  @author Fei Protocol
+
+  This contract will be the unique TRIBE minting contract. 
+  All minting is subject to an annual inflation rate limit.
+  For example if circulating supply is 1m and inflation is capped at 10%, then no more than 100k TRIBE can enter circulation in the following year.
+
+  The contract will increase (decrease) the rate limit proportionally as supply increases (decreases)
+
+  Governance and admins can only lower the max inflation %. 
+  They can also exclude (unexclude) addresses' TRIBE balances from the circulating supply. 
+  The minter's balance is excluded by default.
+
+  ACCESS_CONTROL:
+  This contract follows a somewhat unique access control pattern. 
+  It has a contract admin which is NOT intended for optimistic approval, but rather for contracts such as the TribeReserveStabilizer.
+  An additional potential contract admin is one which automates the inclusion and removal of excluded deposits from on-chain timelocks.
+
+  Additionally, the ability to transfer the tribe minter role is held by the contract *owner* rather than governor or admin.
+  The owner will intially be the DAO timelock.
+  This keeps the power to transfer or burn TRIBE minting rights isolated.
+*/
+contract TribeMinter is ITribeMinter, RateLimited, Ownable {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    uint256 public override annualMaxInflationBasisPoints;
+
+    EnumerableSet.AddressSet internal _lockedTribeAddresses;
+
+    /// @notice Tribe Reserve Stabilizer constructor
+    /// @param _core Fei Core to reference
+    constructor(
+        address _core,
+        uint256 _annualMaxInflationBasisPoints,
+        address _owner,
+        address[] memory _lockedTribeAddressList
+    ) 
+      RateLimited(0, 0, 0, false)
+      CoreRef(_core)
+    {
+        _setAnnualMaxInflationBasisPoints(_annualMaxInflationBasisPoints);
+        _poke();
+
+        // start with a full buffer
+        _resetBuffer();
+
+        transferOwnership(_owner);
+
+        _addLockedTribeAddress(address(this));
+        for (uint256 i = 0; i < _lockedTribeAddressList.length; i++) {
+            _addLockedTribeAddress(_lockedTribeAddressList[i]);
+        }
+    }
+
+    /// @notice update the rate limit per second and buffer cap
+    function poke() public override {
+        (uint256 oldBufferCap, uint256 newBufferCap) = _poke();
+
+        // Increasing the buffer cap shouldn't also increase capacity atomically
+        // Deplete buffer by the newly increased cap difference
+        if (newBufferCap > oldBufferCap) {
+            uint256 increment = newBufferCap - oldBufferCap;
+            _depleteBuffer(increment);
+        }
+    }
+
+    /// @dev no-op, reverts. Prevent admin or governor from overwriting ideal rate limit
+    function setRateLimitPerSecond(uint256) external pure override {
+        revert("no-op");
+    }
+
+    /// @dev no-op, reverts. Prevent admin or governor from overwriting ideal buffer cap
+    function setBufferCap(uint256) external pure override { 
+        revert("no-op");
+    }
+
+    /// @notice mints TRIBE to the target address, subject to rate limit
+    /// @param to the address to send TRIBE to
+    /// @param amount the amount of TRIBE to send
+    function mint(address to, uint256 amount) external override onlyGovernorOrAdmin {
+        // first apply rate limit 
+        _depleteBuffer(amount);
+
+        // then mint
+        _mint(to, amount);
+    }
+
+    /// @notice add an address to the lockedTribe excluded list
+    function addLockedTribeAddress(address lockedTribeAddress) external override onlyGovernorOrAdmin {
+        _addLockedTribeAddress(lockedTribeAddress);
+    }
+
+    /// @notice remove an address from the lockedTribe excluded list
+    function removeLockedTribeAddress(address lockedTribeAddress) external onlyGovernorOrAdmin {
+        _lockedTribeAddresses.remove(lockedTribeAddress);
+        emit RemoveLockedTribeAddress(lockedTribeAddress);
+    }
+
+    /// @notice changes the TRIBE minter address
+    /// @param newMinter the new minter address
+    function setMinter(address newMinter) external override onlyOwner {
+        require(newMinter != address(0), "TribeReserveStabilizer: zero address");
+        ITribe _tribe = ITribe(address(tribe()));
+        _tribe.setMinter(newMinter);
+    }
+
+    /// @notice sets the max annual inflation relative to current supply
+    /// @param newAnnualMaxInflationBasisPoints the new max inflation % denominated in basis points (1/10000)
+    function setAnnualMaxInflationBasisPoints(uint256 newAnnualMaxInflationBasisPoints) external override onlyGovernorOrAdmin {
+        _setAnnualMaxInflationBasisPoints(newAnnualMaxInflationBasisPoints);
+    }
+
+    /// @notice return the ideal buffer cap based on TRIBE circulating supply
+    function idealBufferCap() public view override returns (uint256) {
+        return tribeCirculatingSupply() * annualMaxInflationBasisPoints / Constants.BASIS_POINTS_GRANULARITY;
+    }
+
+    /// @notice return the TRIBE supply, subtracting locked TRIBE
+    function tribeCirculatingSupply() public view override returns (uint256) {
+        IERC20 _tribe = tribe();
+
+        // Remove all locked TRIBE from total supply calculation
+        uint256 lockedTribe;
+        for (uint256 i = 0; i < _lockedTribeAddresses.length(); i++) {
+            lockedTribe += _tribe.balanceOf(_lockedTribeAddresses.at(i));
+        }
+
+        return _tribe.totalSupply() - lockedTribe;
+    }
+
+    /// @notice alias for tribeCirculatingSupply
+    /// @dev for compatibility with ERC-20 standard for off-chain 3rd party sites
+    function totalSupply() public view override returns (uint256) {
+        return tribeCirculatingSupply();
+    }
+
+    /// @notice return whether a poke is needed or not i.e. is buffer cap != ideal cap
+    function isPokeNeeded() external view override returns (bool) {
+        return idealBufferCap() != bufferCap;
+    }
+
+    /// @notice return the set of locked TRIBE holding addresses to be excluded from circulating supply
+    function lockedTribeAddresses() external view override returns(address[] memory) {
+        return _lockedTribeAddresses.values();
+    }
+
+    function _addLockedTribeAddress(address lockedTribeAddress) internal {
+        _lockedTribeAddresses.add(lockedTribeAddress);
+        emit AddLockedTribeAddress(lockedTribeAddress);
+    }
+
+    // Update the buffer cap and rate limit if needed
+    function _poke() internal returns (uint256 oldBufferCap, uint256 newBufferCap) {
+        newBufferCap = idealBufferCap();
+        oldBufferCap = bufferCap;
+        require(newBufferCap != oldBufferCap, "TribeMinter: No rate limit change needed");
+        
+        _setBufferCap(newBufferCap);
+        _setRateLimitPerSecond(newBufferCap / Constants.ONE_YEAR);
+    }
+
+    // Transfer held TRIBE first, then mint to cover remainder
+    function _mint(address to, uint256 amount) internal {
+        ITribe _tribe = ITribe(address(tribe()));
+
+        uint256 _tribeBalance = _tribe.balanceOf(address(this));
+        uint256 mintAmount = amount;
+
+        // First transfer maximum amount of held TRIBE
+        if(_tribeBalance != 0) {
+            uint256 transferAmount = Math.min(_tribeBalance, amount);
+
+            _tribe.transfer(to, transferAmount);
+
+            mintAmount = mintAmount - transferAmount;
+            assert(mintAmount + transferAmount == amount);
+        }
+        
+        // Then mint if any more is needed
+        if (mintAmount != 0) {
+            _tribe.mint(to, mintAmount);
+        }
+    }
+
+    function _setAnnualMaxInflationBasisPoints(uint256 newAnnualMaxInflationBasisPoints) internal {
+        uint256 oldAnnualMaxInflationBasisPoints = annualMaxInflationBasisPoints;
+        require(newAnnualMaxInflationBasisPoints != 0, "TribeMinter: cannot have 0 inflation");
+
+        // make sure the new inflation is strictly lower, unless the old inflation is 0 (which is only true upon construction)
+        require(newAnnualMaxInflationBasisPoints < oldAnnualMaxInflationBasisPoints || oldAnnualMaxInflationBasisPoints == 0, "TribeMinter: cannot increase max inflation");
+
+        annualMaxInflationBasisPoints = newAnnualMaxInflationBasisPoints;
+
+        emit AnnualMaxInflationUpdate(oldAnnualMaxInflationBasisPoints, newAnnualMaxInflationBasisPoints);
+    }
+}

--- a/contracts/dao/TribeMinter.sol
+++ b/contracts/dao/TribeMinter.sol
@@ -102,7 +102,7 @@ contract TribeMinter is ITribeMinter, RateLimited, Ownable {
     }
 
     /// @notice remove an address from the lockedTribe excluded list
-    function removeLockedTribeAddress(address lockedTribeAddress) external onlyGovernorOrAdmin {
+    function removeLockedTribeAddress(address lockedTribeAddress) external override onlyGovernorOrAdmin {
         _lockedTribeAddresses.remove(lockedTribeAddress);
         emit RemoveLockedTribeAddress(lockedTribeAddress);
     }

--- a/contracts/dao/TribeMinter.sol
+++ b/contracts/dao/TribeMinter.sol
@@ -34,12 +34,16 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 contract TribeMinter is ITribeMinter, RateLimited, Ownable {
     using EnumerableSet for EnumerableSet.AddressSet;
 
+    /// @notice the max inflation in TRIBE circulating supply per year in basis points (1/10000)
     uint256 public override annualMaxInflationBasisPoints;
 
     EnumerableSet.AddressSet internal _lockedTribeAddresses;
 
     /// @notice Tribe Reserve Stabilizer constructor
     /// @param _core Fei Core to reference
+    /// @param _annualMaxInflationBasisPoints the max inflation in TRIBE circulating supply per year in basis points (1/10000)
+    /// @param _owner the owner, capable of changing the tribe minter address.
+    /// @param _lockedTribeAddressList the initial list of locked TRIBE holding contract addresses
     constructor(
         address _core,
         uint256 _annualMaxInflationBasisPoints,

--- a/contracts/mock/MockTribeMinter.sol
+++ b/contracts/mock/MockTribeMinter.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+interface ITribe {
+    function mint(address to, uint256 amount) external;
+}
+
+contract MockTribeMinter {
+
+    ITribe public tribe;
+    constructor(ITribe _tribe) {
+        tribe = _tribe;
+    }
+
+    function mint(address to, uint256 amount) external {
+        tribe.mint(to, amount);
+    }
+}

--- a/contracts/stabilizer/ITribeReserveStabilizer.sol
+++ b/contracts/stabilizer/ITribeReserveStabilizer.sol
@@ -15,10 +15,6 @@ interface ITribeReserveStabilizer {
 
     // ----------- Governor only state changing api -----------
 
-    function setMinter(address newMinter) external;
-
-    function mint(address to, uint256 amount) external;
-
     function setCollateralizationOracle(ICollateralizationOracle newCollateralizationOracle) external;
 
     function setCollateralizationThreshold(uint256 newCollateralizationThresholdBasisPoints) external;

--- a/contracts/stabilizer/TribeReserveStabilizer.sol
+++ b/contracts/stabilizer/TribeReserveStabilizer.sol
@@ -3,12 +3,9 @@ pragma solidity ^0.8.4;
 
 import "./ReserveStabilizer.sol";
 import "./ITribeReserveStabilizer.sol";
+import "../dao/ITribeMinter.sol";
 import "../utils/RateLimited.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-
-interface ITribeMinter {
-    function mint(address to, uint256 amount) external;
-}
 
 /// @title implementation for a TRIBE Reserve Stabilizer
 /// @author Fei Protocol

--- a/contracts/utils/RateLimited.sol
+++ b/contracts/utils/RateLimited.sol
@@ -26,6 +26,7 @@ abstract contract RateLimited is CoreRef {
     /// @notice the buffer at the timestamp of lastBufferUsedTime
     uint256 private _bufferStored;
 
+    event BufferUsed(uint256 amountUsed, uint256 bufferRemaining);
     event BufferCapUpdate(uint256 oldBufferCap, uint256 newBufferCap);
     event RateLimitPerSecondUpdate(uint256 oldRateLimitPerSecond, uint256 newRateLimitPerSecond);
 
@@ -43,13 +44,13 @@ abstract contract RateLimited is CoreRef {
     }
 
     /// @notice set the rate limit per second
-    function setRateLimitPerSecond(uint256 newRateLimitPerSecond) external onlyGovernorOrAdmin {
+    function setRateLimitPerSecond(uint256 newRateLimitPerSecond) external virtual onlyGovernorOrAdmin {
         require(newRateLimitPerSecond <= MAX_RATE_LIMIT_PER_SECOND, "RateLimited: rateLimitPerSecond too high");
         _setRateLimitPerSecond(newRateLimitPerSecond);
     }
 
     /// @notice set the buffer cap
-    function setbufferCap(uint256 newBufferCap) external onlyGovernorOrAdmin {
+    function setBufferCap(uint256 newBufferCap) external virtual onlyGovernorOrAdmin {
         _setBufferCap(newBufferCap);
     }
 
@@ -82,6 +83,8 @@ abstract contract RateLimited is CoreRef {
 
         lastBufferUsedTime = block.timestamp;
 
+        emit BufferUsed(usedAmount, _bufferStored);
+
         return usedAmount;
     }
 
@@ -103,9 +106,13 @@ abstract contract RateLimited is CoreRef {
 
         // Cap the existing stored buffer
         if (_bufferStored > newBufferCap) {
-            _bufferStored = newBufferCap;
+            _resetBuffer();
         }
 
         emit BufferCapUpdate(oldBufferCap, newBufferCap);
+    }
+
+    function _resetBuffer() internal {
+        _bufferStored = bufferCap;
     }
 }

--- a/test/unit/dao/TribeMinter.test.ts
+++ b/test/unit/dao/TribeMinter.test.ts
@@ -11,7 +11,7 @@ before(() => {
   chai.use(CBN(ethers.BigNumber));
 });
 
-describe.only('TribeMinter', function () {
+describe('TribeMinter', function () {
   let userAddress: string;
   let governorAddress: string;
   let core: Core;

--- a/test/unit/dao/TribeMinter.test.ts
+++ b/test/unit/dao/TribeMinter.test.ts
@@ -1,0 +1,321 @@
+import { expectRevert, getAddresses, getCore, getImpersonatedSigner, increaseTime } from '../../helpers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { Signer } from 'ethers';
+import { Core, Tribe, TribeMinter } from '@custom-types/contracts';
+import chai from 'chai';
+import CBN from 'chai-bn';
+const toBN = ethers.BigNumber.from;
+
+before(() => {
+  chai.use(CBN(ethers.BigNumber));
+});
+
+describe('TribeMinter', function () {
+  let userAddress: string;
+  let governorAddress: string;
+  let core: Core;
+  let tribe: Tribe;
+  let tribeMinter: TribeMinter;
+
+  const impersonatedSigners: { [key: string]: Signer } = {};
+
+  before(async () => {
+    const addresses = await getAddresses();
+
+    // add any addresses you want to impersonate here
+    const impersonatedAddresses = [addresses.userAddress, addresses.governorAddress];
+
+    for (const address of impersonatedAddresses) {
+      impersonatedSigners[address] = await getImpersonatedSigner(address);
+    }
+  });
+
+  beforeEach(async function () {
+    ({ userAddress, governorAddress } = await getAddresses());
+    core = await getCore();
+
+    tribe = await ethers.getContractAt('Tribe', await core.tribe());
+
+    tribeMinter = await (
+      await ethers.getContractFactory('TribeMinter')
+    ).deploy(
+      core.address,
+      '1000', // 10% inflation cap
+      governorAddress,
+      [] // no additional lockedTribeAddresses
+    );
+
+    await tribe.connect(impersonatedSigners[governorAddress]).setMinter(tribeMinter.address);
+  });
+
+  describe('Init', function () {
+    it('annualMaxInflationBasisPoints', async function () {
+      expect(await tribeMinter.annualMaxInflationBasisPoints()).to.be.bignumber.equal(toBN('1000'));
+    });
+
+    it('owner', async function () {
+      expect(await tribeMinter.owner()).to.be.equal(governorAddress);
+    });
+
+    it('bufferCap', async function () {
+      const bufferCap = await tribeMinter.bufferCap();
+      expect(bufferCap).to.be.bignumber.equal(ethers.constants.WeiPerEther.mul(100_000_000));
+      expect(bufferCap).to.be.bignumber.equal(await tribeMinter.idealBufferCap());
+      expect(bufferCap).to.be.bignumber.equal(await tribeMinter.buffer());
+    });
+
+    it('isPokeNeeded', async function () {
+      expect(await tribeMinter.isPokeNeeded()).to.be.false;
+    });
+
+    it('rateLimitPerSecond', async function () {
+      expect(await tribeMinter.rateLimitPerSecond()).to.be.bignumber.equal(
+        ethers.constants.WeiPerEther.mul(100_000_000).div(31_557_600)
+      );
+    });
+
+    it('tribeCirculatingSupply', async function () {
+      expect(await tribeMinter.tribeCirculatingSupply()).to.be.bignumber.equal(await tribe.totalSupply());
+      expect(await tribeMinter.totalSupply()).to.be.bignumber.equal(await tribe.totalSupply());
+    });
+
+    it('lockedTribeAddresses', async function () {
+      const lockedAddresses = await tribeMinter.lockedTribeAddresses();
+      expect(lockedAddresses.length).to.be.equal(1);
+      expect(lockedAddresses[0]).to.be.equal(tribeMinter.address);
+    });
+  });
+
+  describe('Poke', function () {
+    let mintAmount;
+    let inflationIncrement;
+
+    beforeEach(async function () {
+      mintAmount = ethers.constants.WeiPerEther.mul(10_000);
+
+      // set the inflation increment to 10% of the mintAmount because that is the annualMaxInflation
+      inflationIncrement = mintAmount.div(10);
+    });
+
+    describe('Increase Supply', function () {
+      beforeEach(async function () {
+        await tribeMinter.connect(impersonatedSigners[governorAddress]).mint(userAddress, mintAmount);
+
+        // Increase time to refill the buffer
+        await increaseTime(10000000);
+      });
+
+      it('increases rate limit', async function () {
+        const bufferCapBefore = await tribeMinter.bufferCap();
+
+        expect(await tribeMinter.isPokeNeeded()).to.be.true;
+        const tx = await tribeMinter.poke();
+
+        // Check the events, particularly that the buffer is used by the increase
+        expect(tx).to.emit(tribeMinter, 'BufferUsed').withArgs(inflationIncrement, bufferCapBefore);
+
+        // To get rate limit per second divide by 365.25 days in seconds
+        expect(tx)
+          .to.emit(tribeMinter, 'RateLimitPerSecondUpdate')
+          .withArgs(bufferCapBefore.div(31_557_600), bufferCapBefore.add(inflationIncrement).div(31_557_600));
+        expect(tx)
+          .to.emit(tribeMinter, 'BufferCapUpdate')
+          .withArgs(bufferCapBefore, bufferCapBefore.add(inflationIncrement));
+
+        expect(await tribeMinter.isPokeNeeded()).to.be.false;
+      });
+    });
+
+    describe('Decrease Supply', function () {
+      beforeEach(async function () {
+        // Transferring TRIBE to user address and setting it to locked effectively decreases circulating supply
+        await core.connect(impersonatedSigners[governorAddress]).allocateTribe(userAddress, mintAmount);
+        await tribeMinter.connect(impersonatedSigners[governorAddress]).addLockedTribeAddress(userAddress);
+      });
+
+      it('decreases rate limit', async function () {
+        const bufferCapBefore = await tribeMinter.bufferCap();
+
+        expect(await tribeMinter.isPokeNeeded()).to.be.true;
+
+        const tx = await tribeMinter.poke();
+
+        // Check the events, particularly that no buffer is used
+        expect(tx).to.not.emit(tribeMinter, 'BufferUsed');
+
+        // To get rate limit per second divide by 365.25 days in seconds
+        expect(tx)
+          .to.emit(tribeMinter, 'RateLimitPerSecondUpdate')
+          .withArgs(bufferCapBefore.div(31_557_600), bufferCapBefore.sub(inflationIncrement).div(31_557_600));
+        expect(tx)
+          .to.emit(tribeMinter, 'BufferCapUpdate')
+          .withArgs(bufferCapBefore, bufferCapBefore.sub(inflationIncrement));
+
+        expect(await tribeMinter.isPokeNeeded()).to.be.false;
+      });
+    });
+
+    describe('No Change', function () {
+      it('reverts', async function () {
+        expect(await tribeMinter.isPokeNeeded()).to.be.false;
+        await expectRevert(tribeMinter.poke(), 'TribeMinter: No rate limit change needed');
+      });
+    });
+  });
+
+  describe('Mint', function () {
+    let mintAmount;
+    beforeEach(async function () {
+      mintAmount = ethers.constants.WeiPerEther.mul(10_000);
+    });
+
+    describe('Access', function () {
+      it('governor succeeds', async function () {
+        const bufferCap = await tribeMinter.bufferCap();
+
+        // Check that minting uses up the rate limit buffer
+        expect(await tribeMinter.connect(impersonatedSigners[governorAddress]).mint(userAddress, mintAmount))
+          .to.emit(tribeMinter, 'BufferUsed')
+          .withArgs(mintAmount, bufferCap.sub(mintAmount));
+        expect(await tribe.balanceOf(userAddress)).to.be.equal(mintAmount);
+      });
+
+      it('non-governor reverts', async function () {
+        await expectRevert(
+          tribeMinter.connect(impersonatedSigners[userAddress]).mint(userAddress, mintAmount),
+          'CoreRef: Caller is not a governor'
+        );
+      });
+    });
+
+    describe('No Held TRIBE', function () {
+      it('mints all TRIBE', async function () {
+        // If the deposit holds no TRIBE, 100% of the mint should be truly minted
+        expect(await tribe.balanceOf(tribeMinter.address)).to.be.equal(toBN('0'));
+        expect(await tribe.balanceOf(userAddress)).to.be.equal(toBN('0'));
+
+        await tribeMinter.connect(impersonatedSigners[governorAddress]).mint(userAddress, mintAmount);
+
+        expect(await tribe.balanceOf(tribeMinter.address)).to.be.equal(toBN('0'));
+        expect(await tribe.balanceOf(userAddress)).to.be.equal(toBN(mintAmount));
+      });
+    });
+
+    describe('Some Held TRIBE', function () {
+      beforeEach(async function () {
+        await tribeMinter.connect(impersonatedSigners[governorAddress]).mint(tribeMinter.address, mintAmount);
+        expect(await tribe.balanceOf(tribeMinter.address)).to.be.equal(mintAmount);
+      });
+
+      it('mints some TRIBE', async function () {
+        // If the deposit holds some TRIBE, it should transfer that TRIBE before minting
+        expect(await tribe.balanceOf(userAddress)).to.be.equal(toBN('0'));
+        await tribeMinter.connect(impersonatedSigners[governorAddress]).mint(userAddress, mintAmount.mul(2));
+        expect(await tribe.balanceOf(tribeMinter.address)).to.be.equal(toBN('0'));
+        expect(await tribe.balanceOf(userAddress)).to.be.equal(mintAmount.mul(2));
+      });
+    });
+  });
+
+  describe('Set Minter', function () {
+    it('governor succeeds', async function () {
+      await tribeMinter.connect(impersonatedSigners[governorAddress]).setMinter(userAddress);
+      expect(await tribe.minter()).to.be.equal(userAddress);
+    });
+
+    it('non-governor reverts', async function () {
+      await expectRevert(
+        tribeMinter.connect(impersonatedSigners[userAddress]).setMinter(userAddress),
+        'Ownable: caller is not the owner'
+      );
+    });
+  });
+
+  describe('Add Locked Tribe Address', function () {
+    it('governor succeeds', async function () {
+      const signer = impersonatedSigners[governorAddress];
+
+      // First mint some TRIBE to check if it is excluded later
+      const mintAmount = ethers.constants.WeiPerEther.mul(10_000);
+      await tribeMinter.connect(signer).mint(userAddress, mintAmount);
+
+      const supplyBefore = await tribeMinter.totalSupply();
+
+      expect(await tribeMinter.connect(signer).addLockedTribeAddress(userAddress))
+        .to.emit(tribeMinter, 'AddLockedTribeAddress')
+        .withArgs(userAddress);
+
+      // Check the new lockedTribeAddresses
+      const lockedAddresses = await tribeMinter.lockedTribeAddresses();
+      expect(lockedAddresses[1]).to.be.equal(userAddress);
+      expect(lockedAddresses.length).to.be.equal(2);
+
+      // Check that the minted TRIBE was excluded
+      expect(await tribeMinter.totalSupply()).to.be.bignumber.equal(supplyBefore.sub(mintAmount));
+    });
+
+    it('non-governor reverts', async function () {
+      await expectRevert(
+        tribeMinter.connect(impersonatedSigners[userAddress]).addLockedTribeAddress(userAddress),
+        'CoreRef: Caller is not a governor or contract admin'
+      );
+    });
+  });
+
+  describe('Remove Locked Tribe Address', function () {
+    it('governor succeeds', async function () {
+      const signer = impersonatedSigners[governorAddress];
+
+      // First mint some excluded TRIBE to see if it is re-included after removing
+      const mintAmount = ethers.constants.WeiPerEther.mul(10_000);
+      await tribeMinter.connect(signer).mint(tribeMinter.address, mintAmount);
+
+      const supplyBefore = await tribeMinter.totalSupply();
+
+      expect(await tribeMinter.connect(signer).removeLockedTribeAddress(tribeMinter.address))
+        .to.emit(tribeMinter, 'RemoveLockedTribeAddress')
+        .withArgs(tribeMinter.address);
+
+      // Check lockedTribeAddresses is empty after removing tribeMinter
+      const lockedAddresses = await tribeMinter.lockedTribeAddresses();
+      expect(lockedAddresses.length).to.be.equal(0);
+
+      // Then check the previously excluded balance is now included
+      expect(await tribeMinter.totalSupply()).to.be.bignumber.equal(supplyBefore.add(mintAmount));
+    });
+
+    it('non-governor reverts', async function () {
+      await expectRevert(
+        tribeMinter.connect(impersonatedSigners[userAddress]).removeLockedTribeAddress(userAddress),
+        'CoreRef: Caller is not a governor or contract admin'
+      );
+    });
+  });
+
+  describe('Set Annual Max Inflation', function () {
+    it('governor succeeds', async function () {
+      await tribeMinter.connect(impersonatedSigners[governorAddress]).setAnnualMaxInflationBasisPoints('300');
+      expect(await tribeMinter.annualMaxInflationBasisPoints()).to.be.bignumber.equal(toBN(300));
+    });
+
+    it('non-governor reverts', async function () {
+      await expectRevert(
+        tribeMinter.connect(impersonatedSigners[userAddress]).setAnnualMaxInflationBasisPoints('300'),
+        'CoreRef: Caller is not a governor or contract admin'
+      );
+    });
+  });
+
+  describe('Set Buffer Cap', function () {
+    it('reverts', async function () {
+      await expectRevert(tribeMinter.connect(impersonatedSigners[userAddress]).setBufferCap(0), 'no-op');
+    });
+  });
+
+  describe('Set Rate Limit Per Second', function () {
+    it('reverts', async function () {
+      await expectRevert(tribeMinter.connect(impersonatedSigners[userAddress]).setBufferCap(0), 'no-op');
+    });
+  });
+});

--- a/test/unit/utils/RateLimitedMinter.test.ts
+++ b/test/unit/utils/RateLimitedMinter.test.ts
@@ -119,14 +119,14 @@ describe('RateLimitedMinter', function () {
       await this.rateLimitedMinter
         .connect(impersonatedSigners[governorAddress])
         .connect(impersonatedSigners[governorAddress])
-        .setbufferCap('10000', {});
+        .setBufferCap('10000', {});
       expect(await this.rateLimitedMinter.bufferCap()).to.be.equal(toBN('10000'));
       expect(await this.rateLimitedMinter.buffer()).to.be.equal(toBN('10000'));
     });
 
     it('non-governor reverts', async function () {
       await expectRevert(
-        this.rateLimitedMinter.connect(impersonatedSigners[userAddress]).setbufferCap('10000'),
+        this.rateLimitedMinter.connect(impersonatedSigners[userAddress]).setBufferCap('10000'),
         'CoreRef: Caller is not a governor'
       );
     });


### PR DESCRIPTION
  
Separates all Tribe Minting logic out from TribeReserveStabilizer into a TribeMinter contract
  
-------
  @title implementation for a TRIBE Minter Contract
  @author Fei Protocol

  This contract will be the unique TRIBE minting contract. 
  All minting is subject to an annual inflation rate limit.
  For example if circulating supply is 1m and inflation is capped at 10%, then no more than 100k TRIBE can enter circulation in the following year.

  The contract will increase (decrease) the rate limit proportionally as supply increases (decreases)

  Governance and admins can only lower the max inflation %. 
  They can also exclude (unexclude) addresses' TRIBE balances from the circulating supply. 
  The minter's balance is excluded by default.

  ACCESS_CONTROL:
  This contract follows a somewhat unique access control pattern. 
  It has a contract admin which is NOT intended for optimistic approval, but rather for contracts such as the TribeReserveStabilizer.
  An additional potential contract admin is one which automates the inclusion and removal of excluded deposits from on-chain timelocks.

  Additionally, the ability to transfer the tribe minter role is held by the contract *owner* rather than governor or admin.
  The owner will intially be the DAO timelock.
  This keeps the power to transfer or burn TRIBE minting rights isolated.
  
  -------
  Also makes some light changes to RateLimited contract