### PR TITLE
merger proposal update

### DIFF
--- a/proposals/dao/merger.ts
+++ b/proposals/dao/merger.ts
@@ -101,7 +101,9 @@ export const setup: SetupUpgradeFunc = async (addresses, oldContracts, contracts
 
   const signer = await getImpersonatedSigner(guardian);
 
-  await tribeRagequit.connect(signer).setExchangeRate(equity);
+  if ((await tribeRagequit.intrinsicValueExchangeRateBase()).toString() === '0') {
+    await tribeRagequit.connect(signer).setExchangeRate(equity);
+  }
 
   const rgt = contracts.rgt;
   await forceEth(addresses.rariTimelock);

--- a/proposals/dao/merger.ts
+++ b/proposals/dao/merger.ts
@@ -36,9 +36,7 @@ const merkleRoot = '0x8c1f858b87b4e23cb426875833bf8f1aaeb627fe2f47e62385d704c415
 
 const rageQuitStart = '1640221200'; // Dec 23, 1am UTC
 const rageQuitDeadline = '1640480400'; // Dec 26, 1am UTC
-const equity = '792326034963459120910718196';
-
-const toBN = ethers.BigNumber.from;
+const equity = '592326034963459120910718196'; // changed to intentionally brick validate. TODO use live value
 
 export const deploy: DeployUpgradeFunc = async (deployAddress, addresses, logging = false) => {
   const { tribe, rariTimelock } = addresses;

--- a/proposals/dao/merger.ts
+++ b/proposals/dao/merger.ts
@@ -36,7 +36,7 @@ const merkleRoot = '0x8c1f858b87b4e23cb426875833bf8f1aaeb627fe2f47e62385d704c415
 
 const rageQuitStart = '1640221200'; // Dec 23, 1am UTC
 const rageQuitDeadline = '1640480400'; // Dec 26, 1am UTC
-const equity = '792326034963459120910718196'; // TODO use live value
+const equity = '692588388367337720822976255';
 
 export const deploy: DeployUpgradeFunc = async (deployAddress, addresses, logging = false) => {
   const { tribe, rariTimelock } = addresses;
@@ -132,7 +132,7 @@ export const validate: ValidateUpgradeFunc = async (addresses, oldContracts, con
   expect(await tribeRagequit.bothPartiesAccepted()).to.be.true;
   expect(await pegExchanger.bothPartiesAccepted()).to.be.true;
 
-  expect((await tribeRagequit.intrinsicValueExchangeRateBase()).toString()).to.be.equal('1234273768');
+  expect((await tribeRagequit.intrinsicValueExchangeRateBase()).toString()).to.be.equal('1078903938');
   expect((await tribe.balanceOf(addresses.pegExchangerDripper)).toString()).to.be.equal('170000000000000000000000000');
   expect((await tribe.balanceOf(addresses.pegExchanger)).toString()).to.be.equal('100000000000000000000000000');
 

--- a/proposals/dao/merger.ts
+++ b/proposals/dao/merger.ts
@@ -36,7 +36,7 @@ const merkleRoot = '0x8c1f858b87b4e23cb426875833bf8f1aaeb627fe2f47e62385d704c415
 
 const rageQuitStart = '1640221200'; // Dec 23, 1am UTC
 const rageQuitDeadline = '1640480400'; // Dec 26, 1am UTC
-const equity = '592326034963459120910718196'; // changed to intentionally brick validate. TODO use live value
+const equity = '792326034963459120910718196'; // TODO use live value
 
 export const deploy: DeployUpgradeFunc = async (deployAddress, addresses, logging = false) => {
   const { tribe, rariTimelock } = addresses;
@@ -125,7 +125,9 @@ export const teardown: TeardownUpgradeFunc = async (addresses, oldContracts, con
 export const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts) => {
   const tribeRagequit: TRIBERagequit = contracts.tribeRagequit as TRIBERagequit;
   const pegExchanger: PegExchanger = contracts.pegExchanger as PegExchanger;
-  const { tribe, fei } = contracts;
+  const { tribe, fei, rariTimelock } = contracts;
+
+  expect(await rariTimelock.admin()).to.be.equal(addresses.tribeRariDAO);
 
   expect(await tribeRagequit.bothPartiesAccepted()).to.be.true;
   expect(await pegExchanger.bothPartiesAccepted()).to.be.true;

--- a/proposals/description/merger.ts
+++ b/proposals/description/merger.ts
@@ -65,7 +65,7 @@ const merger: ProposalDescription = {
 
   Ragequit details:
   - live until unix epoch 1640480400: Dec 26, 1am UTC
-  - Intrinsic Value:  
+  - Intrinsic Value: $1.078903938
 
   Rari forum: https://forums.rari.capital/d/177-feirari-token-merge/56
   Tribe forum: https://tribe.fei.money/t/fip-51-fei-rari-token-merge/3642/105

--- a/proposals/description/merger.ts
+++ b/proposals/description/merger.ts
@@ -63,6 +63,10 @@ const merger: ProposalDescription = {
   5. Grant FEI minting to TRIBERagequit
   6. Send 315k FEI to GFX
 
+  Ragequit details:
+  - live until unix epoch 1640480400: Dec 26, 1am UTC
+  - Intrinsic Value:  
+
   Rari forum: https://forums.rari.capital/d/177-feirari-token-merge/56
   Tribe forum: https://tribe.fei.money/t/fip-51-fei-rari-token-merge/3642/105
   Code: https://github.com/fei-protocol/fei-protocol-core/tree/develop/contracts/merger

--- a/test/integration/tests/merger.ts
+++ b/test/integration/tests/merger.ts
@@ -69,7 +69,15 @@ describe('e2e-merger', function () {
 
       const signer = await getImpersonatedSigner(guardian);
 
-      await time.increaseTo(await tribeRagequit.rageQuitStart());
+      const startTime = await tribeRagequit.rageQuitStart();
+
+      // Advance to vote start
+      if (toBN(await time.latest()).lt(toBN(startTime))) {
+        doLogging && console.log(`Advancing To: ${startTime}`);
+        await time.increaseTo(startTime);
+      } else {
+        doLogging && console.log('Ragequit live');
+      }
 
       // Ragequit 1 TRIBE
       const feiBalanceBefore = await fei.balanceOf(guardian);
@@ -81,7 +89,7 @@ describe('e2e-merger', function () {
       const tribeBalanceAfter = await tribe.balanceOf(guardian);
 
       expect(tribeBalanceBefore.sub(tribeBalanceAfter)).to.be.equal(ethers.constants.WeiPerEther);
-      expect(feiBalanceAfter.sub(feiBalanceBefore)).to.be.bignumber.equal(toBN('1234273768000000000'));
+      expect(feiBalanceAfter.sub(feiBalanceBefore)).to.be.bignumber.equal(toBN('1078903938000000000'));
 
       // Ragequit original TRIBE fails
       expect(tribeRagequit.connect(signer).ngmi(guardianBalance, guardianBalance, proofArray)).to.be.revertedWith(


### PR DESCRIPTION
Runbook for proposal:

- [x] Read Protocol Equity from [CR Oracle # pcvStats] - (https://etherscan.io/address/0xFF6f59333cfD8f4Ebc14aD0a0E181a83e655d257#readContract) : 692588388367337720822976255 @ 10:50 am PT 12-18-2021
- [x] Plug Protocol Equity into [TRIBERagequit # exchangeRate](https://etherscan.io/address/0xE77d572F04904fFea40899FD907F7ADd6Ea5228A#readContract) and verify around $1 x 1e9 - 1078903938 @ 10:50 am PT 12-18-2021
- [x] Add equity from 1 to merger DAO script global param and IV from 2 to validate step
- [x] Add IV to merger description
- [x] Make sure everything passes in CI
- [x] Set IV on-chain
- [x] Construct calldata `DEPLOY_FILE=merger npm run calldata`
- [ ] Propose to tally by sending tx to FeiDAO
- [ ] Check proposal validity manually and automatically `DEPLOY_FILE=merger PROPOSAL_NUMBER=<number> npm run check-proposal`