### PR TITLE
FIP-78a: Metagovernance - ANGLE

### DIFF
--- a/contracts/metagov/AngleDelegatorPCVDeposit.sol
+++ b/contracts/metagov/AngleDelegatorPCVDeposit.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "./SnapshotDelegatorPCVDeposit.sol";
+import "./utils/VoteEscrowTokenManager.sol";
+import "./utils/LiquidityGaugeManager.sol";
+import "./utils/OZGovernorVoter.sol";
+
+/// @title ANGLE Token PCV Deposit
+/// @author Fei Protocol
+contract AngleDelegatorPCVDeposit is SnapshotDelegatorPCVDeposit, VoteEscrowTokenManager, LiquidityGaugeManager, OZGovernorVoter {
+
+    /// @notice ANGLE token manager
+    /// @param _core Fei Core for reference
+    /// @param _initialDelegate initial delegate for snapshot votes
+    constructor(
+        address _core,
+        address _initialDelegate
+    ) SnapshotDelegatorPCVDeposit(
+        _core,
+        IERC20(0x31429d1856aD1377A8A0079410B297e1a9e214c2), // ANGLE
+        keccak256("anglegovernance.eth"),
+        _initialDelegate
+    ) VoteEscrowTokenManager(
+        IERC20(0x31429d1856aD1377A8A0079410B297e1a9e214c2), // ANGLE
+        IVeToken(0x0C462Dbb9EC8cD1630f1728B2CFD2769d09f0dd5), // veANGLE
+        4 * 365 * 86400 // 4 years
+    ) LiquidityGaugeManager() OZGovernorVoter() {}
+
+    /// @notice returns total balance of PCV in the Deposit
+    function balance() public view override returns (uint256) {
+        return _totalTokens(); // liquid and vote-escrowed tokens
+    }
+}

--- a/contracts/metagov/utils/LiquidityGaugeManager.sol
+++ b/contracts/metagov/utils/LiquidityGaugeManager.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "../../refs/CoreRef.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILiquidityGauge {
+    function deposit(uint256 value) external;
+    function withdraw(uint256 value, bool claim_rewards) external;
+    function claim_rewards() external;
+    function balanceOf(address) external view returns(uint256);
+}
+interface ILiquidityGaugeController {
+    function vote_for_gauge_weights(address gauge_addr, uint256 user_weight) external;
+    function last_user_vote(address user, address gauge) external view returns(uint256);
+    function vote_user_power(address user) external view returns(uint256);
+}
+
+/// @title Liquidity gauge manager, used to stake tokens in liquidity gauges.
+/// @author Fei Protocol
+abstract contract LiquidityGaugeManager is CoreRef {
+
+    /// @notice Vote for a gauge's weight
+    /// @param gaugeController the address of a gauge controller contract
+    /// @param gaugeAddress the address of a gauge controlled by the gaugeController
+    /// @param gaugeWeight the weight of gaugeAddress in basis points [0, 10_000]
+    function voteForGaugeWeight(
+        address gaugeController,
+        address gaugeAddress,
+        uint256 gaugeWeight
+    ) public whenNotPaused onlyGovernorOrAdmin {
+        ILiquidityGaugeController(gaugeController).vote_for_gauge_weights(gaugeAddress, gaugeWeight);
+    }
+
+    /// @notice Stake tokens in a gauge
+    /// @param gaugeAddress the address of a gauge to stake tokens in
+    /// @param token the address of the token to stake in the gauge
+    /// @param amount the amount of tokens to stake in the gauge
+    function stakeInGauge(
+        address gaugeAddress,
+        address token,
+        uint256 amount
+    ) public whenNotPaused onlyPCVController {
+        IERC20(token).approve(gaugeAddress, amount);
+        ILiquidityGauge(gaugeAddress).deposit(amount);
+    }
+
+    /// @notice Stake all tokens held in a gauge
+    /// @param gaugeAddress the address of a gauge to stake tokens in
+    /// @param token the address of the token to stake in the gauge
+    function stakeAllInGauge(
+        address gaugeAddress,
+        address token
+    ) public whenNotPaused onlyPCVController {
+        uint256 amount = IERC20(token).balanceOf(address(this));
+        stakeInGauge(gaugeAddress, token, amount);
+    }
+
+    /// @notice Unstake tokens from a gauge
+    /// @param gaugeAddress the address of a gauge to unstake tokens from
+    /// @param token the address of the token to unstake from the gauge
+    /// @param amount the amount of tokens to unstake from the gauge
+    function unstakeFromGauge(
+        address gaugeAddress,
+        address token,
+        uint256 amount
+    ) public whenNotPaused onlyPCVController {
+        ILiquidityGauge(gaugeAddress).withdraw(amount, false);
+    }
+
+    /// @notice Claim rewards associated to a gauge where this contract stakes
+    /// tokens.
+    function claimGaugeRewards(address gaugeAddress) public whenNotPaused {
+        ILiquidityGauge(gaugeAddress).claim_rewards();
+    }
+}

