### PR TITLE
refactor IPCVDepositAggregator

### DIFF
--- a/contracts/pcv/IPCVDepositAggregator.sol
+++ b/contracts/pcv/IPCVDepositAggregator.sol
@@ -81,14 +81,12 @@ interface IPCVDepositAggregator {
     /// @param weight the new weight for the buffer
     function setBufferWeight(uint256 weight) external;
 
-    // ---------- Guardian or Admin Only State Changing API ----------
-
     /// @notice tops up a deposit from the aggregator's balance
     /// @param pcvDeposit the address of the pcv deposit to top up
     /// @dev this will only pull from the balance that is left over after the aggregator's buffer fills up
     function depositSingle(address pcvDeposit) external;
 
-    // ---------- Guardian Only State Changing API ----------
+    // ---------- Guardian or Governor Only State Changing API ----------
 
     /// @notice sets the weight of a pcv deposit to zero
     /// @param depositAddress the address of the pcv deposit to set the weight of to zero

--- a/contracts/pcv/IPCVDepositAggregator.sol
+++ b/contracts/pcv/IPCVDepositAggregator.sol
@@ -51,6 +51,13 @@ interface IPCVDepositAggregator {
         uint256 newWeight
     );
 
+    // ----------- Public Functions ----------
+
+    /// @notice tops up a deposit from the aggregator's balance
+    /// @param pcvDeposit the address of the pcv deposit to top up
+    /// @dev this will only pull from the balance that is left over after the aggregator's buffer fills up
+    function depositSingle(address pcvDeposit) external;
+
     // ----------- Governor Only State Changing API -----------
 
     /// @notice replaces this contract with a new PCV Deposit Aggregator on the rewardsAssetManager
@@ -80,11 +87,6 @@ interface IPCVDepositAggregator {
     /// @notice set the weight for the buffer specifically
     /// @param weight the new weight for the buffer
     function setBufferWeight(uint256 weight) external;
-
-    /// @notice tops up a deposit from the aggregator's balance
-    /// @param pcvDeposit the address of the pcv deposit to top up
-    /// @dev this will only pull from the balance that is left over after the aggregator's buffer fills up
-    function depositSingle(address pcvDeposit) external;
 
     // ---------- Guardian or Governor Only State Changing API ----------
 

--- a/contracts/pcv/IPCVDepositAggregator.sol
+++ b/contracts/pcv/IPCVDepositAggregator.sol
@@ -53,10 +53,6 @@ interface IPCVDepositAggregator {
 
     // ----------- Governor Only State Changing API -----------
 
-    /// @notice adds a new PCV Deposit to the set of deposits
-    /// @param weight a relative (i.e. not normalized) weight of this PCV deposit
-    function addPCVDeposit(address newPCVDeposit, uint256 weight) external;
-
     /// @notice replaces this contract with a new PCV Deposit Aggregator on the rewardsAssetManager
     /// @param newAggregator the address of the new PCV Deposit Aggregator
     function setNewAggregator(address newAggregator) external;
@@ -66,6 +62,10 @@ interface IPCVDepositAggregator {
     function setAssetManager(address newAssetManager) external;
 
     // ----------- Governor or Admin Only State Changing API -----------
+
+    /// @notice adds a new PCV Deposit to the set of deposits
+    /// @param weight a relative (i.e. not normalized) weight of this PCV deposit
+    function addPCVDeposit(address newPCVDeposit, uint256 weight) external;
 
     /// @notice remove a PCV deposit from the set of deposits
     /// @param pcvDeposit the address of the PCV deposit to remove

--- a/contracts/pcv/IPCVDepositAggregator.sol
+++ b/contracts/pcv/IPCVDepositAggregator.sol
@@ -24,20 +24,6 @@ interface IPCVDepositAggregator {
         address indexed depositAddress
     );
 
-    event Rebalanced(
-        uint256 totalAssets
-    );
-
-    event RebalancedSingle(
-        address indexed pcvDepositAddress
-    );
-
-    event CannotRebalanceSingle(
-        address indexed pcvDeposit, 
-        uint256 amountNeeded, 
-        uint256 aggregatorBalance
-    );
-
     event AggregatorWithdrawal(
         uint256 amount
     );
@@ -67,12 +53,10 @@ interface IPCVDepositAggregator {
 
     // ----------- State changing api -----------
 
-    /// @notice rebalance funds of the underlying deposits to the optimal target percents
-    function rebalance() external;
-
-    /// @notice same as the rebalance function, but for a single deposit
-    /// @param pcvDeposit the address of the pcv deposit to attempt to rebalance
-    function rebalanceSingle(address pcvDeposit) external;
+    /// @notice tops up a deposit from the aggregator's balance
+    /// @param pcvDeposit the address of the pcv deposit to top up
+    /// @dev this will only pull from the balance that is left over after the aggregator's buffer fills up
+    function tryTopUpDeposit(address pcvDeposit) external;
 
     // ----------- Governor only state changing api -----------
 
@@ -92,7 +76,7 @@ interface IPCVDepositAggregator {
 
     /// @notice remove a PCV deposit from the set of deposits
     /// @param pcvDeposit the address of the PCV deposit to remove
-    /// @param shouldRebalance whether or not we want to rebalanceSingle on that deposit address before removing but after setting the weight to zero
+    /// @param shouldRebalance whether or not to withdraw from the pcv deposit before removing it
     function removePCVDeposit(address pcvDeposit, bool shouldRebalance) external;
 
     /// @notice set the relative weight of a particular pcv deposit

--- a/contracts/pcv/IPCVDepositAggregator.sol
+++ b/contracts/pcv/IPCVDepositAggregator.sol
@@ -51,14 +51,7 @@ interface IPCVDepositAggregator {
         uint256 newWeight
     );
 
-    // ----------- State changing api -----------
-
-    /// @notice tops up a deposit from the aggregator's balance
-    /// @param pcvDeposit the address of the pcv deposit to top up
-    /// @dev this will only pull from the balance that is left over after the aggregator's buffer fills up
-    function tryTopUpDeposit(address pcvDeposit) external;
-
-    // ----------- Governor only state changing api -----------
+    // ----------- Governor Only State Changing API -----------
 
     /// @notice adds a new PCV Deposit to the set of deposits
     /// @param weight a relative (i.e. not normalized) weight of this PCV deposit
@@ -72,7 +65,7 @@ interface IPCVDepositAggregator {
     /// @param newAssetManager the address of the new rewards asset manager
     function setAssetManager(address newAssetManager) external;
 
-    // ----------- Governor or Admin only state changing api -----------
+    // ----------- Governor or Admin Only State Changing API -----------
 
     /// @notice remove a PCV deposit from the set of deposits
     /// @param pcvDeposit the address of the PCV deposit to remove
@@ -88,13 +81,20 @@ interface IPCVDepositAggregator {
     /// @param weight the new weight for the buffer
     function setBufferWeight(uint256 weight) external;
 
-    // ---------- Guardian only state changing api ----------
+    // ---------- Guardian or Admin Only State Changing API ----------
+
+    /// @notice tops up a deposit from the aggregator's balance
+    /// @param pcvDeposit the address of the pcv deposit to top up
+    /// @dev this will only pull from the balance that is left over after the aggregator's buffer fills up
+    function depositSingle(address pcvDeposit) external;
+
+    // ---------- Guardian Only State Changing API ----------
 
     /// @notice sets the weight of a pcv deposit to zero
     /// @param depositAddress the address of the pcv deposit to set the weight of to zero
     function setPCVDepositWeightZero(address depositAddress) external;
 
-    // ----------- Read-only api -----------
+    // ----------- Read-Only API -----------
 
     /// @notice the token that the aggregator is managing
     /// @return the address of the token that the aggregator is managing


### PR DESCRIPTION
Removes rebalancing from the PCV Deposit Aggregator.

Rationale: pcv deposits should be as firewalled from each other as possible, so that one compromised or malicious pcv deposit can't rug all tokens in the aggregator.

By removing the rebalance feature, we effectively only allow rebalance-on-push and rebalance-on-withdraw; deposits and withdrawals will still deposit and withdraw, respectively, from each pcv deposit to average the underlying tokens towards their weights, but there will be no atomic interaction that allows pcv to flow from one pcv deposit into another.

Withdraw is still permissioned, of course; a hacker couldn't withdraw from one pcv deposit and then call deposit() to deposit into another.

`depositSingle(address pcvDeposit)` has replaced `rebalanceSingle(address pcvDeposit)`, and permission for this has been set to GuardianOrAdmin, though I'm up for changing this if warranted.