### PR TITLE
[WIP] Add MythX

### DIFF
--- a/scripts/security/README.md
+++ b/scripts/security/README.md
@@ -1,0 +1,10 @@
+# Security
+This contains a series of automated security tools that can be easily run to increase confidence that smart contract code is secure. More tools will be added to this over time.
+
+It contains several scripts to act as wrappers around the relevant tool, and remove the need for manually handling Python environments, Docker containers etc.
+
+## MythX
+Example of how to run:
+`MYTHX_API_KEY=1234 ./scripts/security/runMythx.sh deep ./contracts/fei/Contract1.sol ./contracts/fei/Contract2.sol`
+
+This will pass the Fei MythX API key to the MythX script and run a deep MythX scan on `Contract1.sol` and `Contract2.sol`.

--- a/scripts/security/runMythx.sh
+++ b/scripts/security/runMythx.sh
@@ -19,6 +19,7 @@ setupMythX() {
     source venv/bin/activate
     pip3 install mythx-cli
     echo "Installed MythX CLI"
+    pip3 uninstall "markupsafe" && pip3 install "markupsafe"=="2.0.1"
 }
 
 runMythx() {
@@ -29,23 +30,27 @@ runMythx() {
     fi
 
     # Scan mode
-    if [ -z "$1" ]; then
+    SCAN_MODE=$1
+    if [ -z "$SCAN_MODE" ]; then
         echo "No scan mode specified. Exiting."
         exit 1
     fi
 
     # Contract file paths
-    echo "contract file paths"
-    echo $CONTRACT_FILE_PATHS
+    CONTRACT_FILE_PATHS=$2
+    if [ -z "$CONTRACT_FILE_PATHS" ]; then
+        echo "No contracts specified. Exiting."
+        exit 1
+    fi
 
-    
+    echo "Scan mode: $SCAN_MODE"
+    echo "Contracts for upload: $CONTRACT_FILE_PATHS"
 
-    echo "Uploading contracts to MythX"
+    echo "Uploading..."
     # Upload to Mythx API
-    api_response=mythx --api-key $MYTHX_API_KEY analyze --async \
-        --create-group --mode $SCAN_MODE --remap-import @uniswap=node_modules/@uniswap \
-        --remap-import @openzeppelin=node_modules/@openzeppelin  --remap-import @chainlink=node_modules/@chainlink \ 
-        --include $CONTRACT_FILE_PATHS
+    api_response=$(mythx --api-key $MYTHX_API_KEY analyze $CONTRACT_FILE_PATHS --async \
+        --group-name "fei" --mode $SCAN_MODE --remap-import @uniswap=node_modules/@uniswap \
+        --remap-import @openzeppelin=node_modules/@openzeppelin  --remap-import @chainlink=node_modules/@chainlink)
 
     echo "Uploaded, Mythx response: "
     echo $api_response
@@ -59,5 +64,5 @@ teardown() {
 }
 
 setupMythX 
-runMythx $1 
-# teardown
+runMythx $1 ${@:2}
+teardown

--- a/scripts/security/runMythx.sh
+++ b/scripts/security/runMythx.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
 ##### Upload user specified contracts to MythX for processing  ####
+
+# Example usage:
+# MYTHX_API_KEY=1234 ./scripts/security/runMythx.sh deep ./contracts/fei/contract1.sol ./contracts/fei/contract2.sol
+
 # First argument: scan mode 
 #    - available options are: quick, standard, deep
 # Remaining arguments are the paths to the contracts to be uploaded to MythX
+# Pass MYTHX_API_KEY as an environment variable
+
 
 set -eo pipefail
 
@@ -45,7 +51,7 @@ runMythx() {
     echo $api_response
 }
 
-removeMythX() {
+teardown() {
     echo "Tearing down environment"
     deactivate
     rm -rf venv
@@ -54,3 +60,4 @@ removeMythX() {
 
 setupMythX 
 runMythx $1 
+# teardown

--- a/scripts/security/runMythx.sh
+++ b/scripts/security/runMythx.sh
@@ -49,7 +49,7 @@ runMythx() {
     echo "Uploading..."
     # Upload to Mythx API
     api_response=$(mythx --api-key $MYTHX_API_KEY analyze $CONTRACT_FILE_PATHS --async \
-        --group-name "fei" --mode $SCAN_MODE --remap-import @uniswap=node_modules/@uniswap \
+        --create-group --group-name "test123" --mode $SCAN_MODE --solc-version 0.8.4 --remap-import @uniswap=node_modules/@uniswap \
         --remap-import @openzeppelin=node_modules/@openzeppelin  --remap-import @chainlink=node_modules/@chainlink)
 
     echo "Uploaded, Mythx response: "

--- a/scripts/security/runMythx.sh
+++ b/scripts/security/runMythx.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+##### Upload user specified contracts to MythX for processing  ####
+# First argument: scan mode 
+#    - available options are: quick, standard, deep
+# Remaining arguments are the paths to the contracts to be uploaded to MythX
+
+set -eo pipefail
+
+setupMythX() {
+    echo "Creating a virtual environment"
+    python3 -m venv venv
+    source venv/bin/activate
+    pip3 install mythx-cli
+    echo "Installed MythX CLI"
+}
+
+runMythx() {
+    # Confirm that an API key is available
+    if [ -z "$MYTHX_API_KEY" ]; then
+        echo "No MythX API Key found. Exiting."
+        exit 1
+    fi
+
+    # Scan mode
+    if [ -z "$1" ]; then
+        echo "No scan mode specified. Exiting."
+        exit 1
+    fi
+
+    # Contract file paths
+    echo "contract file paths"
+    echo $CONTRACT_FILE_PATHS
+
+    
+
+    echo "Uploading contracts to MythX"
+    # Upload to Mythx API
+    api_response=mythx --api-key $MYTHX_API_KEY analyze --async \
+        --create-group --mode $SCAN_MODE --remap-import @uniswap=node_modules/@uniswap \
+        --remap-import @openzeppelin=node_modules/@openzeppelin  --remap-import @chainlink=node_modules/@chainlink \ 
+        --include $CONTRACT_FILE_PATHS
+
+    echo "Uploaded, Mythx response: "
+    echo $api_response
+}
+
+removeMythX() {
+    echo "Tearing down environment"
+    deactivate
+    rm -rf venv
+    echo "Removed Python environment"
+}
+
+setupMythX 
+runMythx $1 


### PR DESCRIPTION
# Summary
Starts to incorporate automated security tools into our development processes. This PR adds a `runMythx.sh` script which makes it easy to use the Python based `MythX` CLI package to upload contracts to MythX for static analysis, symbolic analysis, fuzzing etc.

Example usage: `MYTHX_API_KEY=1234 ./scripts/security/runMythx.sh deep ./contracts/fei/contract1.sol ./contracts/fei/contract2.sol`


## Future development
I imagine that in the future, we will incorporate a variety of automated security tools including Slither