--- a/contracts/metagov/utils/OZGovernorVoter.sol
+++ b/contracts/metagov/utils/OZGovernorVoter.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "../../refs/CoreRef.sol";
+
+interface IOZGovernor {
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) external;
+    function castVote(uint256 proposalId, uint8 support) external returns (uint256);
+}
+
+/// @title Abstract class to interact with an OZ governor.
+/// @author Fei Protocol
+abstract contract OZGovernorVoter is CoreRef {
+
+    /// @notice propose a new proposal on the target governor.
+    function propose(
+        IOZGovernor governor,
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) external onlyGovernorOrAdmin {
+        governor.propose(targets, values, calldatas, description);
+    }
+
+    /// @notice cast a vote on a given proposal on the target governor.
+    function castVote(
+        IOZGovernor governor,
+        uint256 proposalId,
+        uint8 support
+    ) external onlyGovernorOrAdmin {
+        governor.castVote(proposalId, support);
+    }
+}

--- a/contracts/metagov/utils/VoteEscrowTokenManager.sol
+++ b/contracts/metagov/utils/VoteEscrowTokenManager.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "../../refs/CoreRef.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IVeToken {
+    function balanceOf(address) external view returns (uint256);
+    function locked(address) external view returns (uint256);
+    function create_lock(uint256 value, uint256 unlock_time) external;
+    function increase_amount(uint256 value) external;
+    function increase_unlock_time(uint256 unlock_time) external;
+    function withdraw() external;
+}
+
+/// @title Vote-escrowed Token Manager
+/// Used to permanently lock tokens in a vote-escrow contract, and refresh
+/// the lock duration as needed.
+/// @author Fei Protocol
+abstract contract VoteEscrowTokenManager is CoreRef {
+
+    /// @notice The maximum lock duration of veTokens
+    uint256 private immutable MAXTIME;
+
+    /// @notice The vote-escrowed token address
+    IVeToken public immutable veToken;
+
+    /// @notice The token address
+    IERC20 public immutable liquidToken;
+
+    /// @notice VoteEscrowTokenManager token Snapshot Delegator PCV Deposit constructor
+    /// @param _liquidToken the token to lock for vote-escrow
+    /// @param _veToken the vote-escrowed token used in governance
+    /// @param _maxTime maximum time tokens can be vote-escrowed for
+    constructor(
+        IERC20 _liquidToken,
+        IVeToken _veToken,
+        uint256 _maxTime
+    ) {
+        liquidToken = _liquidToken;
+        veToken = _veToken;
+        MAXTIME = _maxTime;
+    }
+
+    /// @notice Deposit tokens to get veTokens. Set lock duration to MAXTIME.
+    /// @dev permissionless: anyone can lock tokens and extend the lock
+    /// duration at anytime. The only way to withdraw tokens will be to
+    /// pause this contract for MAXTIME and then call exitLock().
+    function lock() external whenNotPaused {
+        uint256 tokenBalance = liquidToken.balanceOf(address(this));
+        uint256 locked = veToken.locked(address(this));
+        uint256 lockHorizon = block.timestamp + MAXTIME;
+
+        // First lock
+        if (tokenBalance != 0 && locked == 0) {
+            liquidToken.approve(address(veToken), tokenBalance);
+            veToken.create_lock(tokenBalance, lockHorizon);
+        }
+        // Increase amount of tokens locked & refresh duration to MAXTIME
+        else if (tokenBalance != 0 && locked != 0) {
+            liquidToken.approve(address(veToken), tokenBalance);
+            veToken.increase_amount(tokenBalance);
+            veToken.increase_unlock_time(lockHorizon);
+        }
+        // No additional tokens to lock, just refresh duration to MAXTIME
+        else if (tokenBalance == 0 && locked != 0) {
+            veToken.increase_unlock_time(lockHorizon);
+        }
+        // If tokenBalance == 0 and locked == 0, there is nothing to do.
+    }
+
+    /// @notice Exit the veToken lock. For this function to be called and not
+    /// revert, tokens had to be locked previously, and the contract must have
+    /// been paused for MAXTIME in order to prevent permissionless lock extensions
+    /// by calling lock(). This function will recover tokens on the contract,
+    /// which can then be moved by calling withdraw() as a PCVController if the
+    /// contract is also a PCVDeposit, for instance.
+    function exitLock() external {
+        veToken.withdraw();
+    }
+
+    /// @notice returns total balance of tokens, vote-escrowed or liquid.
+    function _totalTokens() internal view returns (uint256) {
+        return liquidToken.balanceOf(address(this)) + veToken.locked(address(this));
+    }
+}

