### PR TITLE
1) Add VetoController and Role hierarchy

### DIFF
--- a/contracts/core/TribeRoles.sol
+++ b/contracts/core/TribeRoles.sol
@@ -26,7 +26,7 @@ library TribeRoles {
     /// @notice can mint FEI arbitrarily
     bytes32 internal constant MINTER = keccak256("MINTER_ROLE");
 
-    /// @notice Can grant any admin role
+    /// @notice Manages lower level - Admin and Mnor - roles. Able to grant and revoke these
     bytes32 internal constant ROLE_ADMIN = keccak256("ROLE_ADMIN");
 
     /*///////////////////////////////////////////////////////////////

--- a/contracts/core/TribeRoles.sol
+++ b/contracts/core/TribeRoles.sol
@@ -33,6 +33,9 @@ library TribeRoles {
                                  Admin Roles
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice capable of granting and revoking other TribeRoles from having veto power over a pod
+    bytes32 internal constant POD_VETO_ADMIN = keccak256("POD_VETO_ADMIN");
+
     /// @notice can manage the majority of Tribe protocol parameters. Sets boundaries for MINOR_PARAM_ROLE.
     bytes32 internal constant PARAMETER_ADMIN = keccak256("PARAMETER_ADMIN");
 

--- a/contracts/core/TribeRoles.sol
+++ b/contracts/core/TribeRoles.sol
@@ -26,7 +26,7 @@ library TribeRoles {
     /// @notice can mint FEI arbitrarily
     bytes32 internal constant MINTER = keccak256("MINTER_ROLE");
 
-    /// @notice Manages lower level - Admin and Mnor - roles. Able to grant and revoke these
+    /// @notice Manages lower level - Admin and Minor - roles. Able to grant and revoke these
     bytes32 internal constant ROLE_ADMIN = keccak256("ROLE_ADMIN");
 
     /*///////////////////////////////////////////////////////////////

--- a/contracts/pods/IPodFactory.sol
+++ b/contracts/pods/IPodFactory.sol
@@ -8,8 +8,9 @@ interface IPodFactory {
     /// @param label Metadata, Human readable label for the pod
     /// @param ensString Metadata, ENS name of the pod
     /// @param imageUrl Metadata, URL to a image to represent the pod in frontends
-    /// @param minDelay Delay on the timelock
     /// @param admin The admin of the pod - able to add and remove pod members
+    /// @param minDelay Delay on the timelock
+    /// @param vetoController A controller through which a pod can be vetoed
     struct PodConfig {
         address[] members;
         uint256 threshold;
@@ -17,6 +18,8 @@ interface IPodFactory {
         string ensString;
         string imageUrl;
         address admin;
+        uint256 minDelay;
+        address vetoController;
     }
 
     function getPodSafe(uint256 podId) external view returns (address);
@@ -34,15 +37,13 @@ interface IPodFactory {
 
     function getPodAdmin(uint256 podId) external view returns (address);
 
-    function createChildOptimisticPod(
-        PodConfig calldata _config,
-        uint256 minDelay
-    ) external returns (uint256, address);
+    function createChildOptimisticPod(PodConfig calldata _config)
+        external
+        returns (uint256, address);
 
     function updatePodController(address newPodController) external;
 
-    function burnerCreateChildOptimisticPods(
-        PodConfig[] calldata _config,
-        uint256[] calldata minDelay
-    ) external returns (uint256[] memory, address[] memory);
+    function burnerCreateChildOptimisticPods(PodConfig[] calldata _config)
+        external
+        returns (uint256[] memory, address[] memory);
 }

--- a/contracts/pods/IPodFactory.sol
+++ b/contracts/pods/IPodFactory.sol
@@ -24,6 +24,8 @@ interface IPodFactory {
 
     function getPodSafe(uint256 podId) external view returns (address);
 
+    function getPodTimelock(uint256 podId) external view returns (address);
+
     function getNumMembers(uint256 podId) external view returns (uint256);
 
     function getPodMembers(uint256 podId)

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -30,7 +30,7 @@ contract PodFactory is CoreRef, IPodFactory {
     address public immutable podExecutor;
 
     /// @notice Mapping between podId and it's optimistic timelock
-    mapping(uint256 => address) public getPodTimelock;
+    mapping(uint256 => address) public override getPodTimelock;
 
     /// @notice Mapping between timelock and podId
     mapping(address => uint256) public getPodId;
@@ -65,7 +65,6 @@ contract PodFactory is CoreRef, IPodFactory {
 
         podExecutor = _podExecutor;
         podController = IControllerV1(_podController);
-        // TODO: Checkout what happens when migrate controller. Probs need to update pointer here
         memberToken = IMemberToken(_memberToken);
     }
 

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -135,16 +135,13 @@ contract PodFactory is CoreRef, IPodFactory {
     //////////////////// STATE-CHANGING API ////////////////////
 
     /// @notice Create a child Orca pod with optimistic timelock. Callable by the DAO and the Tribal Council
-    function createChildOptimisticPod(
-        PodConfig calldata _config,
-        uint256 minDelay
-    )
+    function createChildOptimisticPod(PodConfig calldata _config)
         public
         override
         hasAnyOfTwoRoles(TribeRoles.GOVERNOR, TribeRoles.POD_DEPLOYER_ROLE)
         returns (uint256, address)
     {
-        return _createChildOptimisticPod(_config, minDelay);
+        return _createChildOptimisticPod(_config);
     }
 
     /// @notice Migrate to a new podController. Upgrades are opt in
@@ -161,10 +158,11 @@ contract PodFactory is CoreRef, IPodFactory {
     }
 
     /// @notice One time use at deploy time function to create childOptimisticTimelocks
-    function burnerCreateChildOptimisticPods(
-        PodConfig[] calldata _config,
-        uint256[] calldata _minDelay
-    ) external override returns (uint256[] memory, address[] memory) {
+    function burnerCreateChildOptimisticPods(PodConfig[] calldata _config)
+        external
+        override
+        returns (uint256[] memory, address[] memory)
+    {
         require(
             burnerDeploymentUsed == false,
             "Burner deployment already used"
@@ -176,8 +174,7 @@ contract PodFactory is CoreRef, IPodFactory {
         {
             for (uint256 i = 0; i < _config.length; i += 1) {
                 (uint256 podId, address timelock) = _createChildOptimisticPod(
-                    _config[i],
-                    _minDelay[i]
+                    _config[i]
                 );
                 podIds[i] = podId;
                 timelocks[i] = timelock;
@@ -191,11 +188,10 @@ contract PodFactory is CoreRef, IPodFactory {
 
     /// @notice Internal method to create a child optimistic pod
     /// @param _config Pod configuraton
-    /// @param _minDelay Delay on the timelock
-    function _createChildOptimisticPod(
-        PodConfig calldata _config,
-        uint256 _minDelay
-    ) internal returns (uint256, address) {
+    function _createChildOptimisticPod(PodConfig calldata _config)
+        internal
+        returns (uint256, address)
+    {
         uint256 podId = memberToken.getNextAvailablePodId();
 
         address safeAddress = createPod(
@@ -210,8 +206,9 @@ contract PodFactory is CoreRef, IPodFactory {
 
         address timelock = createOptimisticTimelock(
             safeAddress,
-            _minDelay,
-            podExecutor
+            _config.minDelay,
+            podExecutor,
+            _config.vetoController
         );
 
         // Set mapping from podId to timelock for reference
@@ -253,10 +250,12 @@ contract PodFactory is CoreRef, IPodFactory {
     function createOptimisticTimelock(
         address safeAddress,
         uint256 minDelay,
-        address publicExecutor
+        address publicExecutor,
+        address vetoController
     ) internal returns (address) {
-        address[] memory proposers = new address[](1);
+        address[] memory proposers = new address[](2);
         proposers[0] = safeAddress;
+        proposers[1] = vetoController;
 
         address[] memory executors = new address[](2);
         executors[0] = safeAddress;

--- a/contracts/pods/VetoController.sol
+++ b/contracts/pods/VetoController.sol
@@ -10,8 +10,7 @@ import {TribeRoles} from "../core/TribeRoles.sol";
 /// @title Pod Veto Controller
 /// @notice Exposes veto functionality over the timelock of pods to a configurable set of TribeRoles
 /// @dev This contract is intended to be set as a proposer on the timelock of a pod. This gives it the ability
-///      to cancel a proposal. The contract introduced to allow TribeRoles to be added and revoked from
-///      vetoing pods
+///      to cancel a proposal. TribeRoles are added which have the ability to veto proposals.
 contract VetoController is CoreRef {
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
@@ -53,13 +52,13 @@ contract VetoController is CoreRef {
     }
 
     /// @notice Grant veto permission over a particular pod to a TribeRole
-    /// @dev Permissioned to the GOVERNOR, ROLE_ADMIN and GUARDIAN. Used to allow particular TribeRoles
+    /// @dev Permissioned to the GOVERNOR, POD_VETO_ADMIN and GUARDIAN. Used to allow particular TribeRoles
     ///      to be granted veto ability over pods
     function grantVetoPermission(uint256 _podId, bytes32 role)
         public
         hasAnyOfThreeRoles(
             TribeRoles.GOVERNOR,
-            TribeRoles.ROLE_ADMIN,
+            TribeRoles.POD_VETO_ADMIN,
             TribeRoles.GUARDIAN
         )
     {
@@ -73,7 +72,7 @@ contract VetoController is CoreRef {
         public
         hasAnyOfThreeRoles(
             TribeRoles.GOVERNOR,
-            TribeRoles.ROLE_ADMIN,
+            TribeRoles.POD_VETO_ADMIN,
             TribeRoles.GUARDIAN
         )
     {

--- a/contracts/pods/VetoController.sol
+++ b/contracts/pods/VetoController.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {IPodFactory} from "./IPodFactory.sol";
+import {CoreRef} from "../refs/CoreRef.sol";
+import {TribeRoles} from "../core/TribeRoles.sol";
+
+/// @title Pod Veto Controller
+/// @notice Exposes veto functionality over the timelock of pods to addresses with a VETO_TRIBE_ROLE
+/// @dev This contract is intended to be set as a proposer on the timelock of a pod. This gives it the ability
+///      to cancel a proposal. Contract introduced to allow TribeRoles to be added and revoked from
+///      vetoing pods
+contract VetoController is CoreRef {
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    /// @notice PodFactory that was used to create pods
+    IPodFactory private podFactory;
+
+    constructor(address _core, address _podFactory) CoreRef(_core) {
+        podFactory = IPodFactory(_podFactory);
+    }
+
+    event VetoTimelock(uint256 indexed podId, address indexed timelock);
+    event GrantVetoPermission(
+        uint256 indexed podId,
+        address indexed timelock,
+        bytes32 tribeRole
+    );
+    event RevokeVetoPermission(
+        uint256 indexed podId,
+        address indexed timelock,
+        bytes32 tribeRole
+    );
+
+    /// @notice Mapping between a pod timelock and the TribeRoles that are allowed to veto transactions on it
+    mapping(address => EnumerableSet.Bytes32Set) private podVetoRoles;
+
+    /// @notice Get all the TribeRoles that have veto power over a pod
+    function getPodVetoRoles(uint256 _podId)
+        external
+        view
+        returns (bytes32[] memory)
+    {
+        address timelock = podFactory.getPodTimelock(_podId);
+
+        if (podVetoRoles[timelock].length() == 0) {
+            bytes32[] memory empty = new bytes32[](0);
+            return empty;
+        }
+        return podVetoRoles[timelock].values();
+    }
+
+    /// @notice Grant veto permission over a particular pod to a TribeRole
+    /// @dev Permissioned to the GOVERNOR, ROLE_ADMIN and GUARDIAN. Used to allow particular TribeRoles
+    ///      to be granted veto ability over pods
+    function grantVetoPermission(uint256 _podId, bytes32 role)
+        public
+        hasAnyOfThreeRoles(
+            TribeRoles.GOVERNOR,
+            TribeRoles.ROLE_ADMIN,
+            TribeRoles.GUARDIAN
+        )
+    {
+        address timelock = podFactory.getPodTimelock(_podId);
+        podVetoRoles[timelock].add(role);
+        emit GrantVetoPermission(_podId, timelock, role);
+    }
+
+    function revokeVetoPermission(uint256 _podId, bytes32 role)
+        public
+        hasAnyOfThreeRoles(
+            TribeRoles.GOVERNOR,
+            TribeRoles.ROLE_ADMIN,
+            TribeRoles.GUARDIAN
+        )
+    {
+        address timelock = podFactory.getPodTimelock(_podId);
+        podVetoRoles[timelock].remove(role);
+        emit RevokeVetoPermission(_podId, timelock, role);
+    }
+
+    /// @notice Batch grant veto permission
+    function batchGrantVetoPermission(
+        uint256[] memory _podIds,
+        bytes32[] memory roles
+    ) external {
+        for (uint256 i = 0; i < roles.length; i += 1) {
+            grantVetoPermission(_podIds[i], roles[i]);
+        }
+    }
+
+    /// @notice Batch revoke veto permission
+    function batchRevokeVetoPermission(
+        uint256[] memory _podIds,
+        bytes32[] memory roles
+    ) external {
+        for (uint256 i = 0; i < roles.length; i += 1) {
+            revokeVetoPermission(_podIds[i], roles[i]);
+        }
+    }
+
+    /// @notice Veto a proposal in a pod timelock
+    function veto(uint256 _podId, bytes32 proposalId) external {
+        address timelock = podFactory.getPodTimelock(_podId);
+        emit VetoTimelock(_podId, timelock);
+        TimelockController(payable(timelock)).cancel(proposalId);
+    }
+}

--- a/contracts/pods/VetoController.sol
+++ b/contracts/pods/VetoController.sol
@@ -8,9 +8,9 @@ import {CoreRef} from "../refs/CoreRef.sol";
 import {TribeRoles} from "../core/TribeRoles.sol";
 
 /// @title Pod Veto Controller
-/// @notice Exposes veto functionality over the timelock of pods to addresses with a VETO_TRIBE_ROLE
+/// @notice Exposes veto functionality over the timelock of pods to a configurable set of TribeRoles
 /// @dev This contract is intended to be set as a proposer on the timelock of a pod. This gives it the ability
-///      to cancel a proposal. Contract introduced to allow TribeRoles to be added and revoked from
+///      to cancel a proposal. The contract introduced to allow TribeRoles to be added and revoked from
 ///      vetoing pods
 contract VetoController is CoreRef {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -68,6 +68,7 @@ contract VetoController is CoreRef {
         emit GrantVetoPermission(_podId, timelock, role);
     }
 
+    /// @notice Revoke a particular TribeRole's veto permission over a pod
     function revokeVetoPermission(uint256 _podId, bytes32 role)
         public
         hasAnyOfThreeRoles(

--- a/contracts/pods/VetoController.sol
+++ b/contracts/pods/VetoController.sol
@@ -87,8 +87,14 @@ contract VetoController is CoreRef {
         uint256[] memory _podIds,
         bytes32[] memory roles
     ) external {
-        for (uint256 i = 0; i < roles.length; i += 1) {
+        require(_podIds.length == roles.length, "Mismatched input lengths");
+        for (uint256 i = 0; i < roles.length; ) {
             grantVetoPermission(_podIds[i], roles[i]);
+
+            // i is constrained by being < roles.length
+            unchecked {
+                i += 1;
+            }
         }
     }
 
@@ -97,8 +103,13 @@ contract VetoController is CoreRef {
         uint256[] memory _podIds,
         bytes32[] memory roles
     ) external {
-        for (uint256 i = 0; i < roles.length; i += 1) {
+        require(_podIds.length == roles.length, "Mismatched input lengths");
+        for (uint256 i = 0; i < roles.length; ) {
             revokeVetoPermission(_podIds[i], roles[i]);
+            // i is constrained by being < roles.length
+            unchecked {
+                i += 1;
+            }
         }
     }
 

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -71,9 +71,9 @@ function mintOrcaTokens(
     inviteToken.mint(to, amount);
 }
 
-function getPodParams(address admin)
+function getPodParams(address admin, address vetoController)
     pure
-    returns (IPodFactory.PodConfig memory, uint256)
+    returns (IPodFactory.PodConfig memory)
 {
     uint256 threshold = 2;
     bytes32 label = bytes32("hellopod");
@@ -92,7 +92,9 @@ function getPodParams(address admin)
         label: label,
         ensString: ensString,
         imageUrl: imageUrl,
-        admin: admin
+        admin: admin,
+        minDelay: minDelay,
+        vetoController: vetoController
     });
-    return (config, minDelay);
+    return config;
 }

--- a/contracts/test/integration/optimisticPods/PodFactory.t.sol
+++ b/contracts/test/integration/optimisticPods/PodFactory.t.sol
@@ -244,10 +244,19 @@ contract PodFactoryIntegrationTest is DSTest {
         configs[1] = podConfigB;
 
         vm.prank(feiDAOTimelock);
-        factory.burnerCreateChildOptimisticPods(configs);
+        (uint256[] memory podIds, ) = factory.burnerCreateChildOptimisticPods(
+            configs
+        );
         assertTrue(factory.burnerDeploymentUsed());
 
         vm.expectRevert(bytes("Burner deployment already used"));
         factory.burnerCreateChildOptimisticPods(configs);
+
+        // Check pod admin
+        address setPodAdminA = IControllerV1(podController).podAdmin(podIds[0]);
+        assertEq(setPodAdminA, podAdmin);
+
+        address setPodAdminB = IControllerV1(podController).podAdmin(podIds[0]);
+        assertEq(setPodAdminB, podAdmin);
     }
 }

--- a/contracts/test/integration/optimisticPods/VetoController.t.sol
+++ b/contracts/test/integration/optimisticPods/VetoController.t.sol
@@ -73,6 +73,54 @@ contract VetoControllerIntegrationTest is DSTest {
         assertEq(vetoTribeRoles[0], roleToGrant);
     }
 
+    function testBatchGrantVetoPermission() public {
+        bytes32[] memory rolesToGrant = new bytes32[](2);
+        rolesToGrant[0] = keccak256("TEST_ROLE_1");
+        rolesToGrant[1] = keccak256("TEST_ROLE_2");
+
+        uint256[] memory podIds = new uint256[](2);
+        podIds[0] = uint256(0);
+        podIds[1] = uint256(1);
+
+        vm.prank(feiDAOTimelock);
+        vetoController.batchGrantVetoPermission(podIds, rolesToGrant);
+
+        bytes32[] memory vetoTribeRoles1 = vetoController.getPodVetoRoles(
+            podIds[0]
+        );
+        assertEq(vetoTribeRoles1.length, 2);
+
+        bytes32[] memory vetoTribeRoles2 = vetoController.getPodVetoRoles(
+            podIds[1]
+        );
+        assertEq(vetoTribeRoles2.length, 2);
+    }
+
+    function testBatchRevokeVetoPermission() public {
+        bytes32[] memory rolesToGrant = new bytes32[](2);
+        rolesToGrant[0] = keccak256("TEST_ROLE_1");
+        rolesToGrant[1] = keccak256("TEST_ROLE_2");
+
+        uint256[] memory podIds = new uint256[](2);
+        podIds[0] = uint256(0);
+        podIds[1] = uint256(1);
+
+        vm.startPrank(feiDAOTimelock);
+        vetoController.batchGrantVetoPermission(podIds, rolesToGrant);
+        vetoController.batchRevokeVetoPermission(podIds, rolesToGrant);
+        vm.stopPrank();
+
+        bytes32[] memory vetoTribeRoles1 = vetoController.getPodVetoRoles(
+            podIds[0]
+        );
+        assertEq(vetoTribeRoles1.length, 0);
+
+        bytes32[] memory vetoTribeRoles2 = vetoController.getPodVetoRoles(
+            podIds[1]
+        );
+        assertEq(vetoTribeRoles2.length, 0);
+    }
+
     function testRevokeVetoPermission() public {
         bytes32 roleToGrant = keccak256("TEST_ROLE");
 

--- a/contracts/test/integration/optimisticPods/VetoController.t.sol
+++ b/contracts/test/integration/optimisticPods/VetoController.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import {DSTest} from "../../utils/DSTest.sol";
+import {Vm} from "../../utils/Vm.sol";
+import {VetoController} from "../../../pods/VetoController.sol";
+import {IPodFactory} from "../../../pods/IPodFactory.sol";
+import {PodFactory} from "../../../pods/PodFactory.sol";
+import {mintOrcaTokens, getPodParams} from "../fixtures/Orca.sol";
+
+contract VetoControllerTest is DSTest {
+    uint256 podId;
+    address timelock;
+    VetoController vetoController;
+    IPodFactory podFactory;
+
+    address private podAdmin = address(0x11);
+    address private core = 0x8d5ED43dCa8C2F7dFB20CF7b53CC7E593635d7b9;
+    address private feiDAOTimelock = 0xd51dbA7a94e1adEa403553A8235C302cEbF41a3c;
+    address private podController = 0xD89AAd5348A34E440E72f5F596De4fA7e291A3e8;
+    address private memberToken = 0x0762aA185b6ed2dCA77945Ebe92De705e0C37AE3;
+
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+
+    function setUp() public {
+        // 1. Deploy podFactory
+        address podExecutor = address(0x10);
+        podFactory = new PodFactory(
+            core,
+            podController,
+            memberToken,
+            podExecutor
+        );
+        mintOrcaTokens(address(podFactory), 2, vm);
+
+        // 2. Deploy VetoController
+        vetoController = new VetoController(core, address(podFactory));
+
+        // 3. Create a pod, which has the vetoController as a proposer
+        IPodFactory.PodConfig memory podConfig = getPodParams(
+            podAdmin,
+            address(vetoController)
+        );
+
+        vm.prank(feiDAOTimelock);
+        (podId, timelock) = podFactory.createChildOptimisticPod(podConfig);
+    }
+
+    function testInitialState() public {
+        bytes32[] memory vetoTribeRoles = vetoController.getPodVetoRoles(0);
+        assertEq(vetoTribeRoles.length, 0);
+    }
+
+    function testGrantVetoPermission() public {
+        bytes32 roleToGrant = keccak256("TEST_ROLE");
+
+        vm.prank(feiDAOTimelock);
+        vetoController.grantVetoPermission(podId, roleToGrant);
+
+        bytes32[] memory vetoTribeRoles = vetoController.getPodVetoRoles(podId);
+        assertEq(vetoTribeRoles.length, 1);
+        assertEq(vetoTribeRoles[0], roleToGrant);
+    }
+
+    function testRevokeVetoPermission() public {
+        bytes32 roleToGrant = keccak256("TEST_ROLE");
+
+        vm.prank(feiDAOTimelock);
+        vetoController.grantVetoPermission(podId, roleToGrant);
+
+        // Revoke granted role
+        vetoController.revokeVetoPermission(podId, roleToGrant);
+
+        bytes32[] memory vetoTribeRoles = vetoController.getPodVetoRoles(podId);
+        assertEq(vetoTribeRoles.length, 0);
+    }
+}

--- a/contracts/test/integration/optimisticPods/VetoController.t.sol
+++ b/contracts/test/integration/optimisticPods/VetoController.t.sol
@@ -4,11 +4,14 @@ pragma solidity ^0.8.0;
 import {DSTest} from "../../utils/DSTest.sol";
 import {Vm} from "../../utils/Vm.sol";
 import {VetoController} from "../../../pods/VetoController.sol";
+import {TribeRoles} from "../../../core/TribeRoles.sol";
+import {Core} from "../../../core/Core.sol";
 import {IPodFactory} from "../../../pods/IPodFactory.sol";
+import {ITimelock} from "../../../dao/timelock/ITimelock.sol";
 import {PodFactory} from "../../../pods/PodFactory.sol";
 import {mintOrcaTokens, getPodParams} from "../fixtures/Orca.sol";
 
-contract VetoControllerTest is DSTest {
+contract VetoControllerIntegrationTest is DSTest {
     uint256 podId;
     address timelock;
     VetoController vetoController;
@@ -49,6 +52,14 @@ contract VetoControllerTest is DSTest {
     function testInitialState() public {
         bytes32[] memory vetoTribeRoles = vetoController.getPodVetoRoles(0);
         assertEq(vetoTribeRoles.length, 0);
+
+        // Validate VetoController has proposer role, this will allow it to veto
+        ITimelock timelockContract = ITimelock(timelock);
+        bool hasProposerRole = timelockContract.hasRole(
+            keccak256("PROPOSER_ROLE"),
+            address(vetoController)
+        );
+        assertTrue(hasProposerRole);
     }
 
     function testGrantVetoPermission() public {
@@ -69,9 +80,42 @@ contract VetoControllerTest is DSTest {
         vetoController.grantVetoPermission(podId, roleToGrant);
 
         // Revoke granted role
+        vm.prank(feiDAOTimelock);
         vetoController.revokeVetoPermission(podId, roleToGrant);
 
         bytes32[] memory vetoTribeRoles = vetoController.getPodVetoRoles(podId);
         assertEq(vetoTribeRoles.length, 0);
+    }
+
+    /// @notice Validate that can cancel a transaction proposed on a pod timelock, to which an address
+    ///         has been granted veto power
+    function testCancel() public {
+        // 1. Create
+        bytes32 testRole = keccak256("TEST_ROLE");
+        address testAddress = address(0x12);
+
+        // 1. Create test role and grant to a testAddress
+        vm.startPrank(feiDAOTimelock);
+        Core(core).createRole(testRole, TribeRoles.GOVERNOR);
+        Core(core).grantRole(testRole, testAddress);
+        vm.stopPrank();
+
+        // 2. Grant test role veto power on this pod
+        vm.prank(feiDAOTimelock);
+        vetoController.grantVetoPermission(podId, testRole);
+
+        // 3. Validate that it can call veto
+        // Note: Check it reverts with "TimelockController: operation cannot be cancelled"
+        //       - if this codepath is reached, it has passed the permission check
+        bytes32 proposalId = bytes32("0x1");
+        vm.expectRevert(
+            bytes("TimelockController: operation cannot be cancelled")
+        );
+        vetoController.veto(podId, proposalId);
+    }
+
+    /// @notice Validate that an attempt to cancel a transaction on a different pod timelock fails
+    function testFailCancelFailsOnDifferentPod() public {
+        // TODO
     }
 }

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -202,12 +202,15 @@ const validateTribeRoles = async (
   const daoIsPodDeployer = await core.hasRole(ethers.utils.id('POD_DEPLOYER_ROLE'), feiDAOTimelockAddress);
   expect(daoIsPodDeployer).to.be.true;
 
-  // TribalCouncilTimelock roles: ROLE_ADMIN, POD_DEPLOYER_ROLE
+  // TribalCouncilTimelock roles: ROLE_ADMIN, POD_DEPLOYER_ROLE, POD_VETO_ROLE
   const councilIsRoleAdmin = await core.hasRole(ethers.utils.id('ROLE_ADMIN'), tribalCouncilTimelockAddress);
   expect(councilIsRoleAdmin).to.be.true;
 
   const councilIsPodDeployer = await core.hasRole(ethers.utils.id('POD_DEPLOYER_ROLE'), tribalCouncilTimelockAddress);
   expect(councilIsPodDeployer).to.be.true;
+
+  const councilIsPodVetoAdmin = await core.hasRole(ethers.utils.id('POD_VETO_ADMIN'), tribalCouncilTimelockAddress);
+  expect(councilIsPodVetoAdmin).to.be.true;
 
   // Protocol pod timelock roles: Specific first pod duties role
   const protocolPodIsVotiumRole = await core.hasRole(ethers.utils.id('VOTIUM_ADMIN_ROLE'), protocolPodTimelockAddress);

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -29,6 +29,16 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'createRole(bytes32,bytes32)',
       arguments: [
+        '0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', // POD_VETO_ADMIN
+        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
+      ],
+      description: 'Create POD_VETO_ADMIN role, with ROLE_ADMIN as the role admin'
+    },
+    {
+      target: 'core',
+      values: '0',
+      method: 'createRole(bytes32,bytes32)',
+      arguments: [
         '0x2d46c62aa6fbc9b550f22e00476aebb90f4ea69cd492a68db4d444217763330d', // VOTIUM_ADMIN_ROLE
         '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
       ],
@@ -43,6 +53,16 @@ const fip_82: ProposalDescription = {
       description: `
       Grant Tribal Council timelock the ROLE_ADMIN role. TribalCouncil will be able to manage Admin level roles
       and below
+      `
+    },
+    {
+      target: 'core',
+      values: '0',
+      method: 'grantRole(bytes32,address)',
+      arguments: ['0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', '{tribalCouncilTimelock}'],
+      description: `
+      Grant POD_VETO_ADMIN to TribalCouncil timelock. TribalCouncil will be able grant or revoke other TribeRoles
+      from having veto permissions over pods
       `
     },
     {

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -3,7 +3,7 @@ import { ProposalDescription } from '@custom-types/types';
 const fip_82: ProposalDescription = {
   title: 'FIP-82: Deploy TribalCouncil',
   commands: [
-    //////////// GRANT POD TIMELOCKS RELEVANT ACCESS ROLES ///////////
+    //////////// Create relevant TribeRoles and transfer admin of relevant roles to ROLE_ADMIN ///////////
     {
       target: 'core',
       values: '0',
@@ -29,40 +29,43 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'createRole(bytes32,bytes32)',
       arguments: [
-        '0xa8d944a5277d6a203f114d020d26918a390f167b089a46be4fca9da716d23783', // ORACLE_ADMIN
-        '0x899bd46557473cb80307a9dabc297131ced39608330a2d29b2d52b660c03923e' // GOVERN_ROLE
+        '0x2d46c62aa6fbc9b550f22e00476aebb90f4ea69cd492a68db4d444217763330d', // VOTIUM_ADMIN_ROLE
+        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
       ],
-      description: 'Create ORACLE_ADMIN role'
+      description: 'Transfer VOTIUM_ADMIN_ROLE admin from GOVERNOR to ROLE_ADMIN'
     },
+    //////////////// Grant relevant TribeRoles to relevant timelock contracts ///////////////
     {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
       arguments: ['0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096', '{tribalCouncilTimelock}'],
-      description: 'Grant Tribal Council ROLE_ADMIN'
+      description: `
+      Grant Tribal Council timelock the ROLE_ADMIN role. TribalCouncil will be able to manage Admin level roles
+      and below
+      `
     },
     {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
       arguments: ['0x1c4afb10045e2ffba702b04df46e551f6f2c584499b4abe7b6136efe6b05a34d', '{tribalCouncilTimelock}'],
-      description: 'Grant POD_DEPLOYER_ROLE to TribalCouncil timelock'
+      description: 'Grant POD_DEPLOYER_ROLE to TribalCouncil timelock. TribalCouncil will be able to deploy pods'
     },
     {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
-      arguments: ['0x1c4afb10045e2ffba702b04df46e551f6f2c584499b4abe7b6136efe6b05a34d', '{protocolPodTimelock}'],
-      description: 'Grant POD_DEPLOYER_ROLE to Protocol pod timelock'
+      arguments: ['0x1c4afb10045e2ffba702b04df46e551f6f2c584499b4abe7b6136efe6b05a34d', '{feiDAOTimelock}'],
+      description: 'Grant POD_DEPLOYER_ROLE to FeiDAO timelock. FeiDAO will be able to create and deploy pods'
     },
     {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
       arguments: ['0xa8d944a5277d6a203f114d020d26918a390f167b089a46be4fca9da716d23783', '{protocolPodTimelock}'],
-      description: 'Grant Protocol Pod ORACLE_ADMIN role'
+      description: 'Grant Protocol Pod VOTIUM_ADMIN_ROLE role. Protocol pod will be able to manage Votium bribes'
     },
-
     //////////////    Configure Membership of Council and Pod /////////////
     {
       target: 'memberToken',

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -17,10 +17,22 @@ const fip_82: ProposalDescription = {
     {
       target: 'core',
       values: '0',
+      method: 'grantRole(bytes32,address)',
+      arguments: [
+        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096', // GOVERN_ROLE
+        '{feiDAOTimelock}' // Fei DAI timelock
+      ],
+      description: `
+      Grant FEI DAO timelock ROLE_ADMIN, so it is able to manage roles and grant roles that are managed
+      by this role.`
+    },
+    {
+      target: 'core',
+      values: '0',
       method: 'createRole(bytes32,bytes32)',
       arguments: [
         '0x1c4afb10045e2ffba702b04df46e551f6f2c584499b4abe7b6136efe6b05a34d', // POD_DEPLOYER_ROLE
-        '0x899bd46557473cb80307a9dabc297131ced39608330a2d29b2d52b660c03923e' // GOVERN_ROLE
+        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
       ],
       description: 'Create POD_DEPLOYER_ROLE role'
     },
@@ -32,17 +44,9 @@ const fip_82: ProposalDescription = {
         '0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', // POD_VETO_ADMIN
         '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
       ],
-      description: 'Create POD_VETO_ADMIN role, with ROLE_ADMIN as the role admin'
-    },
-    {
-      target: 'core',
-      values: '0',
-      method: 'createRole(bytes32,bytes32)',
-      arguments: [
-        '0x2d46c62aa6fbc9b550f22e00476aebb90f4ea69cd492a68db4d444217763330d', // VOTIUM_ADMIN_ROLE
-        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
-      ],
-      description: 'Transfer VOTIUM_ADMIN_ROLE admin from GOVERNOR to ROLE_ADMIN'
+      description: `
+      Create POD_VETO_ADMIN role, using the GOVERNOR role. Later to be assigned ROLE_ADMIN as admin
+      `
     },
     //////////////// Grant relevant TribeRoles to relevant timelock contracts ///////////////
     {
@@ -59,6 +63,7 @@ const fip_82: ProposalDescription = {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
+      // Admin of POD_VETO_ADMIN role is ROLE_ADMIN. ROLE_ADMIN is granted to GOVERNOR
       arguments: ['0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', '{tribalCouncilTimelock}'],
       description: `
       Grant POD_VETO_ADMIN to TribalCouncil timelock. TribalCouncil will be able grant or revoke other TribeRoles
@@ -83,8 +88,18 @@ const fip_82: ProposalDescription = {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
-      arguments: ['0xa8d944a5277d6a203f114d020d26918a390f167b089a46be4fca9da716d23783', '{protocolPodTimelock}'],
+      arguments: ['0x2d46c62aa6fbc9b550f22e00476aebb90f4ea69cd492a68db4d444217763330d', '{protocolPodTimelock}'],
       description: 'Grant Protocol Pod VOTIUM_ADMIN_ROLE role. Protocol pod will be able to manage Votium bribes'
+    },
+    {
+      target: 'core',
+      values: '0',
+      method: 'createRole(bytes32,bytes32)',
+      arguments: [
+        '0x2d46c62aa6fbc9b550f22e00476aebb90f4ea69cd492a68db4d444217763330d', // VOTIUM_ADMIN_ROLE
+        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
+      ],
+      description: 'Transfer VOTIUM_ADMIN_ROLE admin from GOVERNOR to ROLE_ADMIN'
     },
     //////////////    Configure Membership of Council and Pod /////////////
     {

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -118,7 +118,7 @@ const fip_82: ProposalDescription = {
           '0x0000000000000000000000000000000000000014',
           '0x0000000000000000000000000000000000000015'
         ],
-        '13', // TODO: Replace hardcoded value with real podId
+        '17', // TODO: Replace hardcoded value with real podId
         '0x0000000000000000000000000000000000000000000000000000000000000000'
       ],
       description: 'Add designated members to the Tribal Council'
@@ -139,7 +139,7 @@ const fip_82: ProposalDescription = {
           '0x000000000000000000000000000000000000000B',
           '0x000000000000000000000000000000000000000C'
         ],
-        '13' // TODO: Replace hardcoded value with real podId
+        '17' // TODO: Replace hardcoded value with real podId
       ],
       description: 'Remove placeholder members from Tribal Council'
     },
@@ -155,7 +155,7 @@ const fip_82: ProposalDescription = {
           '0x000000000000000000000000000000000000000C',
           '0x000000000000000000000000000000000000000D'
         ],
-        '14', // TODO: Replace with real protocol pod ID
+        '18', // TODO: Replace with real protocol pod ID
         '0x0000000000000000000000000000000000000000000000000000000000000000'
       ],
       description: 'Add designated members to the Protocol Pod'
@@ -172,7 +172,7 @@ const fip_82: ProposalDescription = {
           '0x0000000000000000000000000000000000000007',
           '0x0000000000000000000000000000000000000008'
         ],
-        '14' // TODO: Replace with real protocol pod ID
+        '18' // TODO: Replace with real protocol pod ID
       ],
       description: 'Remove initial placeholder members from Protocol Pod'
     },
@@ -181,7 +181,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'updatePodAdmin(uint256,address)',
       arguments: [
-        '14', // TODO: Replace with real protocol pod ID
+        '18', // TODO: Replace with real protocol pod ID
         '{tribalCouncilTimelock}'
       ],
       description: `

--- a/protocol-configuration/optimisticGovernance.ts
+++ b/protocol-configuration/optimisticGovernance.ts
@@ -9,6 +9,17 @@ type PodConfig = {
   placeHolderMembers: string[];
 };
 
+export type PodCreationConfig = {
+  members: string[];
+  threshold: number;
+  label: string;
+  ensString: string;
+  imageUrl: string;
+  admin: string;
+  minDelay: number;
+  vetoController: string;
+};
+
 export const tribalCouncilMembers = [
   '0x000000000000000000000000000000000000000D', // TODO: Complete with real member addresses
   '0x000000000000000000000000000000000000000E',

--- a/protocol-configuration/permissions.ts
+++ b/protocol-configuration/permissions.ts
@@ -29,9 +29,12 @@ export const permissions = {
   BALANCER_MANAGER_ADMIN_ROLE: [],
   PSM_ADMIN_ROLE: [],
   TRIBAL_CHIEF_ADMIN_ROLE: ['optimisticTimelock', 'tribalChiefSyncV2'],
-  VOTIUM_ADMIN_ROLE: ['opsOptimisticTimelock'],
+  VOTIUM_ADMIN_ROLE: ['opsOptimisticTimelock', 'protocolPodTimelock'],
   PCV_GUARDIAN_ADMIN_ROLE: ['optimisticTimelock'],
   METAGOVERNANCE_VOTE_ADMIN: ['feiDAOTimelock', 'opsOptimisticTimelock'],
   METAGOVERNANCE_TOKEN_STAKING: ['feiDAOTimelock', 'opsOptimisticTimelock'],
-  METAGOVERNANCE_GAUGE_ADMIN: ['feiDAOTimelock', 'optimisticTimelock']
+  METAGOVERNANCE_GAUGE_ADMIN: ['feiDAOTimelock', 'optimisticTimelock'],
+  ROLE_ADMIN: ['feiDAOTimelock', 'tribalCouncilTimelock'],
+  POD_DEPLOYER_ROLE: ['feiDAOTimelock', 'tribalCouncilTimelock'],
+  POD_VETO_ADMIN: ['tribalCouncilTimelock']
 };


### PR DESCRIPTION
# Summary
This PR introduces two elements:
1. VetoController
2. Role hierarchy between the TribalCouncil and Pods

The VetoController is being introduced principally to allow the TribalCouncil to veto lower ranking pods.

## Description

### Role Hierarchy
Two new roles have been introduced:
- `ROLE_ADMIN`, who's purpose is to manage all roles within `TribeRoles` from `Admin` level down
- `POD_VETO_ADMIN`, who's purpose is to manage the granting and revoking of pod timelock permissions to other TribeRoles

The hierarchy of roles is:
- `GOVERNOR`
   - `ROLE_ADMIN`
        - `Admin Roles`
              - `Minor Roles`     

### VetoController
The `VetoController` allows TribeRoles to be given the ability to veto and cancel proposals that are in the timelock of specific pods. These veto powers can be granted by the `GOVERNOR`, `GUARDIAN` and a newly created role `POD_VETO_ADMIN`.

This contract itself is given the `Proposer` role on the pod timelocks, which in turn allows it to `cancel` and so veto proposals.


## Other
The PR also does some small refactoring, to absorb additional parameters onto the config of the relevant pod.
