### PR TITLE
FIP-60 - Fuse guardian

### DIFF
--- a/contracts/external/Unitroller.sol
+++ b/contracts/external/Unitroller.sol
@@ -12,19 +12,33 @@ abstract contract Unitroller {
     }
     
     address public admin;
+    address public borrowCapGuardian;
+    address public pauseGuardian;
+
     address public oracle;
     address public pendingAdmin;
     uint public closeFactorMantissa;
     uint public liquidationIncentiveMantissa;
     mapping(address => Market) public markets;
     mapping(address => address) public cTokensByUnderlying;
+    mapping(address => uint) public supplyCaps;
 
     function _setPendingAdmin(address newPendingAdmin) public virtual returns (uint); 
+
+    function _setBorrowCapGuardian(address newBorrowCapGuardian) public virtual;
+    function _setMarketSupplyCaps(CToken[] calldata cTokens, uint[] calldata newSupplyCaps) external virtual;
+    function _setMarketBorrowCaps(CToken[] calldata cTokens, uint[] calldata newBorrowCaps) external virtual;
+
+    function _setPauseGuardian(address newPauseGuardian) public virtual returns (uint);
+    function _setMintPaused(CToken cToken, bool state) public virtual returns (bool);
+    function _setBorrowPaused(CToken cToken, bool borrowPaused) public virtual returns (bool);
+    function _setTransferPaused(bool state) public virtual returns (bool);
+    function _setSeizePaused(bool state) public virtual returns (bool);
+
     function _setPriceOracle(address newOracle) external virtual returns (uint256);
     function _setCloseFactor(uint newCloseFactorMantissa) external virtual returns (uint256);
     function _setLiquidationIncentive(uint newLiquidationIncentiveMantissa) external virtual returns (uint);
     function _setCollateralFactor(CToken cToken, uint newCollateralFactorMantissa) public virtual returns (uint256);
-    function _setBorrowPaused(CToken cToken, bool borrowPaused) external virtual;
     function _acceptAdmin() external virtual returns (uint);
     function _deployMarket(bool isCEther, bytes calldata constructionData, uint256 collateralFactorMantissa) external virtual returns (uint);
     function borrowGuardianPaused(address cToken) external view virtual returns(bool);