--- a/contracts/pcv/uniswap/UniswapPCVDeposit.sol
+++ b/contracts/pcv/uniswap/UniswapPCVDeposit.sol
@@ -9,7 +9,9 @@ import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
 import "@uniswap/lib/contracts/libraries/Babylonian.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-/// @title implementation for Uniswap LP PCV Deposit
+/// @title implementation for Uniswap LP PCV Deposit.
+/// Note: the FEI counterpart of tokens deposited have to be pre-minted on
+/// this contract before deposit(), if it doesn't have the MINTER_ROLE role.
 /// @author Fei Protocol
 contract UniswapPCVDeposit is IUniswapPCVDeposit, PCVDeposit, UniRef {
     using Decimal for Decimal.D256;
@@ -200,7 +202,9 @@ contract UniswapPCVDeposit is IUniswapPCVDeposit, PCVDeposit, UniRef {
     }
 
     function _addLiquidity(uint256 tokenAmount, uint256 feiAmount) internal virtual {
-        _mintFei(address(this), feiAmount);
+        if (core().isMinter(address(this))) {
+            _mintFei(address(this), feiAmount);
+        }
 
         uint256 endOfTime = type(uint256).max;
         // Deposit price gated by slippage parameter

--- a/proposals/dao/fip_78a.ts
+++ b/proposals/dao/fip_78a.ts
@@ -1,0 +1,183 @@
+import hre, { ethers, artifacts } from 'hardhat';
+import { expect } from 'chai';
+import {
+  DeployUpgradeFunc,
+  NamedAddresses,
+  SetupUpgradeFunc,
+  TeardownUpgradeFunc,
+  ValidateUpgradeFunc
+} from '@custom-types/types';
+import { getImpersonatedSigner, time } from '@test/helpers';
+import { forceEth } from '@test/integration/setup/utils';
+
+const fipNumber = '78a';
+const DELEGATE_ANGLE = '0x6ef71cA9cD708883E129559F5edBFb9d9D5C6148';
+
+// Do any deployments
+// This should exclusively include new contract deployments
+const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: NamedAddresses, logging: boolean) => {
+  const angleDelegatorFactory = await ethers.getContractFactory('AngleDelegatorPCVDeposit');
+  const angleDelegatorPCVDeposit = await angleDelegatorFactory.deploy(addresses.core, DELEGATE_ANGLE);
+  await angleDelegatorPCVDeposit.deployTransaction.wait();
+  logging && console.log('angleDelegatorPCVDeposit: ', angleDelegatorPCVDeposit.address);
+
+  // Create a new agEUR-FEI Uniswap PCVDeposit that does not stake on the old staking rewards contract
+  const uniswapPCVDepositFactory = await ethers.getContractFactory('UniswapPCVDeposit');
+  const agEurUniswapPCVDeposit = await uniswapPCVDepositFactory.deploy(
+    addresses.core,
+    addresses.angleAgEurFeiPool, // Uniswap-v2 agEUR/FEI pool
+    addresses.uniswapRouter, // UNiswap-v2 router
+    addresses.chainlinkEurUsdOracleWrapper,
+    ethers.constants.AddressZero,
+    '30' // max. 0.3% slippage
+  );
+  await agEurUniswapPCVDeposit.deployTransaction.wait();
+  logging && console.log('New agEUR/FEI Uniswap PCVDeposit:', agEurUniswapPCVDeposit.address);
+
+  return {
+    angleDelegatorPCVDeposit,
+    agEurUniswapPCVDeposit
+  };
+};
+
+// Do any setup necessary for running the test.
+// This could include setting up Hardhat to impersonate accounts,
+// ensuring contracts have a specific state, etc.
+const setup: SetupUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  // Whitelist our contract for vote-locking on Angle's governance
+  logging && console.log('Whitelist angleDelegatorPCVDeposit as a smartwallet on Angle governance...');
+  const ANGLE_MULTISIG_ADDRESS = '0xdC4e6DFe07EFCa50a197DF15D9200883eF4Eb1c8';
+  await forceEth(ANGLE_MULTISIG_ADDRESS);
+  const angleMultisigSigner = await getImpersonatedSigner(ANGLE_MULTISIG_ADDRESS);
+  const abi = ['function approveWallet(address _wallet)'];
+  const smartWalletCheckerInterface = new ethers.utils.Interface(abi);
+  const encodeWhitelistingCall = smartWalletCheckerInterface.encodeFunctionData('approveWallet', [
+    contracts.angleDelegatorPCVDeposit.address
+  ]);
+  await (
+    await angleMultisigSigner.sendTransaction({
+      data: encodeWhitelistingCall,
+      to: '0xAa241Ccd398feC742f463c534a610529dCC5888E' // SmartWalletChecker
+    })
+  ).wait();
+  logging && console.log('Whitelisted angleDelegatorPCVDeposit as a smartwallet on Angle governance.');
+};
+
+// Tears down any changes made in setup() that need to be
+// cleaned up before doing any validation checks.
+const teardown: TeardownUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  console.log(`No actions to complete in teardown for fip${fipNumber}`);
+};
+
+// Run any validations required on the fip using mocha or console logging
+// IE check balances, check state of contracts, etc.
+const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  const daoSigner = await getImpersonatedSigner(contracts.feiDAOTimelock.address);
+  await forceEth(contracts.feiDAOTimelock.address);
+
+  // Validate delegatee
+  expect(await contracts.angleDelegatorPCVDeposit.delegate()).to.be.equal(DELEGATE_ANGLE);
+
+  // Check that liquidity was correctly migrated to the gauge
+  expect(
+    await contracts.angleGaugeUniswapV2FeiAgEur.balanceOf(contracts.angleDelegatorPCVDeposit.address)
+  ).to.be.at.least(ethers.constants.WeiPerEther.mul(9337023)); // should have the same balance as currently
+
+  // Check that gauge vote is properly set to agEUR/FEI Uniswap-v2 pool
+  expect(await contracts.angleGaugeController.vote_user_power(contracts.angleDelegatorPCVDeposit.address)).to.be.equal(
+    '10000'
+  ); // 100% voting power engaged
+  expect(
+    await contracts.angleGaugeController.last_user_vote(
+      contracts.angleDelegatorPCVDeposit.address,
+      contracts.angleGaugeUniswapV2FeiAgEur.address
+    )
+  ).to.be.at.least(1); // timestamp of last vote > 0
+
+  // All ANGLE converted to veANGLE
+  expect(await contracts.angle.balanceOf(contracts.angleDelegatorPCVDeposit.address)).to.be.equal('0');
+  expect(await contracts.veAngle.balanceOf(contracts.angleDelegatorPCVDeposit.address)).to.be.at.least(
+    ethers.constants.WeiPerEther.mul(160000)
+  );
+
+  // Angle game
+  console.log(
+    'angleDelegatorPCVDeposit ANGLE balance',
+    (await contracts.angle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log(
+    'angleDelegatorPCVDeposit veANGLE balance',
+    (await contracts.veAngle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log('ff 1 year');
+  await time.increase(365 * 24 * 3600);
+  await time.advanceBlock();
+  console.log(
+    'angleDelegatorPCVDeposit ANGLE balance',
+    (await contracts.angle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log(
+    'angleDelegatorPCVDeposit veANGLE balance',
+    (await contracts.veAngle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log('claim gauge rewards');
+  await contracts.angleDelegatorPCVDeposit.claimGaugeRewards(
+    contracts.angleGaugeUniswapV2FeiAgEur.address // gauge address
+  );
+  console.log(
+    'angleDelegatorPCVDeposit ANGLE balance',
+    (await contracts.angle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log(
+    'angleDelegatorPCVDeposit veANGLE balance',
+    (await contracts.veAngle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log('prolong locking period');
+  await contracts.angleDelegatorPCVDeposit.lock();
+  console.log(
+    'angleDelegatorPCVDeposit ANGLE balance',
+    (await contracts.angle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log(
+    'angleDelegatorPCVDeposit veANGLE balance',
+    (await contracts.veAngle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log('ff 4 years');
+  await time.increase(4 * 365 * 24 * 3600);
+  await time.advanceBlock();
+  await time.advanceBlock();
+  await time.advanceBlock();
+  await time.advanceBlock();
+  console.log(
+    'angleDelegatorPCVDeposit ANGLE balance',
+    (await contracts.angle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log(
+    'angleDelegatorPCVDeposit veANGLE balance',
+    (await contracts.veAngle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  /*console.log('exitLock()');
+  await contracts.angleDelegatorPCVDeposit.exitLock();
+  console.log(
+    'angleDelegatorPCVDeposit ANGLE balance',
+    (await contracts.angle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log(
+    'angleDelegatorPCVDeposit veANGLE balance',
+    (await contracts.veAngle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );*/
+  console.log('lock()');
+  await contracts.angleDelegatorPCVDeposit.lock();
+  console.log(
+    'angleDelegatorPCVDeposit ANGLE balance',
+    (await contracts.angle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+  console.log(
+    'angleDelegatorPCVDeposit veANGLE balance',
+    (await contracts.veAngle.balanceOf(contracts.angleDelegatorPCVDeposit.address)) / 1e18
+  );
+
+  console.log('FIP-78a done');
+};
+
+export { deploy, setup, teardown, validate };

--- a/proposals/description/fip_78a.ts
+++ b/proposals/description/fip_78a.ts
@@ -1,0 +1,117 @@
+import { ProposalDescription } from '@custom-types/types';
+
+const fip_9001: ProposalDescription = {
+  title: 'FIP-9001: Metagov update [find a cool name]',
+  commands: [
+    {
+      target: 'core',
+      values: '0',
+      method: 'createRole(bytes32,bytes32)',
+      arguments: [
+        '0x5b5763ebd14d5a5d64e0b90c5e541f0e220ced6d249a6188d33227d6d799380b',
+        '0x899bd46557473cb80307a9dabc297131ced39608330a2d29b2d52b660c03923e'
+      ],
+      description: 'Create METAGOV_ADMIN_ROLE Role'
+    },
+    {
+      target: 'indexDelegator',
+      values: '0',
+      method: 'setContractAdminRole(bytes32)',
+      arguments: ['0x5b5763ebd14d5a5d64e0b90c5e541f0e220ced6d249a6188d33227d6d799380b'],
+      description: 'Set INDEX delegator Contract Admin Role to METAGOV_ADMIN_ROLE'
+    },
+    {
+      target: 'core',
+      values: '0',
+      method: 'grantRole(bytes32,address)',
+      arguments: ['0x5b5763ebd14d5a5d64e0b90c5e541f0e220ced6d249a6188d33227d6d799380b', '{opsOptimisticTimelock}'],
+      description: 'Grant METAGOV_ADMIN_ROLE Role to OPS OA Timelock'
+    },
+    {
+      target: 'ratioPCVControllerV2',
+      values: '0',
+      method: 'withdrawRatioERC20',
+      arguments: [
+        '{agEurAngleUniswapPCVDeposit}', // deposit
+        '{angle}', // token
+        '{angleDelegatorPCVDeposit}', // to
+        '10000' // basis poins
+      ],
+      description: 'Move all ANGLE tokens to the new Angle deposit'
+    },
+    {
+      target: 'ratioPCVControllerV2',
+      values: '0',
+      method: 'withdrawRatio(address,address,uint256)',
+      arguments: ['{agEurAngleUniswapPCVDeposit}', '{agEurUniswapPCVDeposit}', '10000'],
+      description: 'Move all agEUR from old to new deposit'
+    },
+    {
+      target: 'core',
+      values: '0',
+      method: 'revokeMinter(address)',
+      arguments: ['{agEurAngleUniswapPCVDeposit}'],
+      description: 'Revoke Minter from old Angle deposit'
+    },
+    {
+      target: 'fei',
+      values: '0',
+      method: 'mint(address,uint256)',
+      arguments: ['{agEurUniswapPCVDeposit}', '10050000000000000000000000'],
+      description: 'Mint 10.05M FEI on the new agEUR Uniswap deposit'
+    },
+    {
+      target: 'agEurUniswapPCVDeposit',
+      values: '0',
+      method: 'deposit()',
+      arguments: [],
+      description: 'Deposit agEUR/FEI to Uniswap v2'
+    },
+    {
+      target: 'ratioPCVControllerV2',
+      values: '0',
+      method: 'withdrawRatioERC20',
+      arguments: [
+        '{agEurUniswapPCVDeposit}', // deposit
+        '{angleAgEurFeiPool}', // token
+        '{angleDelegatorPCVDeposit}', // to
+        '10000' // basis poins
+      ],
+      description: 'Move all Uni-v2 LP tokens to the new Angle delegator deposit'
+    },
+    {
+      target: 'angleDelegatorPCVDeposit',
+      values: '0',
+      method: 'lock()',
+      arguments: [],
+      description: 'Vote-lock ANGLE to veANGLE'
+    },
+    {
+      target: 'angleDelegatorPCVDeposit',
+      values: '0',
+      method: 'voteForGaugeWeight(address,address,uint256)',
+      arguments: [
+        '{angleGaugeController}', // gauge controller
+        '{angleGaugeUniswapV2FeiAgEur}', // gauge address
+        '10000' // weight
+      ],
+      description: 'Vote 100% weight for the FEI/agEUR Uniswap-v2 pool gauge'
+    },
+    {
+      target: 'angleDelegatorPCVDeposit',
+      values: '0',
+      method: 'stakeAllInGauge(address,address)',
+      arguments: [
+        '{angleGaugeUniswapV2FeiAgEur}', // gauge
+        '{angleAgEurFeiPool}' // token
+      ],
+      description: 'Stake all Uni-v2 LP tokens in gauge'
+    }
+  ],
+  description: `
+
+TODO
+`
+};
+
+export default fip_9001;

--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -986,9 +986,19 @@ const MainnetAddresses: MainnetAddresses = {
     address: '0x5adDc89785D75C86aB939E9e15bfBBb7Fc086A87',
     category: AddressCategory.External
   },
-  angleStakingRewards: {
-    artifactName: 'IStakingRewards',
-    address: '0xBcb307F590972B1C3188b7916d2969Cf75309dc6',
+  angleGaugeController: {
+    artifactName: 'ILiquidityGaugeController',
+    address: '0x9aD7e7b0877582E14c17702EecF49018DD6f2367',
+    category: AddressCategory.External
+  },
+  angleGaugeUniswapV2FeiAgEur: {
+    artifactName: 'ILiquidityGauge',
+    address: '0xd6282C5aEAaD4d776B932451C44b8EB453E44244',
+    category: AddressCategory.External
+  },
+  veAngle: {
+    artifactName: 'IVeToken',
+    address: '0x0C462Dbb9EC8cD1630f1728B2CFD2769d09f0dd5',
     category: AddressCategory.External
   },
   aRai: {

--- a/test/integration/proposals_config.ts
+++ b/test/integration/proposals_config.ts
@@ -3,6 +3,7 @@ import { ProposalCategory, ProposalsConfigMap } from '@custom-types/types';
 // import fip_xx_proposal from '@proposals/description/fip_xx';
 
 import fip_77 from '@proposals/description/fip_77';
+import fip_78a from '@proposals/description/fip_78a';
 
 const proposals: ProposalsConfigMap = {
   /*
@@ -13,6 +14,15 @@ const proposals: ProposalsConfigMap = {
         proposal: fip_xx_proposal // full proposal file, imported from '@proposals/description/fip_xx.ts'
     }
     */
+  fip_78a: {
+    deploy: true,
+    proposalId: undefined,
+    affectedContractSignoff: [],
+    deprecatedContractSignoff: [],
+    category: ProposalCategory.DAO,
+    totalValue: 0,
+    proposal: fip_78a
+  },
   fip_77: {
     deploy: false,
     proposalId: undefined,

--- a/test/unit/pcv/uniswap/UniswapPCVDeposit.test.ts
+++ b/test/unit/pcv/uniswap/UniswapPCVDeposit.test.ts
@@ -63,14 +63,12 @@ describe('EthUniswapPCVDeposit', function () {
       '100'
     );
 
-    await this.core.connect(impersonatedSigners[governorAddress]).grantMinter(this.pcvDeposit.address, {});
-
     await this.pair
       .connect(impersonatedSigners[userAddress])
       .set(50000000, 100000, LIQUIDITY_INCREMENT, { value: 100000 }); // 500:1 FEI/ETH with 10k liquidity
 
     await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pair.address, 50000000, {});
-    1;
+
     await this.weth.mint(this.pair.address, 100000);
   });
 
@@ -122,11 +120,15 @@ describe('EthUniswapPCVDeposit', function () {
 
     describe('Post deposit values', function () {
       beforeEach(async function () {
+        // seed deposit with 100k ETH
         await impersonatedSigners[userAddress].sendTransaction({
           from: userAddress,
           to: this.pcvDeposit.address,
           value: 100000
         });
+        // pre-mint FEI for deposit (400 * 100k FEI)
+        await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pcvDeposit.address, 40000000, {});
+        // deposit
         await this.pcvDeposit.connect(impersonatedSigners[userAddress]).deposit({});
       });
 
@@ -153,11 +155,15 @@ describe('EthUniswapPCVDeposit', function () {
       });
       describe('With existing liquidity', function () {
         beforeEach(async function () {
+          // seed deposit with 100k ETH
           await impersonatedSigners[userAddress].sendTransaction({
             from: userAddress,
             to: this.pcvDeposit.address,
             value: 100000
           });
+          // pre-mint FEI for deposit (400 * 100k FEI)
+          await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pcvDeposit.address, 40000000, {});
+          // deposit
           await this.pcvDeposit.connect(impersonatedSigners[userAddress]).deposit({});
         });
 
@@ -200,11 +206,15 @@ describe('EthUniswapPCVDeposit', function () {
           beforeEach(async function () {
             await this.router.setAmountMin(39000000);
             await this.pcvDeposit.connect(impersonatedSigners[governorAddress]).setMaxBasisPointsFromPegLP(300, {});
+            // seed deposit with 100k ETH
             await impersonatedSigners[userAddress].sendTransaction({
               from: userAddress,
               to: this.pcvDeposit.address,
               value: 100000
             });
+            // pre-mint FEI for deposit (400 * 100k FEI)
+            await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pcvDeposit.address, 40000000, {});
+            // deposit
             await this.pcvDeposit.connect(impersonatedSigners[userAddress]).deposit({});
           });
 
@@ -233,11 +243,15 @@ describe('EthUniswapPCVDeposit', function () {
       describe('Pool price changes over threshold', function () {
         beforeEach(async function () {
           await this.router.setAmountMin(41000000);
+          // seed deposit with 100k ETH
           await impersonatedSigners[userAddress].sendTransaction({
             from: userAddress,
             to: this.pcvDeposit.address,
-            value: toBN(100000)
+            value: 100000
           });
+          // pre-mint FEI for deposit (400 * 100k FEI)
+          await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pcvDeposit.address, 40000000, {});
+          // deposit
           await this.pcvDeposit.connect(impersonatedSigners[userAddress]).deposit({});
         });
 
@@ -270,7 +284,9 @@ describe('EthUniswapPCVDeposit', function () {
             to: this.pcvDeposit.address,
             value: 100000
           });
-          await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pcvDeposit.address, '1000', {});
+          // pre-mint FEI for deposit (400 * 100k * 2 FEI) + 1000 extra
+          await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pcvDeposit.address, 80001000, {});
+          // deposit
           await this.pcvDeposit.connect(impersonatedSigners[userAddress]).deposit({});
         });
 
@@ -299,11 +315,15 @@ describe('EthUniswapPCVDeposit', function () {
         beforeEach(async function () {
           await this.oracle.setExchangeRate(600); // 600:1 oracle price
           // Then deposit
+          // seed deposit with 100k ETH
           await impersonatedSigners[userAddress].sendTransaction({
             from: userAddress,
             to: this.pcvDeposit.address,
             value: 100000
           });
+          // pre-mint FEI for deposit (600 * 100k FEI)
+          await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pcvDeposit.address, 60000000, {});
+          // deposit
           await this.pcvDeposit.connect(impersonatedSigners[userAddress]).deposit({});
         });
 
@@ -361,11 +381,15 @@ describe('EthUniswapPCVDeposit', function () {
     });
     describe('With Balance', function () {
       beforeEach(async function () {
+        // seed deposit with 100k ETH
         await impersonatedSigners[userAddress].sendTransaction({
           from: userAddress,
           to: this.pcvDeposit.address,
           value: 100000
         });
+        // pre-mint FEI for deposit (400 * 100k FEI)
+        await this.fei.connect(impersonatedSigners[minterAddress]).mint(this.pcvDeposit.address, 40000000, {});
+        // deposit
         await this.pcvDeposit.connect(impersonatedSigners[userAddress]).deposit({});
         this.beneficiaryBalance = await this.weth.balanceOf(beneficiaryAddress1);
       });


### PR DESCRIPTION
The purpose of this PR is to enable meta-governance with the protocol-owned governance tokens :
- ANGLE
- INDEX (already live)

# SnapshotDelegatorPCVDeposit
This contract existed already, I just moved it to a new `metagov` folder. The constructor also now include the setting of a contract admin role `_setContractAdminRole(keccak256("METAGOV_ADMIN_ROLE"));`, to enable OA to change delegates.

Used for `INDEX` (already deployed on-chain)

# AngleDelegatorPCVDeposit
This contract is a `SnapshotDelegatorPCVDeposit` that can also vote-escrow tokens (`VoteEscrowTokenManager`), vote and propose on an OZ governor (`OZGovernorVoter`), and stake tokens in gauges and claim their rewards (`LiquidityGaugeManager`).

Used for `ANGLE`.