### PR TITLE
Read pause override

### DIFF
--- a/contracts/oracle/collateralization/CollateralizationOracleWrapper.sol
+++ b/contracts/oracle/collateralization/CollateralizationOracleWrapper.sol
@@ -19,27 +19,6 @@ interface IPausable {
 contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrapper, CoreRef {
     using Decimal for Decimal.D256;
 
-    // ----------- Events ------------------------------------------------------
-
-    event CachedValueUpdate(
-        address from,
-        uint256 indexed protocolControlledValue,
-        uint256 indexed userCirculatingFei,
-        int256 indexed protocolEquity
-    );
-
-    event CollateralizationOracleUpdate(
-        address from,
-        address indexed oldOracleAddress,
-        address indexed newOracleAddress
-    );
-
-    event DeviationThresholdUpdate(
-        address from,
-        uint256 indexed oldThreshold,
-        uint256 indexed newThreshold
-    );
-
     // ----------- Properties --------------------------------------------------
 
     /// @notice address of the CollateralizationOracle to memoize
@@ -57,7 +36,7 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
     uint256 public override deviationThresholdBasisPoints;
 
     /// @notice a flag to override pause behavior for reads
-    bool public readPauseOverride;
+    bool public override readPauseOverride;
 
     // ----------- Constructor -------------------------------------------------
 
@@ -134,8 +113,9 @@ contract CollateralizationOracleWrapper is Timed, ICollateralizationOracleWrappe
 
     /// @notice set the readPauseOverride flag
     /// @param _readPauseOverride the new flag for readPauseOverride
-    function setReadPauseOverride(bool _readPauseOverride) external onlyGuardianOrGovernor {
+    function setReadPauseOverride(bool _readPauseOverride) external override onlyGuardianOrGovernor {
         readPauseOverride = _readPauseOverride;
+        emit ReadPauseOverrideUpdate(_readPauseOverride);
     }
 
     /// @notice governor or admin override to directly write to the cache

--- a/contracts/oracle/collateralization/ICollateralizationOracleWrapper.sol
+++ b/contracts/oracle/collateralization/ICollateralizationOracleWrapper.sol
@@ -7,12 +7,38 @@ import "./ICollateralizationOracle.sol";
 /// @author Fei Protocol
 interface ICollateralizationOracleWrapper is ICollateralizationOracle {
 
+    // ----------- Events ------------------------------------------------------
+
+    event CachedValueUpdate(
+        address from,
+        uint256 indexed protocolControlledValue,
+        uint256 indexed userCirculatingFei,
+        int256 indexed protocolEquity
+    );
+
+    event CollateralizationOracleUpdate(
+        address from,
+        address indexed oldOracleAddress,
+        address indexed newOracleAddress
+    );
+
+    event DeviationThresholdUpdate(
+        address from,
+        uint256 indexed oldThreshold,
+        uint256 indexed newThreshold
+    );
+
+    event ReadPauseOverrideUpdate(
+        bool readPauseOverride
+    );
     // ----------- Public state changing api -----------
 
     function updateIfOutdated() external;
 
     // ----------- Governor only state changing api -----------
     function setValidityDuration(uint256 _validityDuration) external;
+
+    function setReadPauseOverride(bool newReadPauseOverride) external;
 
     function setDeviationThresholdBasisPoints(uint256 _newDeviationThresholdBasisPoints) external;
 
@@ -46,4 +72,6 @@ interface ICollateralizationOracleWrapper is ICollateralizationOracle {
     );
 
     function isExceededDeviationThreshold() external view returns (bool);
+
+    function readPauseOverride() external view returns(bool);
 }

--- a/test/unit/oracle/CollateralizationOracleWrapper.test.ts
+++ b/test/unit/oracle/CollateralizationOracleWrapper.test.ts
@@ -112,7 +112,7 @@ describe('CollateralizationOracleWrapper', function () {
     });
   });
 
-  describe.only('Read Pause', function() {
+  describe('Read Pause', function() {
     describe('setReadPauseOverride', function() {
       it('governor succeeds', async function() {
         await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).setReadPauseOverride(true);

--- a/test/unit/oracle/CollateralizationOracleWrapper.test.ts
+++ b/test/unit/oracle/CollateralizationOracleWrapper.test.ts
@@ -112,14 +112,14 @@ describe('CollateralizationOracleWrapper', function () {
     });
   });
 
-  describe('Read Pause', function() {
-    describe('setReadPauseOverride', function() {
-      it('governor succeeds', async function() {
+  describe('Read Pause', function () {
+    describe('setReadPauseOverride', function () {
+      it('governor succeeds', async function () {
         await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).setReadPauseOverride(true);
         expect(await this.oracleWrapper.readPauseOverride()).to.be.true;
       });
 
-      it('non-governor reverts', async function() {
+      it('non-governor reverts', async function () {
         await expectRevert(
           this.oracleWrapper.connect(impersonatedSigners[userAddress]).setReadPauseOverride(true),
           'CoreRef: Caller is not a guardian or governor'
@@ -127,13 +127,13 @@ describe('CollateralizationOracleWrapper', function () {
       });
     });
 
-    describe('ReadPause overrides pause', async function() {
+    describe('ReadPause overrides pause', async function () {
       beforeEach(async function () {
         await this.oracleWrapper.update();
         await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).pause();
       });
 
-      it('succeeds', async function() {
+      it('succeeds', async function () {
         expect((await this.oracleWrapper.read())[1]).to.be.false;
         await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).setReadPauseOverride(true);
         expect((await this.oracleWrapper.read())[1]).to.be.true;

--- a/test/unit/oracle/CollateralizationOracleWrapper.test.ts
+++ b/test/unit/oracle/CollateralizationOracleWrapper.test.ts
@@ -112,6 +112,35 @@ describe('CollateralizationOracleWrapper', function () {
     });
   });
 
+  describe.only('Read Pause', function() {
+    describe('setReadPauseOverride', function() {
+      it('governor succeeds', async function() {
+        await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).setReadPauseOverride(true);
+        expect(await this.oracleWrapper.readPauseOverride()).to.be.true;
+      });
+
+      it('non-governor reverts', async function() {
+        await expectRevert(
+          this.oracleWrapper.connect(impersonatedSigners[userAddress]).setReadPauseOverride(true),
+          'CoreRef: Caller is not a guardian or governor'
+        );
+      });
+    });
+
+    describe('ReadPause overrides pause', async function() {
+      beforeEach(async function () {
+        await this.oracleWrapper.update();
+        await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).pause();
+      });
+
+      it('succeeds', async function() {
+        expect((await this.oracleWrapper.read())[1]).to.be.false;
+        await this.oracleWrapper.connect(impersonatedSigners[governorAddress]).setReadPauseOverride(true);
+        expect((await this.oracleWrapper.read())[1]).to.be.true;
+      });
+    });
+  });
+
   describe('setCollateralizationOracle()', function () {
     it('should emit CollateralizationOracleUpdate', async function () {
       await expect(


### PR DESCRIPTION
Add the ability for the guardian to enforce reads are valid even while paused.

This is useful when the guardian is manually adjusting the cache values via CollateralizationOracleGuardian.