--- a/contracts/feirari/FuseGuardian.sol
+++ b/contracts/feirari/FuseGuardian.sol
@@ -1,0 +1,109 @@
+pragma solidity ^0.8.0;
+
+import "../refs/CoreRef.sol";
+import "../external/Unitroller.sol";
+
+/// @title a Fuse pause and borrow cap guardian used to expand access control to more Fei roles
+/// @author joeysantoro
+contract FuseGuardian is CoreRef {
+
+    /// @notice the fuse comptroller
+    Unitroller public immutable comptroller;
+
+    /// @param _core address of core contract
+    /// @param _comptroller the fuse comptroller
+    constructor(
+        address _core,
+        Unitroller _comptroller
+    ) CoreRef(_core) {
+        comptroller = _comptroller;
+        /// @notice The reason we are reusing the tribal chief admin role is it consolidates control in the OA,
+        /// and means we don't have to do another governance action to create this role in core
+        _setContractAdminRole(keccak256("TRIBAL_CHIEF_ADMIN_ROLE"));
+    }
+
+    // ************ BORROW GUARDIAN FUNCTIONS ************
+    /**
+      * @notice Set the given supply caps for the given cToken markets. Supplying that brings total underlying supply to or above supply cap will revert.
+      * @dev Admin or borrowCapGuardian function to set the supply caps. A supply cap of 0 corresponds to unlimited supplying.
+      * @param cTokens The addresses of the markets (tokens) to change the supply caps for
+      * @param newSupplyCaps The new supply cap values in underlying to be set. A value of 0 corresponds to unlimited supplying.
+      */
+    function _setMarketSupplyCaps(CToken[] memory cTokens, uint[] memory newSupplyCaps) public isGovernorOrGuardianOrAdmin {
+        comptroller._setMarketSupplyCaps(cTokens, newSupplyCaps);
+    }
+
+    function _setMarketSupplyCapsByUnderlying(address[] calldata underlyings, uint[] calldata newSupplyCaps) external {
+        _setMarketSupplyCaps(_underlyingToCTokens(underlyings), newSupplyCaps);
+    }
+
+    function _underlyingToCTokens(address[] memory underlyings) internal view returns (CToken[] memory) {
+        CToken[] memory cTokens = new CToken[](underlyings.length);
+        for (uint256 i = 0; i < underlyings.length; i++) {
+            address cToken = comptroller.cTokensByUnderlying(underlyings[i]);
+            require(cToken != address(0), "cToken doesn't exist");
+            cTokens[i] = CToken(cToken);
+        }
+        return cTokens;
+    }
+
+    /**
+      * @notice Set the given borrow caps for the given cToken markets. Borrowing that brings total borrows to or above borrow cap will revert.
+      * @dev Admin or borrowCapGuardian function to set the borrow caps. A borrow cap of 0 corresponds to unlimited borrowing.
+      * @param cTokens The addresses of the markets (tokens) to change the borrow caps for
+      * @param newBorrowCaps The new borrow cap values in underlying to be set. A value of 0 corresponds to unlimited borrowing.
+      */
+    function _setMarketBorrowCaps(CToken[] memory cTokens, uint[] memory newBorrowCaps) public isGovernorOrGuardianOrAdmin {
+        comptroller._setMarketBorrowCaps(cTokens, newBorrowCaps);
+    }
+
+    function _setMarketBorrowCapsByUnderlying(address[] calldata underlyings, uint[] calldata newBorrowCaps) external {
+        _setMarketBorrowCaps(_underlyingToCTokens(underlyings), newBorrowCaps);
+    }
+
+    /**
+     * @notice Admin function to change the Borrow Cap Guardian
+     * @param newBorrowCapGuardian The address of the new Borrow Cap Guardian
+     */
+    function _setBorrowCapGuardian(address newBorrowCapGuardian) external onlyGovernor {
+        comptroller._setBorrowCapGuardian(newBorrowCapGuardian);
+    }
+
+    // ************ PAUSE GUARDIAN FUNCTIONS ************
+    /**
+     * @notice Admin function to change the Pause Guardian
+     * @param newPauseGuardian The address of the new Pause Guardian
+     * @return uint 0=success, otherwise a failure. (See enum Error for details)
+     */
+    function _setPauseGuardian(address newPauseGuardian) public onlyGovernor returns (uint) {
+        return comptroller._setPauseGuardian(newPauseGuardian);
+    }
+
+    function _setMintPausedByUnderlying(address underlying, bool state) external {
+        address cToken = comptroller.cTokensByUnderlying(underlying);
+        require(cToken != address(0), "cToken doesn't exist");
+        _setMintPaused(CToken(cToken), state);
+    }
+
+    function _setMintPaused(CToken cToken, bool state) public isGovernorOrGuardianOrAdmin returns (bool) {
+        return comptroller._setMintPaused(cToken, state);
+    }
+
+    function _setBorrowPausedByUnderlying(address underlying, bool state) external {
+        address cToken = comptroller.cTokensByUnderlying(underlying);
+        require(cToken != address(0), "cToken doesn't exist");
+        _setBorrowPaused(CToken(cToken), state);
+    }
+
+    function _setBorrowPaused(CToken cToken, bool state) public isGovernorOrGuardianOrAdmin returns (bool) {
+        return comptroller._setBorrowPaused(cToken, state);
+    }
+
+    function _setTransferPaused(bool state) public isGovernorOrGuardianOrAdmin returns (bool) {
+        return comptroller._setSeizePaused(state);
+    }
+
+    function _setSeizePaused(bool state) public isGovernorOrGuardianOrAdmin returns (bool) {
+        return comptroller._setSeizePaused(state);
+    }
+}

