### PR TITLE
Add e2e tests for Governance upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@balancer-labs/v2-pool-weighted": "^2.0.1",
         "@chainlink/contracts": "^0.1.7",
+        "@gnosis.pm/safe-core-sdk": "^0.2.0",
         "@nomiclabs/hardhat-waffle": "^2.0.3",
         "@openzeppelin/contracts": "^4.4.2",
         "@openzeppelin/test-environment": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@balancer-labs/v2-pool-weighted": "^2.0.1",
     "@chainlink/contracts": "^0.1.7",
+    "@gnosis.pm/safe-core-sdk": "^0.2.0",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
     "@openzeppelin/contracts": "^4.4.2",
     "@openzeppelin/test-environment": "^0.1.7",

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -271,10 +271,6 @@ const validateTribeRoles = async (
   const councilIsPodAdmin = await core.hasRole(ethers.utils.id('POD_ADMIN'), tribalCouncilTimelockAddress);
   expect(councilIsPodAdmin).to.be.true;
 
-  // Protocol pod timelock roles: Specific first pod duties role
-  const protocolPodIsVotiumRole = await core.hasRole(ethers.utils.id('VOTIUM_ADMIN_ROLE'), protocolPodTimelockAddress);
-  expect(protocolPodIsVotiumRole).to.be.true;
-
   // TribalCouncil Gnosis Safe roles: POD_METADATA_REGISTER_ROLE
   const councilHasMetadataRegisterRole = await core.hasRole(
     ethers.utils.id('POD_METADATA_REGISTER_ROLE'),

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -10,7 +10,7 @@ import {
 import { getImpersonatedSigner } from '@test/helpers';
 import { tribeCouncilPodConfig, protocolPodConfig, PodCreationConfig } from '@protocol/optimisticGovernance';
 import { abi as timelockABI } from '../../artifacts/contracts/dao/timelock/OptimisticTimelock.sol/OptimisticTimelock.json';
-import { abi as gnosisSafeABI } from '../../artifacts/contracts/pods/orcaInterfaces/IGnosisSafe.sol/IGnosisSafe.json';
+import { abi as gnosisSafeABI } from '../../artifacts/contracts/pods/interfaces/IGnosisSafe.sol/IGnosisSafe.json';
 import { Contract } from 'ethers';
 const toBN = ethers.BigNumber.from;
 

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -54,7 +54,7 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
   );
   await podFactory.deployTransaction.wait();
   await mintOrcaToken(podFactory.address);
-  logging && console.log('DAO pod factory deployed to:', podFactory.address);
+  logging && console.log('Pod factory deployed to:', podFactory.address);
 
   // 3. Deploy PodAdminGateway contract
   const podAdminGatewayFactory = await ethers.getContractFactory('PodAdminGateway');

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -173,7 +173,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchAddPodMember(uint256 _podId,address[] memory _members)',
       arguments: [
-        '19',
+        '23',
         [
           '0x000000000000000000000000000000000000000D', // TODO: Complete with real member addresses
           '0x000000000000000000000000000000000000000E',
@@ -193,7 +193,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchRemovePodMember(uint256 _podId, address[] memory)',
       arguments: [
-        '19', // TODO: Replace hardcoded value with real podId
+        '23', // TODO: Replace hardcoded value with real podId
         [
           '0x0000000000000000000000000000000000000004',
           '0x0000000000000000000000000000000000000005',
@@ -213,7 +213,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchAddPodMember(uint256 _podId,address[] memory _members)',
       arguments: [
-        '20', // TODO: Replace with real protocol pod ID
+        '24', // TODO: Replace with real protocol pod ID
         [
           '0x0000000000000000000000000000000000000009', // TODO: Complete with real member addresses
           '0x000000000000000000000000000000000000000A',
@@ -229,7 +229,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchRemovePodMember(uint256 _podId, address[] memory)',
       arguments: [
-        '20', // TODO: Replace with real protocol pod ID
+        '24', // TODO: Replace with real protocol pod ID
         [
           '0x0000000000000000000000000000000000000004',
           '0x0000000000000000000000000000000000000005',

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -120,13 +120,6 @@ const fip_82: ProposalDescription = {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
-      arguments: ['0x2d46c62aa6fbc9b550f22e00476aebb90f4ea69cd492a68db4d444217763330d', '{protocolPodTimelock}'],
-      description: 'Grant Protocol Pod VOTIUM_ADMIN_ROLE role. Protocol pod will be able to manage Votium bribes'
-    },
-    {
-      target: 'core',
-      values: '0',
-      method: 'grantRole(bytes32,address)',
       arguments: ['0xf62a46a499242191aaab61084d4912c2c0a8c48e3d70edfb5a9be2bc9e92622f', '{tribalCouncilSafe}'],
       description: 'Grant TribalCouncil Gnosis Safe address role to register metadata'
     },

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -166,7 +166,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchAddPodMember(uint256 _podId,address[] memory _members)',
       arguments: [
-        '23',
+        '24',
         [
           '0x000000000000000000000000000000000000000D', // TODO: Complete with real member addresses
           '0x000000000000000000000000000000000000000E',
@@ -186,7 +186,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchRemovePodMember(uint256 _podId, address[] memory)',
       arguments: [
-        '23', // TODO: Replace hardcoded value with real podId
+        '24', // TODO: Replace hardcoded value with real podId
         [
           '0x0000000000000000000000000000000000000004',
           '0x0000000000000000000000000000000000000005',
@@ -206,7 +206,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchAddPodMember(uint256 _podId,address[] memory _members)',
       arguments: [
-        '24', // TODO: Replace with real protocol pod ID
+        '25', // TODO: Replace with real protocol pod ID
         [
           '0x0000000000000000000000000000000000000009', // TODO: Complete with real member addresses
           '0x000000000000000000000000000000000000000A',
@@ -222,7 +222,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchRemovePodMember(uint256 _podId, address[] memory)',
       arguments: [
-        '24', // TODO: Replace with real protocol pod ID
+        '25', // TODO: Replace with real protocol pod ID
         [
           '0x0000000000000000000000000000000000000004',
           '0x0000000000000000000000000000000000000005',

--- a/protocol-configuration/optimisticGovernance.ts
+++ b/protocol-configuration/optimisticGovernance.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 
-type PodConfig = {
+export type PodConfig = {
   members: string[];
   threshold: number;
   label: string;

--- a/test/integration/tests/tribalCouncil.ts
+++ b/test/integration/tests/tribalCouncil.ts
@@ -136,10 +136,9 @@ describe.only('Tribal Council', function () {
   });
 
   it('should be able to toggle membership transfers', async () => {
-    // Waiting for membership transfer lock PR
-    // await podAdminGateway.connect(feiDAOTimelockSigner).lockMembershipTransfer(tribalCouncilPodId);
-    // const isLocked = await podAdminGateway.isMembershipTransferLocked(tribalCouncilPodId);
-    // expect(isLocked).to.be.true;
+    await podAdminGateway.connect(feiDAOTimelockSigner).unlockMembershipTransfers(tribalCouncilPodId);
+    const isLocked = await podFactory.getIsMembershipTransferLocked(tribalCouncilPodId);
+    expect(isLocked).to.be.false;
   });
 
   ///////////    TribalCouncil management of other pods  /////////////

--- a/test/integration/tests/tribalCouncil.ts
+++ b/test/integration/tests/tribalCouncil.ts
@@ -136,7 +136,6 @@ describe.only('Tribal Council', function () {
     await roleBastion.connect(tribalCouncilTimelockSigner).createRole(ethers.utils.id('DUMMY_ROLE'));
 
     // Validate that the role was created with the appropriate admin
-    
   });
 
   // it('can authorise another address with a role', async () => {


### PR DESCRIPTION
# Summary
Adds e2e tests for the governance upgrade. 

Also removes assigning the first child pod to be deployed the `VOTIUM_ROLE`. Instead, want to setup with just a vanilla pod which the TribalCouncil authorises once it is setup