--- a/contracts/feirari/FuseGuardian.sol
+++ b/contracts/feirari/FuseGuardian.sol
@@ -29,12 +29,16 @@ contract FuseGuardian is CoreRef {
       * @param cTokens The addresses of the markets (tokens) to change the supply caps for
       * @param newSupplyCaps The new supply cap values in underlying to be set. A value of 0 corresponds to unlimited supplying.
       */
-    function _setMarketSupplyCaps(CToken[] memory cTokens, uint[] calldata newSupplyCaps) public isGovernorOrGuardianOrAdmin {
-        comptroller._setMarketSupplyCaps(cTokens, newSupplyCaps);
+    function _setMarketSupplyCaps(CToken[] memory cTokens, uint[] calldata newSupplyCaps) external isGovernorOrGuardianOrAdmin {
+        _setMarketSupplyCapsInternal(cTokens, newSupplyCaps);
     }
 
-    function _setMarketSupplyCapsByUnderlying(address[] calldata underlyings, uint[] calldata newSupplyCaps) external {
-        _setMarketSupplyCaps(_underlyingToCTokens(underlyings), newSupplyCaps);
+    function _setMarketSupplyCapsByUnderlying(address[] calldata underlyings, uint[] calldata newSupplyCaps) external isGovernorOrGuardianOrAdmin {
+        _setMarketSupplyCapsInternal(_underlyingToCTokens(underlyings), newSupplyCaps);
+    }
+
+    function _setMarketSupplyCapsInternal(CToken[] memory cTokens, uint[] calldata newSupplyCaps) internal {
+        comptroller._setMarketSupplyCaps(cTokens, newSupplyCaps);
     }
 
     function _underlyingToCTokens(address[] calldata underlyings) internal view returns (CToken[] memory) {
@@ -53,12 +57,16 @@ contract FuseGuardian is CoreRef {
       * @param cTokens The addresses of the markets (tokens) to change the borrow caps for
       * @param newBorrowCaps The new borrow cap values in underlying to be set. A value of 0 corresponds to unlimited borrowing.
       */
-    function _setMarketBorrowCaps(CToken[] memory cTokens, uint[] calldata newBorrowCaps) public isGovernorOrGuardianOrAdmin {
+    function _setMarketBorrowCaps(CToken[] memory cTokens, uint[] calldata newBorrowCaps) external isGovernorOrGuardianOrAdmin {
+        _setMarketBorrowCapsInternal(cTokens, newBorrowCaps);
+    }
+
+    function _setMarketBorrowCapsInternal(CToken[] memory cTokens, uint[] calldata newBorrowCaps) internal {
         comptroller._setMarketBorrowCaps(cTokens, newBorrowCaps);
     }
 
-    function _setMarketBorrowCapsByUnderlying(address[] calldata underlyings, uint[] calldata newBorrowCaps) external {
-        _setMarketBorrowCaps(_underlyingToCTokens(underlyings), newBorrowCaps);
+    function _setMarketBorrowCapsByUnderlying(address[] calldata underlyings, uint[] calldata newBorrowCaps) external isGovernorOrGuardianOrAdmin {
+        _setMarketBorrowCapsInternal(_underlyingToCTokens(underlyings), newBorrowCaps);
     }
 
     /**

--- a/proposals/dao/fip_60.ts
+++ b/proposals/dao/fip_60.ts
@@ -123,7 +123,7 @@ export const deploy: DeployUpgradeFunc = async (deployAddress, addresses, loggin
   await fuseGuardian.deployed();
 
   logging && console.log('fuseGuardian: ', fuseGuardian.address);
-  
+
   return {
     tribalChiefSyncExtension,
     d3StakingTokenWrapper,
@@ -163,7 +163,7 @@ export const validate: ValidateUpgradeFunc = async (addresses, oldContracts, con
   const comptroller = contracts.rariPool8Comptroller;
 
   const d3Ctoken = await comptroller.cTokensByUnderlying(addresses.curveD3pool);
-    expect(d3Ctoken).to.not.be.equal(ethers.constants.AddressZero);
+  expect(d3Ctoken).to.not.be.equal(ethers.constants.AddressZero);
 
   const fei3CrvCtoken = await comptroller.cTokensByUnderlying(addresses.curve3Metapool);
   expect(fei3CrvCtoken).to.not.be.equal(ethers.constants.AddressZero);
@@ -174,23 +174,16 @@ export const validate: ValidateUpgradeFunc = async (addresses, oldContracts, con
   expect(await rariPool8Comptroller.supplyCaps(fei3CrvCtoken)).to.be.equal(
     ethers.constants.WeiPerEther.mul(25_000_000)
   ); // 25 M
-  expect(await rariPool8Comptroller.supplyCaps(gelatoCtoken)).to.be.equal(
-    ethers.constants.WeiPerEther.mul(2_500_000_000)
-  ); // 2.5 B
 
   // borrow paused
   expect(await rariPool8Comptroller.borrowGuardianPaused(d3Ctoken)).to.be.true;
   expect(await rariPool8Comptroller.borrowGuardianPaused(fei3CrvCtoken)).to.be.true;
-  expect(await rariPool8Comptroller.borrowGuardianPaused(gelatoCtoken)).to.be.true;
 
   // LTV
   expect((await rariPool8Comptroller.markets(d3Ctoken)).collateralFactorMantissa).to.be.equal(
     ethers.constants.WeiPerEther.mul(60).div(100)
   );
   expect((await rariPool8Comptroller.markets(fei3CrvCtoken)).collateralFactorMantissa).to.be.equal(
-    ethers.constants.WeiPerEther.mul(60).div(100)
-  );
-  expect((await rariPool8Comptroller.markets(gelatoCtoken)).collateralFactorMantissa).to.be.equal(
     ethers.constants.WeiPerEther.mul(60).div(100)
   );
 

--- a/proposals/description/fip_60.ts
+++ b/proposals/description/fip_60.ts
@@ -45,6 +45,51 @@ const fip_60: ProposalDescription = {
       description: 'Add FEI-DAI G-UNI to FeiRari'
     },
     {
+      target: 'rariPool8Comptroller',
+      values: '0',
+      method: '_setPauseGuardian(address)',
+      arguments: ['{fuseGuardian}'],
+      description: 'Set Fuse pause guardian'
+    },
+    {
+      target: 'fuseGuardian',
+      values: '0',
+      method: '_setBorrowPausedByUnderlying(address,bool)',
+      arguments: ['{curveD3pool}', true],
+      description: 'Set d3 borrow paused'
+    },
+    {
+      target: 'fuseGuardian',
+      values: '0',
+      method: '_setBorrowPausedByUnderlying(address,bool)',
+      arguments: ['{curve3Metapool}', true],
+      description: 'Set Fei-3Crv borrow paused'
+    },
+    {
+      target: 'fuseGuardian',
+      values: '0',
+      method: '_setBorrowPausedByUnderlying(address,bool)',
+      arguments: ['{gUniFeiDaiLP}', true],
+      description: 'Set Gelato borrow paused'
+    },
+    {
+      target: 'rariPool8Comptroller',
+      values: '0',
+      method: '_setBorrowCapGuardian(address)',
+      arguments: ['{fuseGuardian}'],
+      description: 'Set Fuse borrow cap guardian'
+    },
+    {
+      target: 'fuseGuardian',
+      values: '0',
+      method: '_setMarketSupplyCapsByUnderlying(address[],uint256[])',
+      arguments: [
+        ['{curveD3pool}', '{curve3Metapool}', '{gUniFeiDaiLP}'],
+        ['25000000000000000000000000', '25000000000000000000000000', '2500000000000000000000000000']
+      ],
+      description: 'Set Fuse supply caps'
+    },
+    {
       target: 'tribalChief',
       values: '0',
       method: 'add(uint120,address,address,(uint128,uint128)[])',


### PR DESCRIPTION
Creates a Fuse pause/borrow cap admin wrapper which gives access to Guardian and TribalChiefAdmins the ability to pause pools and set caps.

It also includes a utility for pausing/capping by underlying rather than the cToken. This is important because the cToken address cannot be pre-computed so this feature allows atomic deployment/pausing/capping.