### PR TITLE
Governance TODOs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,11 @@
+1. Do not use optimistic timelock - use the raw OZ timelock
+2. Combine/aggregate some of the pod specific roles
+3. Allow Orca pods to be created without a timelock
+4. If min delay is defined on an orca pod, enforce a limit
+5. Remove podAdminGateway migration concept from admin. Admin will be fixed (the migrated admin will lose timelock proposer/cancel access)
+6. Prefix all internal methods with `_`
+7. Remove burner function for pod creation. Just create inside constructor
+8. Find way to stop DAO proposal being bricked by podId changing underfoot
+9. DAO vote to migrate all roles
+
+No orca controller upgrade functionality

--- a/contracts/core/TribeRoles.sol
+++ b/contracts/core/TribeRoles.sol
@@ -86,11 +86,6 @@ library TribeRoles {
     /*///////////////////////////////////////////////////////////////
                                  Minor Roles
     //////////////////////////////////////////////////////////////*/
-
-    /// @notice capable of deploying optimistic governance pods
-    bytes32 internal constant POD_DEPLOYER_ROLE =
-        keccak256("POD_DEPLOYER_ROLE");
-
     bytes32 internal constant POD_METADATA_REGISTER_ROLE =
         keccak256("POD_METADATA_REGISTER_ROLE");
 

--- a/contracts/dao/timelock/OptimisticTimelock.sol
+++ b/contracts/dao/timelock/OptimisticTimelock.sol
@@ -26,7 +26,7 @@ contract OptimisticTimelock is TimelockController, CoreRef {
 
         In addition it allows for much more granular and flexible access for multisig operators
     */
-    // Guardian can become admin on every Optimistic timelock and effetively become 
+    // Guardian can become admin on every Optimistic timelock and effetively become
     function becomeAdmin() public onlyGuardianOrGovernor {
         this.grantRole(TIMELOCK_ADMIN_ROLE, msg.sender);
     }

--- a/contracts/dao/timelock/OptimisticTimelock.sol
+++ b/contracts/dao/timelock/OptimisticTimelock.sol
@@ -26,7 +26,6 @@ contract OptimisticTimelock is TimelockController, CoreRef {
 
         In addition it allows for much more granular and flexible access for multisig operators
     */
-    // Guardian can become admin on every Optimistic timelock and effetively become
     function becomeAdmin() public onlyGuardianOrGovernor {
         this.grantRole(TIMELOCK_ADMIN_ROLE, msg.sender);
     }

--- a/contracts/pods/PodAdminGateway.sol
+++ b/contracts/pods/PodAdminGateway.sol
@@ -26,13 +26,18 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
     /// @notice Pod controller for the pods
     ControllerV1 public immutable podController;
 
+    /// @notice Pod factory
+    IPodFactory public immutable podFactory;
+
     constructor(
         address _core,
         address _memberToken,
-        address _podController
+        address _podController,
+        address _podFactory
     ) CoreRef(_core) {
         memberToken = MemberToken(_memberToken);
         podController = ControllerV1(_podController);
+        podFactory = IPodFactory(_podFactory);
     }
 
     ////////////////////////   GETTERS   ////////////////////////////////
@@ -211,6 +216,10 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
             getSpecificPodAdminRole(_podId)
         )
     {
+        require(
+            _podTimelock == podFactory.getPodTimelock(_podId),
+            "PodId and timelock mismatch"
+        );
         emit VetoTimelock(_podId, _podTimelock, _proposalId);
         TimelockController(payable(_podTimelock)).cancel(_proposalId);
     }

--- a/contracts/pods/PodAdminGateway.sol
+++ b/contracts/pods/PodAdminGateway.sol
@@ -50,7 +50,7 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
         override
         returns (bytes32)
     {
-        return keccak256(abi.encode(_podId, "ORCA_POD", "ADMIN"));
+        return keccak256(abi.encode(_podId, "_ORCA_POD", "_ADMIN"));
     }
 
     /// @notice Calculate the specific pod guardian role identifier
@@ -61,7 +61,7 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
         override
         returns (bytes32)
     {
-        return keccak256(abi.encode(_podId, "ORCA_POD", "GUARDIAN"));
+        return keccak256(abi.encode(_podId, "_ORCA_POD", "_GUARDIAN"));
     }
 
     /////////////////////////    ADMIN PRIVILEDGES       ////////////////////////////

--- a/contracts/pods/PodAdminGateway.sol
+++ b/contracts/pods/PodAdminGateway.sol
@@ -64,20 +64,6 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
         return keccak256(abi.encode(_podId, "ORCA_POD", "POD_VETO_ROLE"));
     }
 
-    /// @notice Calculate the specific pod transfer admin role
-    // TODO: Remove this - not needed
-    function getPodTransferAdminRole(uint256 _podId)
-        public
-        pure
-        override
-        returns (bytes32)
-    {
-        return
-            keccak256(
-                abi.encode(_podId, "ORCA_POD", "POD_TRANSFER_ADMIN_ROLE")
-            );
-    }
-
     /// @notice Calculate the specific pod membership transfer lock role
     function getSetMembershipTransferLockRole(uint256 _podId)
         public
@@ -96,53 +82,6 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
     }
 
     /////////////////////////    ADMIN PRIVILEDGES       ////////////////////////////
-
-    /// @notice Transfer the pod admin address for a pod to another address
-    function transferPodAdmin(uint256 _podId, address newPodAdmin)
-        external
-        override
-        hasAnyOfThreeRoles(
-            TribeRoles.GOVERNOR,
-            TribeRoles.POD_ADMIN,
-            getPodTransferAdminRole(_podId)
-        )
-    {
-        _transferPodAdmin(_podId, newPodAdmin);
-    }
-
-    /// @notice Batch transfer the pod admin address for several pods
-    /// @dev Mass transfer of podAdmins only expected to be performed by GOVERNOR or POD_ADMIN
-    function batchTransferPodAdmins(
-        uint256[] calldata _podIds,
-        address[] calldata newPodAdmins
-    )
-        external
-        override
-        hasAnyOfTwoRoles(TribeRoles.GOVERNOR, TribeRoles.POD_ADMIN)
-    {
-        require(
-            _podIds.length == newPodAdmins.length,
-            "MISMATCHED_ARG_LENGTHS"
-        );
-        uint256 numPodsToTransfer = _podIds.length;
-        for (uint256 i = 0; i < numPodsToTransfer; ) {
-            _transferPodAdmin(_podIds[i], newPodAdmins[i]);
-
-            // i is bounded by numPodsToTransfer
-            unchecked {
-                i += 1;
-            }
-        }
-    }
-
-    /// @notice Transfer a pod admin from this gateway to another address
-    function _transferPodAdmin(uint256 _podId, address newPodAdmin) internal {
-        ControllerV1 podController = podFactory.podController();
-
-        address oldPodAdmin = address(this);
-        emit UpdatePodAdmin(_podId, oldPodAdmin, newPodAdmin);
-        podController.updatePodAdmin(_podId, newPodAdmin);
-    }
 
     /// @notice Admin functionality to add a member to a pod
     /// @dev Permissioned to GOVERNOR, POD_ADMIN and POD_ADD_MEMBER_ROLE

--- a/contracts/pods/PodAdminGateway.sol
+++ b/contracts/pods/PodAdminGateway.sol
@@ -200,11 +200,7 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
     /// @notice Allow a proposal to be vetoed in a pod timelock
     /// @dev Permissioned to GOVERNOR, POD_VETO_ADMIN, GUARDIAN, POD_ADMIN and the specific
     ///      pod admin and guardian roles
-    function veto(
-        uint256 _podId,
-        address _podTimelock,
-        bytes32 _proposalId
-    )
+    function veto(uint256 _podId, bytes32 _proposalId)
         external
         override
         hasAnyOfSixRoles(
@@ -216,10 +212,7 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
             getSpecificPodAdminRole(_podId)
         )
     {
-        require(
-            _podTimelock == podFactory.getPodTimelock(_podId),
-            "PodId and timelock mismatch"
-        );
+        address _podTimelock = podFactory.getPodTimelock(_podId);
         emit VetoTimelock(_podId, _podTimelock, _proposalId);
         TimelockController(payable(_podTimelock)).cancel(_proposalId);
     }

--- a/contracts/pods/PodAdminGateway.sol
+++ b/contracts/pods/PodAdminGateway.sol
@@ -30,8 +30,8 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
     // TODO: Whatever global set of roles are, map them one to one to the specific pod roles.
     // Pod specific roles:
     // ADMIN: If can add, should be able to remove and lock transfers. Should also be able to veto
-    // GUARDIAN: Can remove and veto 
-    // 
+    // GUARDIAN: Can remove and veto
+    //
 
     /// @notice Calculate the specific pod admin role related to adding pod members
     function getPodAddMemberRole(uint256 _podId)
@@ -289,7 +289,7 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
             TribeRoles.GOVERNOR,
             TribeRoles.POD_VETO_ADMIN,
             TribeRoles.GUARDIAN,
-            // TODO: Pod specific admin 
+            // TODO: Pod specific admin
             // TODO: Global pod admin
             getPodVetoRole(_podId)
         )

--- a/contracts/pods/PodAdminGateway.sol
+++ b/contracts/pods/PodAdminGateway.sol
@@ -26,28 +26,6 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
     /// @notice Pod controller for the pods
     ControllerV1 public immutable podController;
 
-    /// @notice Access control modifier to extend CoreRef ACL to check for 6 roles
-    modifier hasAnyOfSixRoles(
-        bytes32 role1,
-        bytes32 role2,
-        bytes32 role3,
-        bytes32 role4,
-        bytes32 role5,
-        bytes32 role6
-    ) {
-        ICore core = core();
-        require(
-            core.hasRole(role1, msg.sender) ||
-                core.hasRole(role2, msg.sender) ||
-                core.hasRole(role3, msg.sender) ||
-                core.hasRole(role4, msg.sender) ||
-                core.hasRole(role5, msg.sender) ||
-                core.hasRole(role6, msg.sender),
-            "UNAUTHORIZED"
-        );
-        _;
-    }
-
     constructor(
         address _core,
         address _memberToken,

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -38,8 +38,8 @@ contract PodFactory is CoreRef, IPodFactory {
     /// @notice Mapping between timelock and podId
     mapping(address => uint256) public getPodId;
 
-    /// @notice Latest pod created
-    uint256 public latestPodId;
+    /// @notice Number of pods created
+    uint256 private numPods;
 
     /// @notice Track whether the one time use initial pod deploy has been used
     bool public genesisDeployed;
@@ -66,6 +66,11 @@ contract PodFactory is CoreRef, IPodFactory {
     }
 
     ///////////////////// GETTERS ///////////////////////
+
+    /// @notice Get the number of pods this factory has created
+    function getNumberOfPods() override external view returns (uint256) {
+        return numPods;
+    }
 
     /// @notice Get the member token
     function getMemberToken() external view override returns (MemberToken) {
@@ -226,8 +231,8 @@ contract PodFactory is CoreRef, IPodFactory {
         // Set mapping from podId to timelock for reference
         getPodTimelock[podId] = timelock;
         getPodId[timelock] = podId;
-        latestPodId = podId;
-        emit CreatePod(podId, safeAddress);
+        numPods += 1;
+        emit CreatePod(podId, safeAddress, timelock);
         return (podId, timelock, safeAddress);
     }
 
@@ -279,6 +284,8 @@ contract PodFactory is CoreRef, IPodFactory {
             proposers,
             executors
         );
+        // TODO: Revoke timelock admin?
+        
         emit CreateTimelock(address(timelock));
         return address(timelock);
     }

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -139,6 +139,7 @@ contract PodFactory is CoreRef, IPodFactory {
         return podController.isTransferLocked(podId);
     }
 
+    /// @notice Deploy the genesis pod, one time use method
     function deployGenesisPod(PodConfig calldata _config)
         external
         override
@@ -148,9 +149,9 @@ contract PodFactory is CoreRef, IPodFactory {
             address
         )
     {
-        require(!genesisDeployed, "Genesis pod already been deployed");
+        require(!genesisDeployed, "Genesis pod already deployed");
         genesisDeployed = true;
-        return createChildOptimisticPod(_config);
+        return _createChildOptimisticPod(_config);
     }
 
     //////////////////// STATE-CHANGING API ////////////////////

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {ControllerV1} from "@orcaprotocol/contracts/contracts/ControllerV1.sol";
 import {MemberToken} from "@orcaprotocol/contracts/contracts/MemberToken.sol";
 import {IGnosisSafe} from "./interfaces//IGnosisSafe.sol";
 import {IPodFactory} from "./interfaces/IPodFactory.sol";
 
 import {TribeRoles} from "../core/TribeRoles.sol";
-import {OptimisticTimelock} from "../dao/timelock/OptimisticTimelock.sol";
 import {CoreRef} from "../refs/CoreRef.sol";
 import {ICore} from "../core/ICore.sol";
 import {IPodAdminGateway} from "./interfaces/IPodAdminGateway.sol";
 
 /// @dev This contract is primarily a factory contract which an admin
 /// can use to deploy more optimistic governance pods. It will create an
-/// Orca pod and deploy an optimistic timelock alongside it.
+/// Orca pod and deploy a timelock alongside it.
 ///
 /// The timelock and Orca pod are then linked up so that the Orca pod is
 /// the only proposer and executor.
@@ -28,7 +28,7 @@ contract PodFactory is CoreRef, IPodFactory {
     /// @notice Public contract that will be granted to execute all timelocks created
     address public immutable podExecutor;
 
-    /// @notice Mapping between podId and it's optimistic timelock
+    /// @notice Mapping between podId and it's timelock
     mapping(uint256 => address) public override getPodTimelock;
 
     /// @notice Mapping between timelock and podId
@@ -137,8 +137,8 @@ contract PodFactory is CoreRef, IPodFactory {
 
     //////////////////// STATE-CHANGING API ////////////////////
 
-    /// @notice Create a child Orca pod with optimistic timelock. Callable by the DAO and the Tribal Council
-    ///         Returns podId, optimistic pod timelock address and the Pod Gnosis Safe address
+    /// @notice Create a child Orca pod with timelock. Callable by the DAO and the Tribal Council
+    ///         Returns podId, pod timelock address and the Pod Gnosis Safe address
     ///         This will lock membership transfers by default
     function createChildOptimisticPod(PodConfig calldata _config)
         public
@@ -161,7 +161,6 @@ contract PodFactory is CoreRef, IPodFactory {
         IPodAdminGateway(_config.admin).lockMembershipTransfers(podId);
         return (podId, timelock, safe);
     }
-
 
     /// @notice One time use at deploy time function to create childOptimisticTimelocks
     function burnerCreateChildOptimisticPods(PodConfig[] calldata _config)
@@ -212,7 +211,7 @@ contract PodFactory is CoreRef, IPodFactory {
     {
         uint256 podId = memberToken.getNextAvailablePodId();
 
-        address safeAddress = createPod(
+        address safeAddress = _createPod(
             _config.members,
             _config.threshold,
             _config.label,
@@ -224,21 +223,23 @@ contract PodFactory is CoreRef, IPodFactory {
 
         address timelock;
         // TODO: Add option to avoid setting a timelock
-        if (minDelay != 0) {
+        if (_config.minDelay != 0) {
             // TODO: Enforce min delay if defined
-            require(minDelay >= 1 days) {
-                timelock = createOptimisticTimelock(
-                safeAddress,
-                _config.minDelay,
-                podExecutor,
-                _config.admin
+            require(_config.minDelay >= 1 days, "Min delay too small");
+            timelock = address(
+                _createTimelock(
+                    safeAddress,
+                    _config.minDelay,
+                    podExecutor,
+                    _config.admin
+                )
             );
             // Set mapping from podId to timelock for reference
             getPodTimelock[podId] = timelock;
             getPodId[timelock] = podId;
             latestPodId = podId;
-            }
-            
+        } else {
+            timelock = address(0);
         }
         emit CreatePod(podId, safeAddress);
         return (podId, timelock, safeAddress);
@@ -267,22 +268,22 @@ contract PodFactory is CoreRef, IPodFactory {
         return podController.podIdToSafe(podId);
     }
 
-    /// @notice Create an optimistic timelock, linking to an Orca pod
+    /// @notice Create a timelock, linking to an Orca pod
     /// @param safeAddress Address of the Gnosis Safe
     /// @param minDelay Delay on the timelock
     /// @param publicExecutor Non-permissioned smart contract that
     ///        allows any address to execute a ready transaction
-    /// @param vetoController Address which manages veto rights over a pod timelock
+    /// @param podAdmin Address which is the admin of the Orca pods
     ///        Will also be able to propose
     // TODO: Prefix with _
-    function createOptimisticTimelock(
+    function _createTimelock(
         address safeAddress,
         uint256 minDelay,
         address publicExecutor,
         address podAdmin
     ) internal returns (address) {
         // TODO: Validate minDelay
-        address[] memory proposers = new address[](2);  // cancel timelock
+        address[] memory proposers = new address[](2); // cancel timelock
         proposers[0] = safeAddress;
         // Note: If you migrate the podAdmin, then it will not have the timelock propsoer role. So it
         // will not be able to cancel the timelock.
@@ -293,17 +294,14 @@ contract PodFactory is CoreRef, IPodFactory {
         executors[0] = safeAddress;
         executors[1] = publicExecutor;
 
-        // TODODODODODO: Use TimelockController from OZ
-        OptimisticTimelock timelock = new TimelockController(
-            address(core()),
+        TimelockController timelock = new TimelockController(
             minDelay,
             proposers,
             executors
         );
-        emit CreateOptimisticTimelock(address(timelock));
+        emit CreateTimelock(address(timelock));
         return address(timelock);
     }
-
 
     // TODO: Way to make Orca pod without timelock
 }

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -39,7 +39,7 @@ contract PodFactory is CoreRef, IPodFactory {
     address[] private podSafeAddresses;
 
     /// @notice Track whether the one time use initial pod deploy has been used
-    bool public genesisDeployed;
+    bool public tribalCouncilDeployed;
 
     /// @notice Minimum delay of a pod timelock, if one is to be created with one
     uint256 public constant MIN_TIMELOCK_DELAY = 1 days;
@@ -164,8 +164,8 @@ contract PodFactory is CoreRef, IPodFactory {
             address
         )
     {
-        require(!genesisDeployed, "Genesis pod already deployed");
-        genesisDeployed = true;
+        require(!tribalCouncilDeployed, "Genesis pod already deployed");
+        tribalCouncilDeployed = true;
         return _createOptimisticPod(_config);
     }
 

--- a/contracts/pods/RoleBastion.sol
+++ b/contracts/pods/RoleBastion.sol
@@ -30,9 +30,5 @@ contract RoleBastion is CoreRef {
         require(roleAdmin == bytes32(0), "Role already exists");
         emit BastionRoleCreate(role, TribeRoles.ROLE_ADMIN);
         core().createRole(role, TribeRoles.ROLE_ADMIN);
-
-        // TODO: DAO vote to transfer all roles which have admins of GOVERNOR
-        // VOTIUM, admin GOVERNOR
-        //  transfer
     }
 }

--- a/contracts/pods/interfaces/IPodAdminGateway.sol
+++ b/contracts/pods/interfaces/IPodAdminGateway.sol
@@ -18,19 +18,12 @@ interface IPodAdminGateway {
         bytes32 proposalId
     );
 
-    function getPodAddMemberRole(uint256 _podId)
+    function getSpecificPodAdminRole(uint256 _podId)
         external
         pure
         returns (bytes32);
 
-    function getPodRemoveMemberRole(uint256 _podId)
-        external
-        pure
-        returns (bytes32);
-
-    function getPodVetoRole(uint256 _podId) external pure returns (bytes32);
-
-    function getSetMembershipTransferLockRole(uint256 _podId)
+    function getSpecificPodGuardianRole(uint256 _podId)
         external
         pure
         returns (bytes32);

--- a/contracts/pods/interfaces/IPodAdminGateway.sol
+++ b/contracts/pods/interfaces/IPodAdminGateway.sol
@@ -26,22 +26,10 @@ interface IPodAdminGateway {
 
     function getPodVetoRole(uint256 _podId) external pure returns (bytes32);
 
-    function getPodTransferAdminRole(uint256 _podId)
-        external
-        pure
-        returns (bytes32);
-
     function getSetMembershipTransferLockRole(uint256 _podId)
         external
         pure
         returns (bytes32);
-
-    function transferPodAdmin(uint256 _podId, address newPodAdmin) external;
-
-    function batchTransferPodAdmins(
-        uint256[] calldata _podIds,
-        address[] calldata newPodAdmins
-    ) external;
 
     function addPodMember(uint256 _podId, address _member) external;
 

--- a/contracts/pods/interfaces/IPodAdminGateway.sol
+++ b/contracts/pods/interfaces/IPodAdminGateway.sol
@@ -12,7 +12,11 @@ interface IPodAdminGateway {
     event PodMembershipTransferLock(uint256 indexed podId, bool lock);
 
     // Veto functionality
-    event VetoTimelock(uint256 indexed podId, address indexed timelock);
+    event VetoTimelock(
+        uint256 indexed podId,
+        address indexed timelock,
+        bytes32 proposalId
+    );
 
     function getPodAddMemberRole(uint256 _podId)
         external
@@ -45,5 +49,9 @@ interface IPodAdminGateway {
 
     function unlockMembershipTransfers(uint256 _podId) external;
 
-    function veto(uint256 _podId, bytes32 proposalId) external;
+    function veto(
+        uint256 _podId,
+        address _podTimelock,
+        bytes32 proposalId
+    ) external;
 }

--- a/contracts/pods/interfaces/IPodAdminGateway.sol
+++ b/contracts/pods/interfaces/IPodAdminGateway.sol
@@ -42,9 +42,5 @@ interface IPodAdminGateway {
 
     function unlockMembershipTransfers(uint256 _podId) external;
 
-    function veto(
-        uint256 _podId,
-        address _podTimelock,
-        bytes32 proposalId
-    ) external;
+    function veto(uint256 _podId, bytes32 proposalId) external;
 }

--- a/contracts/pods/interfaces/IPodFactory.sol
+++ b/contracts/pods/interfaces/IPodFactory.sol
@@ -32,7 +32,7 @@ interface IPodFactory {
         address indexed newController
     );
 
-    function deployGenesisPod(PodConfig calldata _config)
+    function deployCouncilPod(PodConfig calldata _config)
         external
         returns (
             uint256,
@@ -41,6 +41,8 @@ interface IPodFactory {
         );
 
     function getMemberToken() external view returns (MemberToken);
+
+    function getPodSafeAddresses() external view returns (address[] memory);
 
     function getNumberOfPods() external view returns (uint256);
 

--- a/contracts/pods/interfaces/IPodFactory.sol
+++ b/contracts/pods/interfaces/IPodFactory.sol
@@ -21,7 +21,11 @@ interface IPodFactory {
         uint256 minDelay;
     }
 
-    event CreatePod(uint256 indexed podId, address indexed safeAddress);
+    event CreatePod(
+        uint256 indexed podId,
+        address indexed safeAddress,
+        address indexed timelock
+    );
     event CreateTimelock(address indexed timelock);
     event UpdatePodController(
         address indexed oldController,
@@ -37,6 +41,8 @@ interface IPodFactory {
         );
 
     function getMemberToken() external view returns (MemberToken);
+
+    function getNumberOfPods() external view returns (uint256);
 
     function podController() external view returns (ControllerV1);
 

--- a/contracts/pods/interfaces/IPodFactory.sol
+++ b/contracts/pods/interfaces/IPodFactory.sol
@@ -18,6 +18,7 @@ interface IPodFactory {
         bytes32 label;
         string ensString;
         string imageUrl;
+        address admin;
         uint256 minDelay;
     }
 

--- a/contracts/pods/interfaces/IPodFactory.sol
+++ b/contracts/pods/interfaces/IPodFactory.sol
@@ -24,7 +24,7 @@ interface IPodFactory {
     }
 
     event CreatePod(uint256 indexed podId, address indexed safeAddress);
-    event CreateOptimisticTimelock(address indexed timelock);
+    event CreateTimelock(address indexed timelock);
     event UpdatePodController(
         address indexed oldController,
         address indexed newController
@@ -71,6 +71,4 @@ interface IPodFactory {
             address[] memory,
             address[] memory
         );
-
-    function updatePodController(address newPodController) external;
 }

--- a/contracts/pods/interfaces/IPodFactory.sol
+++ b/contracts/pods/interfaces/IPodFactory.sol
@@ -62,7 +62,7 @@ interface IPodFactory {
 
     function getPodAdmin(uint256 podId) external view returns (address);
 
-    function createChildOptimisticPod(PodConfig calldata _config)
+    function createOptimisticPod(PodConfig calldata _config)
         external
         returns (
             uint256,

--- a/contracts/pods/interfaces/IPodFactory.sol
+++ b/contracts/pods/interfaces/IPodFactory.sol
@@ -11,7 +11,6 @@ interface IPodFactory {
     /// @param label Metadata, Human readable label for the pod
     /// @param ensString Metadata, ENS name of the pod
     /// @param imageUrl Metadata, URL to a image to represent the pod in frontends
-    /// @param admin The admin of the pod - able to add and remove pod members. Expected to be set to a Gateway contract
     /// @param minDelay Delay on the timelock
     struct PodConfig {
         address[] members;
@@ -19,7 +18,6 @@ interface IPodFactory {
         bytes32 label;
         string ensString;
         string imageUrl;
-        address admin;
         uint256 minDelay;
     }
 
@@ -29,6 +27,14 @@ interface IPodFactory {
         address indexed oldController,
         address indexed newController
     );
+
+    function deployGenesisPod(PodConfig calldata _config)
+        external
+        returns (
+            uint256,
+            address,
+            address
+        );
 
     function getMemberToken() external view returns (MemberToken);
 
@@ -62,13 +68,5 @@ interface IPodFactory {
             uint256,
             address,
             address
-        );
-
-    function burnerCreateChildOptimisticPods(PodConfig[] calldata _config)
-        external
-        returns (
-            uint256[] memory,
-            address[] memory,
-            address[] memory
         );
 }

--- a/contracts/refs/CoreRef.sol
+++ b/contracts/refs/CoreRef.sol
@@ -148,6 +148,26 @@ abstract contract CoreRef is ICoreRef, Pausable {
         _;
     }
 
+    modifier hasAnyOfSixRoles(
+        bytes32 role1,
+        bytes32 role2,
+        bytes32 role3,
+        bytes32 role4,
+        bytes32 role5,
+        bytes32 role6
+    ) {
+        require(
+            _core.hasRole(role1, msg.sender) ||
+                _core.hasRole(role2, msg.sender) ||
+                _core.hasRole(role3, msg.sender) ||
+                _core.hasRole(role4, msg.sender) ||
+                _core.hasRole(role5, msg.sender) ||
+                _core.hasRole(role6, msg.sender),
+            "UNAUTHORIZED"
+        );
+        _;
+    }
+
     modifier onlyFei() {
         require(msg.sender == address(_fei), "CoreRef: Caller is not FEI");
         _;

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -75,16 +75,25 @@ function mintOrcaTokens(
 }
 
 function getPodParams() pure returns (IPodFactory.PodConfig memory) {
-    uint256 threshold = 1;
     bytes32 label = bytes32("hellopod");
+    return getBasePodParams(label);
+}
+
+function getGenesisPodParams() pure returns (IPodFactory.PodConfig memory) {
+    bytes32 label = bytes32("tribalcouncil");
+    return getBasePodParams(label);
+}
+
+function getBasePodParams(bytes32 label) pure returns (IPodFactory.PodConfig memory) {
+    uint256 threshold = 1;
     string memory ensString = "hellopod.eth";
     string memory imageUrl = "hellopod.com";
     uint256 minDelay = 2 days;
 
     address[] memory members = new address[](3);
     members[0] = address(0x201);
-    members[1] = address(0x201);
-    members[2] = address(0x202);
+    members[1] = address(0x202);
+    members[2] = address(0x203);
 
     IPodFactory.PodConfig memory config = IPodFactory.PodConfig({
         members: members,
@@ -133,7 +142,6 @@ function deployPodWithSystem(
         address(podAdminGateway)
     );
     mintOrcaTokens(address(factory), 2, vm);
-    factory.deployGenesisPod(podConfig);
 
     // Grant POD_ADMIN role to factory
     vm.startPrank(MainnetAddresses.FEI_DAO_TIMELOCK);

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {MemberToken} from "@orcaprotocol/contracts/contracts/MemberToken.sol";
 import {ControllerV1} from "@orcaprotocol/contracts/contracts/ControllerV1.sol";
 import {InviteToken} from "@orcaprotocol/contracts/contracts/InviteToken.sol";
 import {IPodFactory} from "../../../pods/interfaces/IPodFactory.sol";
-import {OptimisticTimelock} from "../../../dao/timelock/OptimisticTimelock.sol";
 import {PodFactory} from "../../../pods/PodFactory.sol";
 import {Vm} from "../../utils/Vm.sol";
 import {PodAdminGateway} from "../../../pods/PodAdminGateway.sol";
@@ -40,18 +40,17 @@ function createPod(
     return expectedPodId;
 }
 
-function setupOptimisticTimelock(
+function setupTimelock(
     address proposer,
     address executor,
     address core
-) returns (OptimisticTimelock) {
+) returns (TimelockController) {
     address[] memory proposers = new address[](1);
     proposers[0] = proposer;
 
     address[] memory executors = new address[](1);
     executors[0] = executor;
-    OptimisticTimelock timelock = new OptimisticTimelock(
-        core,
+    TimelockController timelock = new TimelockController(
         0,
         proposers,
         executors

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -82,7 +82,7 @@ function getPodParams(address admin)
     bytes32 label = bytes32("hellopod");
     string memory ensString = "hellopod.eth";
     string memory imageUrl = "hellopod.com";
-    uint256 minDelay = 0;
+    uint256 minDelay = 2 days;
 
     // Private key of one of the Safe owners. Used to generate signatures in tests
     uint256 ownerPrivateKey = uint256(
@@ -120,7 +120,8 @@ function deployPodWithSystem(
         address,
         address,
         address,
-        address
+        address,
+        IPodFactory.PodConfig memory
     )
 {
     // 1. Deploy PodFactory
@@ -158,6 +159,7 @@ function deployPodWithSystem(
         podTimelock,
         safe,
         address(factory),
-        address(podAdminGateway)
+        address(podAdminGateway),
+        podConfig
     );
 }

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -95,7 +95,7 @@ function getPodParamsWithNoTimelock()
 }
 
 /// @notice Genesis pod, the TribalCouncil, with a timelock
-function getGenesisPodParams() pure returns (IPodFactory.PodConfig memory) {
+function getCouncilPodParams() pure returns (IPodFactory.PodConfig memory) {
     bytes32 label = bytes32("tribalcouncil");
     uint256 minDelay = 2 days;
     return getBasePodParams(label, minDelay);

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -131,7 +131,7 @@ function deployPodWithSystem(
     address podController,
     address memberToken,
     address podExecutor,
-    address podDeployer, // must be GOVERNOR or have POD_DEPLOYER_ROLE
+    address podDeployer, // must be GOVERNOR or have POD_ADMIN role
     Vm vm
 )
     returns (

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -74,21 +74,40 @@ function mintOrcaTokens(
     inviteToken.mint(to, amount);
 }
 
-function getPodParams() pure returns (IPodFactory.PodConfig memory) {
+/// @notice Pod with a timelock
+function getPodParamsWithTimelock()
+    pure
+    returns (IPodFactory.PodConfig memory)
+{
     bytes32 label = bytes32("hellopod");
-    return getBasePodParams(label);
+    uint256 minDelay = 2 days;
+    return getBasePodParams(label, minDelay);
 }
 
+/// @notice Pod without a timelock, minDelay is set to 0
+function getPodParamsWithNoTimelock()
+    pure
+    returns (IPodFactory.PodConfig memory)
+{
+    bytes32 label = bytes32("hellopod");
+    uint256 minDelay = 0;
+    return getBasePodParams(label, minDelay);
+}
+
+/// @notice Genesis pod, the TribalCouncil, with a timelock
 function getGenesisPodParams() pure returns (IPodFactory.PodConfig memory) {
     bytes32 label = bytes32("tribalcouncil");
-    return getBasePodParams(label);
+    uint256 minDelay = 2 days;
+    return getBasePodParams(label, minDelay);
 }
 
-function getBasePodParams(bytes32 label) pure returns (IPodFactory.PodConfig memory) {
+function getBasePodParams(bytes32 label, uint256 minDelay)
+    pure
+    returns (IPodFactory.PodConfig memory)
+{
     uint256 threshold = 1;
     string memory ensString = "hellopod.eth";
     string memory imageUrl = "hellopod.com";
-    uint256 minDelay = 2 days;
 
     address[] memory members = new address[](3);
     members[0] = address(0x201);
@@ -124,7 +143,7 @@ function deployPodWithSystem(
         IPodFactory.PodConfig memory
     )
 {
-    IPodFactory.PodConfig memory podConfig = getPodParams();
+    IPodFactory.PodConfig memory podConfig = getPodParamsWithTimelock();
 
     // 1. Deploy PodAdminGateway
     PodAdminGateway podAdminGateway = new PodAdminGateway(
@@ -152,7 +171,7 @@ function deployPodWithSystem(
     vm.deal(address(factory), 1000 ether);
     vm.prank(podDeployer);
     (uint256 podId, address podTimelock, address safe) = factory
-        .createChildOptimisticPod(podConfig);
+        .createOptimisticPod(podConfig);
 
     return (
         podId,

--- a/contracts/test/integration/governance/NopeDAO.t.sol
+++ b/contracts/test/integration/governance/NopeDAO.t.sol
@@ -212,7 +212,7 @@ contract NopeDAOIntegrationTest is DSTest {
             timelockProposalId
         );
         calldatas[0] = data;
-        
+
         string memory description = "Veto proposal";
         bytes32 descriptionHash = keccak256(bytes(description));
 

--- a/contracts/test/integration/governance/NopeDAO.t.sol
+++ b/contracts/test/integration/governance/NopeDAO.t.sol
@@ -206,9 +206,8 @@ contract NopeDAOIntegrationTest is DSTest {
 
         bytes[] memory calldatas = new bytes[](1);
         bytes memory data = abi.encodeWithSignature(
-            "veto(uint256,address,bytes32)",
+            "veto(uint256,bytes32)",
             podId,
-            address(timelockContract),
             timelockProposalId
         );
         calldatas[0] = data;

--- a/contracts/test/integration/governance/NopeDAO.t.sol
+++ b/contracts/test/integration/governance/NopeDAO.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {ERC20VotesComp} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20VotesComp.sol";
 import {DSTest} from "../../utils/DSTest.sol";
 import {IPodFactory} from "../../../pods/interfaces/IPodFactory.sol";
@@ -11,7 +12,6 @@ import {Core} from "../../../core/Core.sol";
 import {PodFactory} from "../../../pods/PodFactory.sol";
 import {MainnetAddresses} from "../fixtures/MainnetAddresses.sol";
 import {deployPodWithSystem} from "../fixtures/Orca.sol";
-import {OptimisticTimelock} from "../../../dao/timelock/OptimisticTimelock.sol";
 import {PodAdminGateway} from "../../../pods/PodAdminGateway.sol";
 import {DummyStorage} from "../../utils/Fixtures.sol";
 
@@ -156,7 +156,7 @@ contract NopeDAOIntegrationTest is DSTest {
         DummyStorage dummyContract = new DummyStorage();
         assertEq(dummyContract.getVariable(), 5);
 
-        OptimisticTimelock timelockContract = OptimisticTimelock(
+        TimelockController timelockContract = TimelockController(
             payable(podTimelock)
         );
 

--- a/contracts/test/integration/governance/NopeDAO.t.sol
+++ b/contracts/test/integration/governance/NopeDAO.t.sol
@@ -53,13 +53,20 @@ contract NopeDAOIntegrationTest is DSTest {
         vm.stopPrank();
 
         // Create pod, using a podFactory
-        (podId, podTimelock, safe, factory, podAdmin, podConfig) = deployPodWithSystem(
+        (
+            podId,
+            podTimelock,
+            safe,
+            factory,
+            podAdmin,
+            podConfig
+        ) = deployPodWithSystem(
             MainnetAddresses.CORE,
             MainnetAddresses.POD_CONTROLLER,
             MainnetAddresses.MEMBER_TOKEN,
             podExecutor,
-            vm,
-            MainnetAddresses.FEI_DAO_TIMELOCK
+            MainnetAddresses.FEI_DAO_TIMELOCK,
+            vm
         );
     }
 
@@ -168,7 +175,6 @@ contract NopeDAOIntegrationTest is DSTest {
             bytes4(keccak256(bytes("setVariable(uint256)"))),
             newDummyContractVar
         );
-
 
         vm.prank(safe);
         timelockContract.schedule(

--- a/contracts/test/integration/governance/NopeDAO.t.sol
+++ b/contracts/test/integration/governance/NopeDAO.t.sol
@@ -205,13 +205,14 @@ contract NopeDAOIntegrationTest is DSTest {
         values[0] = uint256(0);
 
         bytes[] memory calldatas = new bytes[](1);
-        bytes memory data = abi.encodePacked(
-            bytes4(keccak256(bytes("veto(uint256,bytes32)"))),
+        bytes memory data = abi.encodeWithSignature(
+            "veto(uint256,address,bytes32)",
             podId,
+            address(timelockContract),
             timelockProposalId
         );
         calldatas[0] = data;
-
+        
         string memory description = "Veto proposal";
         bytes32 descriptionHash = keccak256(bytes(description));
 

--- a/contracts/test/integration/governance/OptimisticPodTest.t.sol
+++ b/contracts/test/integration/governance/OptimisticPodTest.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {MemberToken} from "@orcaprotocol/contracts/contracts/MemberToken.sol";
 import {ControllerV1} from "@orcaprotocol/contracts/contracts/ControllerV1.sol";
-import {OptimisticTimelock} from "../../../dao/timelock/OptimisticTimelock.sol";
 import {IGnosisSafe} from "../../../pods/interfaces/IGnosisSafe.sol";
 
-import {createPod, setupOptimisticTimelock, mintOrcaTokens} from "../fixtures/Orca.sol";
+import {createPod, setupTimelock, mintOrcaTokens} from "../fixtures/Orca.sol";
 import {MainnetAddresses} from "../fixtures/MainnetAddresses.sol";
 import {Vm} from "../../utils/Vm.sol";
 import {DSTest} from "../../utils/DSTest.sol";
@@ -63,9 +63,9 @@ contract OptimisticPodIntegrationTest is DSTest {
     }
 
     /// @notice Verify that the pod is set as the proposer and can propose on the timelock
-    function testLinkOptimisticTimelock() public {
+    function testLinkTimelockController() public {
         address safeAddress = controller.podIdToSafe(podId);
-        OptimisticTimelock timelock = setupOptimisticTimelock(
+        TimelockController timelock = setupTimelock(
             safeAddress,
             safeAddress,
             MainnetAddresses.CORE

--- a/contracts/test/integration/governance/PodAdminGateway.t.sol
+++ b/contracts/test/integration/governance/PodAdminGateway.t.sol
@@ -7,7 +7,7 @@ import {DSTest} from "../../utils/DSTest.sol";
 import {PodFactory} from "../../../pods/PodFactory.sol";
 import {PodAdminGateway} from "../../../pods/PodAdminGateway.sol";
 import {IPodAdminGateway} from "../../../pods/interfaces/IPodAdminGateway.sol";
-import {mintOrcaTokens, getPodParams} from "../fixtures/Orca.sol";
+import {mintOrcaTokens, getPodParamsWithTimelock} from "../fixtures/Orca.sol";
 import {IPodFactory} from "../../../pods/interfaces/IPodFactory.sol";
 import {ITimelock} from "../../../dao/timelock/ITimelock.sol";
 import {TribeRoles} from "../../../core/TribeRoles.sol";
@@ -44,7 +44,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
             podExecutor,
             address(podAdminGateway)
         );
-        
+
         // Grant the factory the relevant roles to disable membership locks
         vm.startPrank(feiDAOTimelock);
         Core(core).createRole(TribeRoles.POD_ADMIN, TribeRoles.GOVERNOR);
@@ -52,13 +52,13 @@ contract PodAdminGatewayIntegrationTest is DSTest {
         vm.stopPrank();
 
         // 3. Make config for pod, mint Orca tokens to factory
-        IPodFactory.PodConfig memory config = getPodParams();
+        IPodFactory.PodConfig memory config = getPodParamsWithTimelock();
         podConfig = config;
         mintOrcaTokens(address(factory), 2, vm);
 
         // 4. Create pod
         vm.prank(feiDAOTimelock);
-        (podId, timelock, safe) = factory.createChildOptimisticPod(podConfig);
+        (podId, timelock, safe) = factory.createOptimisticPod(podConfig);
     }
 
     /// @notice Validate that podAdminGateway contract pod admin, and initial state is valid

--- a/contracts/test/integration/governance/PodAdminGateway.t.sol
+++ b/contracts/test/integration/governance/PodAdminGateway.t.sol
@@ -190,7 +190,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
     /// @notice Validate that specific pod guardian role is computed is expected
     function testGetSpecificPodGuardianRole() public {
         bytes32 specificGuardianRole = keccak256(
-            abi.encode(podId, "ORCA_POD", "GUARDIAN")
+            abi.encode(podId, "_ORCA_POD", "_GUARDIAN")
         );
         assertEq(
             specificGuardianRole,
@@ -204,7 +204,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
 
         // Create role in core
         bytes32 specificAdminRole = keccak256(
-            abi.encode(podId, "ORCA_POD", "ADMIN")
+            abi.encode(podId, "_ORCA_POD", "_ADMIN")
         );
 
         vm.startPrank(feiDAOTimelock);

--- a/contracts/test/integration/governance/PodAdminGateway.t.sol
+++ b/contracts/test/integration/governance/PodAdminGateway.t.sol
@@ -280,7 +280,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
         vm.expectRevert(
             bytes("TimelockController: operation cannot be cancelled")
         );
-        podAdminGateway.veto(podId, timelock, bytes32("5"));
+        podAdminGateway.veto(podId, bytes32("5"));
     }
 
     /// @notice Validate that the specific pod amdin can veto
@@ -301,14 +301,6 @@ contract PodAdminGatewayIntegrationTest is DSTest {
         vm.expectRevert(
             bytes("TimelockController: operation cannot be cancelled")
         );
-        podAdminGateway.veto(podId, timelock, bytes32("5"));
-    }
-
-    /// @notice Validate that can not veto for a mismatched podId and timelock
-    function testCanNotVetoForMismatchPodIdTimelock() public {
-        address fakeTimelock = address(0x3);
-        vm.prank(feiDAOTimelock);
-        vm.expectRevert(bytes("PodId and timelock mismatch"));
-        podAdminGateway.veto(podId, fakeTimelock, bytes32("5"));
+        podAdminGateway.veto(podId, bytes32("5"));
     }
 }

--- a/contracts/test/integration/governance/PodAdminGateway.t.sol
+++ b/contracts/test/integration/governance/PodAdminGateway.t.sol
@@ -179,7 +179,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
     /// @notice Validate that specific pod admin role is computed is expected
     function testGetSpecificPodAdminRole() public {
         bytes32 specificAdminRole = keccak256(
-            abi.encode(podId, "ORCA_POD", "ADMIN")
+            abi.encode(podId, "_ORCA_POD", "_ADMIN")
         );
         assertEq(
             specificAdminRole,
@@ -229,7 +229,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
 
         // Create role in core
         bytes32 specificPodAdmin = keccak256(
-            abi.encode(podId, "ORCA_POD", "ADMIN")
+            abi.encode(podId, "_ORCA_POD", "_ADMIN")
         );
 
         vm.startPrank(feiDAOTimelock);
@@ -254,7 +254,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
 
         // Create role in core
         bytes32 specificPodGuardian = keccak256(
-            abi.encode(podId, "ORCA_POD", "GUARDIAN")
+            abi.encode(podId, "_ORCA_POD", "_GUARDIAN")
         );
 
         vm.startPrank(feiDAOTimelock);
@@ -289,7 +289,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
 
         // Create role in core
         bytes32 specificPodAdmin = keccak256(
-            abi.encode(podId, "ORCA_POD", "ADMIN")
+            abi.encode(podId, "_ORCA_POD", "_ADMIN")
         );
 
         vm.startPrank(feiDAOTimelock);

--- a/contracts/test/integration/governance/PodAdminGateway.t.sol
+++ b/contracts/test/integration/governance/PodAdminGateway.t.sol
@@ -44,9 +44,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
             podExecutor,
             address(podAdminGateway)
         );
-
-        factory.deployGenesisPod(podConfig);
-
+        
         // Grant the factory the relevant roles to disable membership locks
         vm.startPrank(feiDAOTimelock);
         Core(core).createRole(TribeRoles.POD_ADMIN, TribeRoles.GOVERNOR);

--- a/contracts/test/integration/governance/PodAdminGateway.t.sol
+++ b/contracts/test/integration/governance/PodAdminGateway.t.sol
@@ -187,17 +187,6 @@ contract PodAdminGatewayIntegrationTest is DSTest {
         assertEq(specificVetoRole, podAdminGateway.getPodVetoRole(podId));
     }
 
-    /// @notice Validate that specific admin transfer role is computed correctly
-    function testGetTransferAdminRole() public {
-        bytes32 specificTransferAdminRole = keccak256(
-            abi.encode(podId, "ORCA_POD", "POD_TRANSFER_ADMIN_ROLE")
-        );
-        assertEq(
-            specificTransferAdminRole,
-            podAdminGateway.getPodTransferAdminRole(podId)
-        );
-    }
-
     /// @notice Validate that specific set membership transfer lock role is set
     function testGetSetMembershipLockRole() public {
         bytes32 specificMembershipLockRole = keccak256(
@@ -298,21 +287,5 @@ contract PodAdminGatewayIntegrationTest is DSTest {
             bytes("TimelockController: operation cannot be cancelled")
         );
         podAdminGateway.veto(podId, bytes32("5"));
-    }
-
-    /// @notice Validate that the pod admin contract can be transferred to another admin
-    function testTransferPodAdmin() public {
-        address newAdmin = address(0x11);
-
-        vm.prank(feiDAOTimelock);
-        podAdminGateway.transferPodAdmin(podId, newAdmin);
-
-        // Validate admin set on pod contract was updated everywhere as expected
-        address orcaControllerReportedAdmin = ControllerV1(podController)
-            .podAdmin(podId);
-        assertEq(orcaControllerReportedAdmin, newAdmin);
-
-        address podFactoryReportedAdmin = factory.getPodAdmin(podId);
-        assertEq(podFactoryReportedAdmin, newAdmin);
     }
 }

--- a/contracts/test/integration/governance/PodFactory.t.sol
+++ b/contracts/test/integration/governance/PodFactory.t.sol
@@ -138,20 +138,17 @@ contract PodFactoryIntegrationTest is DSTest {
     function testPodAdminCanDeploy() public {
         address dummyTribalCouncil = address(0x1);
 
-        // Create ROLE_ADMIN, POD_DEPLOYER role and grant ROLE_ADMIN to a dummyTribalCouncil address
+        // Create ROLE_ADMIN, POD_ADMIN role and grant ROLE_ADMIN to a dummyTribalCouncil address
         vm.startPrank(feiDAOTimelock);
         Core(core).createRole(TribeRoles.ROLE_ADMIN, TribeRoles.GOVERNOR);
-        Core(core).createRole(
-            TribeRoles.POD_ADMIN,
-            TribeRoles.ROLE_ADMIN
-        );
+        Core(core).createRole(TribeRoles.POD_ADMIN, TribeRoles.ROLE_ADMIN);
         Core(core).grantRole(TribeRoles.ROLE_ADMIN, dummyTribalCouncil);
         vm.stopPrank();
 
         // Grant POD_ADMIN to a dummy address
         address dummyPodAdmin = address(0x2);
         vm.prank(dummyTribalCouncil);
-        Core(core).grantRole(TribeRoles.POD_DEPLOYER_ROLE, dummyPodAdmin);
+        Core(core).grantRole(TribeRoles.POD_ADMIN, dummyPodAdmin);
 
         IPodFactory.PodConfig memory podConfig = getPodParamsWithTimelock();
         vm.prank(dummyPodAdmin);

--- a/contracts/test/integration/governance/PodFactory.t.sol
+++ b/contracts/test/integration/governance/PodFactory.t.sol
@@ -282,7 +282,6 @@ contract PodFactoryIntegrationTest is DSTest {
             newDummyContractVar
         );
 
-        uint256 timelockDelay = 500;
         vm.prank(safe);
         timelockContract.schedule(
             address(dummyContract),
@@ -290,7 +289,7 @@ contract PodFactoryIntegrationTest is DSTest {
             timelockExecutionTxData,
             bytes32(0),
             bytes32("1"),
-            timelockDelay
+            podConfig.minDelay
         );
 
         // 4. Validate that transaction is in timelock
@@ -304,8 +303,8 @@ contract PodFactoryIntegrationTest is DSTest {
         assertTrue(timelockContract.isOperationPending(txHash));
 
         // 5. Fast forward to execution time in timelock
-        vm.warp(timelockDelay + 10);
-        vm.roll(timelockDelay + 10);
+        vm.warp(podConfig.minDelay + 10);
+        vm.roll(podConfig.minDelay + 10);
 
         // 6. Execute transaction and validate state is updated
         podExecutor.execute(

--- a/contracts/test/integration/governance/PodFactory.t.sol
+++ b/contracts/test/integration/governance/PodFactory.t.sol
@@ -99,7 +99,7 @@ contract PodFactoryIntegrationTest is DSTest {
         assertEq(storedMembers[1], genesisConfig.members[1]);
         assertEq(storedMembers[2], genesisConfig.members[2]);
 
-        assertEq(factory.getNumberOfPods(), 0);
+        assertEq(factory.getNumberOfPods(), 1);
     }
 
     function testCanOnlyDeployGenesisOnce() public {
@@ -217,6 +217,14 @@ contract PodFactoryIntegrationTest is DSTest {
         // Min delay of timelock
         assertEq(timelockContract.getMinDelay(), podConfig.minDelay);
 
+        // Validate factory does not have TIMELOCK_ADMIN_ROLE
+        assertFalse(
+            timelockContract.hasRole(
+                timelockContract.TIMELOCK_ADMIN_ROLE(),
+                address(factory)
+            )
+        );
+
         //// Validate that membership transfers are disabled
         bool membershipLocked = factory.getIsMembershipTransferLocked(podId);
         assertEq(membershipLocked, true);
@@ -270,7 +278,7 @@ contract PodFactoryIntegrationTest is DSTest {
 
         vm.prank(feiDAOTimelock);
         (uint256 podAId, , ) = factory.createOptimisticPod(podConfig);
-        assertEq(factory.getNumberOfPods(), 0);
+        assertEq(factory.getNumberOfPods(), 1);
 
         address podAAdmin = ControllerV1(podController).podAdmin(podAId);
         assertEq(podAAdmin, podAdmin);
@@ -278,7 +286,7 @@ contract PodFactoryIntegrationTest is DSTest {
         podConfig.label = bytes32("B");
         vm.prank(feiDAOTimelock);
         (uint256 podBId, , ) = factory.createOptimisticPod(podConfig);
-        assertEq(factory.getNumberOfPods(), 1);
+        assertEq(factory.getNumberOfPods(), 2);
 
         assertEq(podBId, podAId + 1);
         address podBAdmin = ControllerV1(podController).podAdmin(podBId);

--- a/contracts/test/integration/governance/PodFactory.t.sol
+++ b/contracts/test/integration/governance/PodFactory.t.sol
@@ -64,7 +64,7 @@ contract PodFactoryIntegrationTest is DSTest {
     /// @notice Validate initial factory state
     function testInitialState() public {
         assertEq(address(factory.podController()), podController);
-        assertEq(factory.latestPodId(), 0);
+        assertEq(factory.getNumberOfPods(), 0);
         assertEq(address(factory.podExecutor()), address(podExecutor));
         assertEq(address(factory.getMemberToken()), memberToken);
         assertEq(factory.MIN_TIMELOCK_DELAY(), 1 days);
@@ -99,8 +99,7 @@ contract PodFactoryIntegrationTest is DSTest {
         assertEq(storedMembers[1], genesisConfig.members[1]);
         assertEq(storedMembers[2], genesisConfig.members[2]);
 
-        uint256 latestPodId = factory.latestPodId();
-        assertEq(latestPodId, genesisPodId);
+        assertEq(factory.getNumberOfPods(), 0);
     }
 
     function testCanOnlyDeployGenesisOnce() public {
@@ -190,8 +189,8 @@ contract PodFactoryIntegrationTest is DSTest {
         assertEq(storedMembers[1], podConfig.members[1]);
         assertEq(storedMembers[2], podConfig.members[2]);
 
-        uint256 latestPodId = factory.latestPodId();
-        assertEq(latestPodId, podId);
+        uint256 numPods = factory.getNumberOfPods();
+        assertEq(numPods, 1);
 
         ///// Validate timelock component of pod
         assertEq(timelock, factory.getPodTimelock(podId));
@@ -271,6 +270,7 @@ contract PodFactoryIntegrationTest is DSTest {
 
         vm.prank(feiDAOTimelock);
         (uint256 podAId, , ) = factory.createOptimisticPod(podConfig);
+        assertEq(factory.getNumberOfPods(), 0);
 
         address podAAdmin = ControllerV1(podController).podAdmin(podAId);
         assertEq(podAAdmin, podAdmin);
@@ -278,6 +278,7 @@ contract PodFactoryIntegrationTest is DSTest {
         podConfig.label = bytes32("B");
         vm.prank(feiDAOTimelock);
         (uint256 podBId, , ) = factory.createOptimisticPod(podConfig);
+        assertEq(factory.getNumberOfPods(), 1);
 
         assertEq(podBId, podAId + 1);
         address podBAdmin = ControllerV1(podController).podAdmin(podBId);

--- a/contracts/test/integration/governance/PodFactory.t.sol
+++ b/contracts/test/integration/governance/PodFactory.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {ControllerV1} from "@orcaprotocol/contracts/contracts/ControllerV1.sol";
 import {IGnosisSafe} from "../../../pods/interfaces/IGnosisSafe.sol";
 import {PodFactory} from "../../../pods/PodFactory.sol";
@@ -16,7 +17,6 @@ import {mintOrcaTokens, getPodParams} from "../fixtures/Orca.sol";
 import {DummyStorage} from "../../utils/Fixtures.sol";
 import {Vm} from "../../utils/Vm.sol";
 import {MainnetAddresses} from "../fixtures/MainnetAddresses.sol";
-import {OptimisticTimelock} from "../../../dao/timelock/OptimisticTimelock.sol";
 
 /// @notice Validate PodFactory critical functionality such as creating pods
 ///  @dev PodAdmin can not also be a pod member
@@ -157,16 +157,6 @@ contract PodFactoryIntegrationTest is DSTest {
         assertEq(factory.getPodAdmin(podId), newAdmin);
     }
 
-    function testUpdatePodController() public {
-        address newController = address(0x10);
-
-        vm.prank(feiDAOTimelock);
-        factory.updatePodController(newController);
-
-        address updatedContoller = address(factory.podController());
-        assertEq(updatedContoller, newController);
-    }
-
     /// @notice Creates a child pod with an optimistic timelock attached
     function testDeployOptimisticGovernancePod() public {
         (IPodFactory.PodConfig memory podConfig, ) = getPodParams(podAdmin);
@@ -281,7 +271,7 @@ contract PodFactoryIntegrationTest is DSTest {
         (, address podTimelock, address safe) = factory
             .createChildOptimisticPod(podConfig);
 
-        OptimisticTimelock timelockContract = OptimisticTimelock(
+        TimelockController timelockContract = TimelockController(
             payable(podTimelock)
         );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,6 @@
         "hardhat-contract-sizer": "^2.5.1",
         "hardhat-gas-reporter": "^1.0.8",
         "merkletreejs": "^0.2.31",
-        "random-bytes": "^1.0.0",
-        "randomstring": "^1.2.2",
         "string-template": "^1.0.0"
       },
       "devDependencies": {
@@ -23145,14 +23143,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
       "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
     },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -23190,34 +23180,6 @@
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
-    },
-    "node_modules/randomstring": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.2.2.tgz",
-      "integrity": "sha512-9FByiB8guWZLbE+akdQiWE3I1I6w7Vn5El4o4y7o5bWQ6DWPcEOp+aLG7Jezc8BVRKKpgJd2ppRX0jnKu1YCfg==",
-      "dependencies": {
-        "array-uniq": "1.0.2",
-        "randombytes": "2.0.3"
-      },
-      "bin": {
-        "randomstring": "bin/randomstring"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/randomstring/node_modules/array-uniq": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-      "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/randomstring/node_modules/randombytes": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
-      "integrity": "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew="
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -46454,11 +46416,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
       "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
     },
-    "random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
-    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -46491,27 +46448,6 @@
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "randomstring": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.2.2.tgz",
-      "integrity": "sha512-9FByiB8guWZLbE+akdQiWE3I1I6w7Vn5El4o4y7o5bWQ6DWPcEOp+aLG7Jezc8BVRKKpgJd2ppRX0jnKu1YCfg==",
-      "requires": {
-        "array-uniq": "1.0.2",
-        "randombytes": "2.0.3"
-      },
-      "dependencies": {
-        "array-uniq": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-          "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0="
-        },
-        "randombytes": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
-          "integrity": "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew="
-        }
       }
     },
     "range-parser": {

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -76,7 +76,7 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
     minDelay: tribeCouncilPodConfig.minDelay
   };
 
-  const genesisTx = await podFactory.deployGenesisPod(tribalCouncilPod);
+  const genesisTx = await podFactory.deployCouncilPod(tribalCouncilPod);
   const { args } = (await genesisTx.wait()).events.find((elem) => elem.event === 'CreatePod');
   const tribalCouncilPodId = args.podId;
   logging && console.log('TribalCouncil pod Id: ', tribalCouncilPodId.toString());

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -63,7 +63,7 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
     podAdminGateway.address // PodAdminGateway
   );
   await podFactory.deployTransaction.wait();
-  await transferOrcaTokens(addresses.orcaERC20Address, deployAddress, podFactory.address, 2);
+  await transferOrcaTokens(addresses.orcaShipToken, deployAddress, podFactory.address, 2);
   logging && console.log('Pod factory deployed to:', podFactory.address);
 
   // 4. Create TribalCouncil and Protocol Tier pods
@@ -203,12 +203,9 @@ const validateTribeRoles = async (
   const daoIsPodDeployer = await core.hasRole(ethers.utils.id('ROLE_ADMIN'), feiDAOTimelockAddress);
   expect(daoIsPodDeployer).to.be.true;
 
-  // TribalCouncilTimelock roles: ROLE_ADMIN, POD_ADMIN, POD_VETO_ADMIN
+  // TribalCouncilTimelock roles: ROLE_ADMIN, POD_ADMIN
   const councilIsRoleAdmin = await core.hasRole(ethers.utils.id('ROLE_ADMIN'), tribalCouncilTimelockAddress);
   expect(councilIsRoleAdmin).to.be.true;
-
-  const councilIsPodVetoAdmin = await core.hasRole(ethers.utils.id('POD_VETO_ADMIN'), tribalCouncilTimelockAddress);
-  expect(councilIsPodVetoAdmin).to.be.true;
 
   const councilIsPodAdmin = await core.hasRole(ethers.utils.id('POD_ADMIN'), tribalCouncilTimelockAddress);
   expect(councilIsPodAdmin).to.be.true;

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -74,7 +74,6 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
     label: tribeCouncilPodConfig.label,
     ensString: tribeCouncilPodConfig.ensString,
     imageUrl: tribeCouncilPodConfig.imageUrl,
-    admin: podAdminGateway.address,
     minDelay: tribeCouncilPodConfig.minDelay
   };
 

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -9,7 +9,7 @@ import {
 } from '@custom-types/types';
 import { getImpersonatedSigner } from '@test/helpers';
 import { tribeCouncilPodConfig, PodCreationConfig } from '@protocol/optimisticGovernance';
-import { abi as timelockABI } from '../../artifacts/contracts/dao/timelock/OptimisticTimelock.sol/OptimisticTimelock.json';
+import { abi as timelockABI } from '../../artifacts/contracts/dao/timelock/TimelockController.sol/TimelockController.json';
 import { abi as gnosisSafeABI } from '../../artifacts/contracts/pods/interfaces/IGnosisSafe.sol/IGnosisSafe.json';
 import { Contract } from 'ethers';
 

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -18,10 +18,8 @@ const validateArraysEqual = (arrayA: string[], arrayB: string[]) => {
   arrayA.every((a) => expect(arrayB.map((b) => b.toLowerCase()).includes(a.toLowerCase())));
 };
 
-// Note: The Orca token is a slow rollout mechanism used by Orca. In order to successfully deploy pods
-// you need to have first been minted Orca tokens. Here, for testing purposes locally, we mint
-// the addresses that will create pods Orca tokens. TODO: Remove once have SHIP tokens on Mainnet
-// TODO: Remove now that have Orca tokens on my deployer address
+// Transfers Orca tokens from deployer address to the factory, so that it can deploy pods
+// Requirement of holding Orca tokens to deploy is a slow rollout mechanism used by Orca
 const transferOrcaTokens = async (
   orcaERC20Address: string,
   deployAddressWithOrca: string,
@@ -43,26 +41,26 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
   await podExecutor.deployTransaction.wait();
   logging && console.log('PodExecutor deployed to', podExecutor.address);
 
-  // 2. Deploy PodAdminGateway contract
-  const podAdminGatewayFactory = await ethers.getContractFactory('PodAdminGateway');
-  const podAdminGateway = await podAdminGatewayFactory.deploy(
-    addresses.core,
-    addresses.orcaMemberToken,
-    addresses.orcaPodController
-  );
-  await podAdminGateway.deployTransaction.wait();
-  logging && console.log(`Deployed PodAdminGateway at ${podAdminGateway.address}`);
-
-  // 3. Deploy tribalCouncilPodFactory
+  // 2. Deploy tribalCouncilPodFactory
   const podFactoryEthersFactory = await ethers.getContractFactory('PodFactory');
   const podFactory = await podFactoryEthersFactory.deploy(
     addresses.core, // core
     addresses.orcaPodController, // podController
     addresses.orcaMemberToken, // podMembershipToken
-    podExecutor.address, // Public pod executor
-    podAdminGateway.address // PodAdminGateway
+    podExecutor.address // Public pod executor
   );
   await podFactory.deployTransaction.wait();
+
+  // 3. Deploy PodAdminGateway contract
+  const podAdminGatewayFactory = await ethers.getContractFactory('PodAdminGateway');
+  const podAdminGateway = await podAdminGatewayFactory.deploy(
+    addresses.core,
+    addresses.orcaMemberToken,
+    addresses.orcaPodController,
+    podFactory.address
+  );
+  await podAdminGateway.deployTransaction.wait();
+  logging && console.log(`Deployed PodAdminGateway at ${podAdminGateway.address}`);
   await transferOrcaTokens(addresses.orcaShipToken, deployAddress, podFactory.address, 2);
   logging && console.log('Pod factory deployed to:', podFactory.address);
 
@@ -73,7 +71,8 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
     label: tribeCouncilPodConfig.label,
     ensString: tribeCouncilPodConfig.ensString,
     imageUrl: tribeCouncilPodConfig.imageUrl,
-    minDelay: tribeCouncilPodConfig.minDelay
+    minDelay: tribeCouncilPodConfig.minDelay,
+    admin: podAdminGateway.address
   };
 
   const genesisTx = await podFactory.deployCouncilPod(tribalCouncilPod);

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -72,7 +72,7 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
     minDelay: tribeCouncilPodConfig.minDelay
   };
 
-  await podFactory.burnerCreateChildOptimisticPods([tribalCouncilPod]);
+  await podFactory.deployGenesisPod(tribalCouncilPod);
 
   const tribalCouncilPodId = await podFactory.latestPodId();
 

--- a/proposals/dao/fip_94.ts
+++ b/proposals/dao/fip_94.ts
@@ -1,0 +1,44 @@
+import hre, { ethers, artifacts } from 'hardhat';
+import { expect } from 'chai';
+import {
+  DeployUpgradeFunc,
+  NamedAddresses,
+  SetupUpgradeFunc,
+  TeardownUpgradeFunc,
+  ValidateUpgradeFunc
+} from '@custom-types/types';
+
+const fipNumber = '94'; // Change me!
+
+// Do any deployments
+// This should exclusively include new contract deployments
+const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: NamedAddresses, logging: boolean) => {
+  console.log(`No deploy actions for fip${fipNumber}`);
+  return {
+    // put returned contract objects here
+  };
+};
+
+// Do any setup necessary for running the test.
+// This could include setting up Hardhat to impersonate accounts,
+// ensuring contracts have a specific state, etc.
+const setup: SetupUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  console.log(`No setup actions for fip${fipNumber}`);
+};
+
+// Tears down any changes made in setup() that need to be
+// cleaned up before doing any validation checks.
+const teardown: TeardownUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  console.log(`No actions to complete in teardown for fip${fipNumber}`);
+};
+
+// Run any validations required on the fip using mocha or console logging
+// IE check balances, check state of contracts, etc.
+const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  // Verify Rari timelock does not have GOVERN_ROLE role
+  const core = contracts.core;
+  const hasGovRole = await core.hasRole(ethers.utils.id('GOVERN_ROLE'), addresses.rariTimelock);
+  expect(hasGovRole).to.equal(false);
+};
+
+export { deploy, setup, teardown, validate };

--- a/proposals/dao/old/optimisticTimelock.ts
+++ b/proposals/dao/old/optimisticTimelock.ts
@@ -81,4 +81,3 @@ module.exports = {
   teardown,
   validate
 };
-

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -20,7 +20,7 @@ const fip_82: ProposalDescription = {
       method: 'createRole(bytes32,bytes32)',
       arguments: [
         '0x6ecc8dff15d98038e3ff32bfe76768123628cfdd2c3d11f2ec23c5433a9d4ba3', // POD_ADMIN
-        '0x899bd46557473cb80307a9dabc297131ced39608330a2d29b2d52b660c03923e' // GOVERN_ROLE
+        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
       ],
       description: 'Create POD_ADMIN role'
     },

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -29,16 +29,6 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'createRole(bytes32,bytes32)',
       arguments: [
-        '0x1c4afb10045e2ffba702b04df46e551f6f2c584499b4abe7b6136efe6b05a34d', // POD_DEPLOYER_ROLE
-        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
-      ],
-      description: 'Create POD_DEPLOYER_ROLE role'
-    },
-    {
-      target: 'core',
-      values: '0',
-      method: 'createRole(bytes32,bytes32)',
-      arguments: [
         '0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', // POD_VETO_ADMIN
         '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096' // ROLE_ADMIN
       ],
@@ -63,7 +53,22 @@ const fip_82: ProposalDescription = {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
-      arguments: ['0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096', '{tribalCouncilTimelock}'],
+      arguments: [
+        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096', // ROLE_ADMIN
+        '{feiDAOTimelock}' // Fei DAO timelock
+      ],
+      description: `
+      Grant FEI DAO timelock ROLE_ADMIN, so it is able to manage roles and grant roles that are managed
+      by this role.`
+    },
+    {
+      target: 'core',
+      values: '0',
+      method: 'grantRole(bytes32,address)',
+      arguments: [
+        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096', // ROLE_ADMIN
+        '{tribalCouncilTimelock}' // TribalCouncil timelock
+      ],
       description: `
       Grant Tribal Council timelock the ROLE_ADMIN role. TribalCouncil will be able to manage Admin level roles
       and below
@@ -74,19 +79,9 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'grantRole(bytes32,address)',
       arguments: [
-        '0x2172861495e7b85edac73e3cd5fbb42dd675baadf627720e687bcfdaca025096', // ROLE_ADMIN
-        '{feiDAOTimelock}' // Fei DAI timelock
+        '0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', // POD_VETO_ADMIN
+        '{tribalCouncilTimelock}' // Tribal council timelock
       ],
-      description: `
-      Grant FEI DAO timelock ROLE_ADMIN, so it is able to manage roles and grant roles that are managed
-      by this role.`
-    },
-    {
-      target: 'core',
-      values: '0',
-      method: 'grantRole(bytes32,address)',
-      // Admin of POD_VETO_ADMIN role is ROLE_ADMIN. ROLE_ADMIN is granted to GOVERNOR
-      arguments: ['0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', '{tribalCouncilTimelock}'],
       description: `
       Grant POD_VETO_ADMIN to TribalCouncil timelock. TribalCouncil will be able grant or revoke other TribeRoles
       from having veto permissions over pods
@@ -96,34 +91,20 @@ const fip_82: ProposalDescription = {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
-      arguments: ['0x1c4afb10045e2ffba702b04df46e551f6f2c584499b4abe7b6136efe6b05a34d', '{tribalCouncilTimelock}'],
-      // TODO: Update to POD_ADMIN, changing
-      description: 'Grant POD_DEPLOYER_ROLE to TribalCouncil timelock. TribalCouncil will be able to deploy pods'
+      arguments: [
+        '0x6ecc8dff15d98038e3ff32bfe76768123628cfdd2c3d11f2ec23c5433a9d4ba3', // POD_ADMIN
+        '{tribalCouncilTimelock}' // Tribal council timelock
+      ],
+      description: 'Grant POD_ADMIN to TribalCouncil timelock'
     },
     {
       target: 'core',
       values: '0',
       method: 'grantRole(bytes32,address)',
       arguments: [
-        '0x6ecc8dff15d98038e3ff32bfe76768123628cfdd2c3d11f2ec23c5433a9d4ba3', // POD_ADMIN
-        '{tribalCouncilTimelock}'
+        '0xf62a46a499242191aaab61084d4912c2c0a8c48e3d70edfb5a9be2bc9e92622f', // POD_METADATA_REGISTER_ROLE
+        '{tribalCouncilSafe}'
       ],
-      description: 'Grant POD_ADMIN role to TribalCouncil timelock'
-    },
-    {
-      // TODO: Also remove
-      target: 'core',
-      values: '0',
-      method: 'grantRole(bytes32,address)',
-      arguments: ['0x1c4afb10045e2ffba702b04df46e551f6f2c584499b4abe7b6136efe6b05a34d', '{feiDAOTimelock}'],
-      description: 'Grant POD_DEPLOYER_ROLE to FeiDAO timelock. FeiDAO will be able to create and deploy pods'
-    },
-    {
-      target: 'core',
-      values: '0',
-      method: 'grantRole(bytes32,address)',
-      // POD_METADATA_REGISTER_ROLE, to allow safe to register data
-      arguments: ['0xf62a46a499242191aaab61084d4912c2c0a8c48e3d70edfb5a9be2bc9e92622f', '{tribalCouncilSafe}'],
       description: 'Grant TribalCouncil Gnosis Safe address role to register metadata'
     },
     {
@@ -132,9 +113,9 @@ const fip_82: ProposalDescription = {
       method: 'grantRole(bytes32,address)',
       arguments: [
         '0x899bd46557473cb80307a9dabc297131ced39608330a2d29b2d52b660c03923e', // GOVERNOR
-        '{roleBastion}' // RoleBastion - used by TribalCouncil to create roles
+        '{roleBastion}' // RoleBastion
       ],
-      description: 'Grant GOVERNOR role to RoleBastion'
+      description: 'Grant GOVERNOR role to RoleBastion. This will be used by the TribalCouncil to create new roles'
     },
     {
       target: 'core',
@@ -142,9 +123,9 @@ const fip_82: ProposalDescription = {
       method: 'grantRole(bytes32,address)',
       arguments: [
         '0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', // POD_VETO_ADMIN
-        '{nopeDAO}'
+        '{nopeDAO}' // Nope DAO
       ],
-      description: 'Grant POD_VETO_ADMIN role to NopeDAO'
+      description: 'Grant POD_VETO_ADMIN role to NopeDAO. This allows the NopeDAO to veto any pod timelock'
     },
     {
       target: 'core',
@@ -162,9 +143,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchAddPodMember(uint256 _podId,address[] memory _members)',
       arguments: [
-        '24', // hardcode tribalcouncil id - memberToken.getNextPodId()
-        // TODO: Sync up with Orca on how to prevent podId changing underfoot
-        // Otherwise this will brick the proposal
+        '24', // TODO: Update to correct TribalCouncil ID once pod is deployed
         [
           '0x000000000000000000000000000000000000000D', // TODO: Complete with real member addresses
           '0x000000000000000000000000000000000000000E',
@@ -184,7 +163,7 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'batchRemovePodMember(uint256 _podId, address[] memory)',
       arguments: [
-        '24', // TODO: Replace hardcoded value with real podId
+        '24', // TODO: Update to correct TribalCouncil ID once pod is deployed
         [
           '0x0000000000000000000000000000000000000004',
           '0x0000000000000000000000000000000000000005',
@@ -210,8 +189,8 @@ const fip_82: ProposalDescription = {
   ],
   description: `
   FIP-82 enacts the governance upgrade to the TRIBE DAO and deploys the TribalCouncil pod. Specifically, this FIP will:
-  1. Create roles for the Tribal Council
-  2. Grant relevant roles to the Tribal Council
+  1. Create roles for the new governance system
+  2. Grant relevant roles to the Tribal Council and infrastructure in the new governance system
   3. Initialise the membership of the Tribal Council
 
   Snapshot vote: https://snapshot.fei.money/#/proposal/0x463fd1be98d9e86c83eb845ca7e2a5555387e3c86ca0b756aada17a11df87f2b

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -79,19 +79,6 @@ const fip_82: ProposalDescription = {
       values: '0',
       method: 'grantRole(bytes32,address)',
       arguments: [
-        '0x29af6c210963c1cf458c6a5bf082996cf54b23ebba0c0fb8ae110e8e43371c71', // POD_VETO_ADMIN
-        '{tribalCouncilTimelock}' // Tribal council timelock
-      ],
-      description: `
-      Grant POD_VETO_ADMIN to TribalCouncil timelock. TribalCouncil will be able grant or revoke other TribeRoles
-      from having veto permissions over pods
-      `
-    },
-    {
-      target: 'core',
-      values: '0',
-      method: 'grantRole(bytes32,address)',
-      arguments: [
         '0x6ecc8dff15d98038e3ff32bfe76768123628cfdd2c3d11f2ec23c5433a9d4ba3', // POD_ADMIN
         '{tribalCouncilTimelock}' // Tribal council timelock
       ],

--- a/proposals/description/fip_94.ts
+++ b/proposals/description/fip_94.ts
@@ -1,0 +1,21 @@
+import { ProposalDescription } from '@custom-types/types';
+
+const fip_94: ProposalDescription = {
+  title: 'FIP-94: Remove GOVERN_ROLE role from Rari timelock',
+  commands: [
+    {
+      target: 'core',
+      values: '0',
+      method: 'revokeRole(bytes32,address)',
+      arguments: [
+        '0x899bd46557473cb80307a9dabc297131ced39608330a2d29b2d52b660c03923e', // GOVERN_ROLE
+        '{rariTimelock}'
+      ],
+      description: 'Revoke GOVERN_ROLE role from Rari timelock'
+    }
+  ],
+  description: `
+  This FIP revokes the GOVERN_ROLE role from the Rari timelock as a safety mechanism.`
+};
+
+export default fip_94;

--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -1856,6 +1856,11 @@ const MainnetAddresses: MainnetAddresses = {
     address: '0x0762aA185b6ed2dCA77945Ebe92De705e0C37AE3',
     category: AddressCategory.External
   },
+  orcaShipToken: {
+    artifactName: 'unknown',
+    address: '0x872EdeaD0c56930777A82978d4D7deAE3A2d1539',
+    category: AddressCategory.External
+  },
   rariGovernanceProxyAdmin: {
     artifactName: 'ProxyAdmin',
     address: '0x1c9aA54a013962C2444ECae06902F31D532c6AD3',

--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -1846,12 +1846,12 @@ const MainnetAddresses: MainnetAddresses = {
     address: '0x2dC77678Be7F900e81c638b056F4835BB7203C96',
     category: AddressCategory.TBD
   },
-  podController: {
+  orcaPodController: {
     artifactName: 'IControllerV1',
     address: '0x17FDC2Eaf2bd46f3e1052CCbccD9e6AD0296C42c',
     category: AddressCategory.External
   },
-  memberToken: {
+  orcaMemberToken: {
     artifactName: 'IMemberToken',
     address: '0x0762aA185b6ed2dCA77945Ebe92De705e0C37AE3',
     category: AddressCategory.External

--- a/protocol-configuration/optimisticGovernance.ts
+++ b/protocol-configuration/optimisticGovernance.ts
@@ -17,6 +17,7 @@ export type PodCreationConfig = {
   label: string;
   ensString: string;
   imageUrl: string;
+  admin: string;
   minDelay: number;
 };
 

--- a/protocol-configuration/optimisticGovernance.ts
+++ b/protocol-configuration/optimisticGovernance.ts
@@ -49,9 +49,9 @@ export const tribeCouncilPodConfig: PodConfig = {
   members: tribalCouncilMembers,
   threshold: 5,
   label: '0x54726962616c436f756e63696c00000000000000000000000000000000000000', // TribalCouncil
-  ensString: 'tribalCouncil',
+  ensString: 'tribalcouncil',
   imageUrl: '',
-  minDelay: 345600,
+  minDelay: 345600, // 4 days
   numMembers: tribalCouncilMembers.length,
   placeHolderMembers: placeHolderCouncilMembers
 };

--- a/protocol-configuration/optimisticGovernance.ts
+++ b/protocol-configuration/optimisticGovernance.ts
@@ -17,7 +17,6 @@ export type PodCreationConfig = {
   label: string;
   ensString: string;
   imageUrl: string;
-  admin: string;
   minDelay: number;
 };
 
@@ -45,13 +44,15 @@ export const placeHolderCouncilMembers = [
   '0x000000000000000000000000000000000000000c'
 ];
 
+export const MIN_TIMELOCK_DELAY = 86400; // 1 day
+
 export const tribeCouncilPodConfig: PodConfig = {
   members: tribalCouncilMembers,
   threshold: 5,
   label: '0x54726962616c436f756e63696c00000000000000000000000000000000000000', // TribalCouncil
   ensString: 'tribalcouncil',
   imageUrl: '',
-  minDelay: 345600, // 4 days
+  minDelay: 86400 * 4, // 4 days
   numMembers: tribalCouncilMembers.length,
   placeHolderMembers: placeHolderCouncilMembers
 };

--- a/protocol-configuration/permissions.ts
+++ b/protocol-configuration/permissions.ts
@@ -35,8 +35,7 @@ export const permissions = {
   METAGOVERNANCE_TOKEN_STAKING: ['feiDAOTimelock', 'opsOptimisticTimelock'],
   METAGOVERNANCE_GAUGE_ADMIN: ['feiDAOTimelock', 'optimisticTimelock'],
   ROLE_ADMIN: ['feiDAOTimelock', 'tribalCouncilTimelock'],
-  POD_DEPLOYER_ROLE: ['feiDAOTimelock', 'tribalCouncilTimelock'],
-  POD_METADATA_REGISTER_ROLE: ['tribalCouncilSafe', 'protocolPodSafe'],
+  POD_METADATA_REGISTER_ROLE: ['tribalCouncilSafe'],
   POD_VETO_ADMIN: ['tribalCouncilTimelock', 'nopeDAO'],
-  POD_ADMIN: ['tribalCouncilTimelock']
+  POD_ADMIN: ['tribalCouncilTimelock', 'podFactory']
 };

--- a/protocol-configuration/permissions.ts
+++ b/protocol-configuration/permissions.ts
@@ -12,7 +12,7 @@ export const permissions = {
     'balancerDepositFeiWeth'
   ],
   BURNER_ROLE: [],
-  GOVERN_ROLE: ['core', 'feiDAOTimelock', 'rariTimelock', 'roleBastion'],
+  GOVERN_ROLE: ['core', 'feiDAOTimelock', 'roleBastion'],
   PCV_CONTROLLER_ROLE: [
     'feiDAOTimelock',
     'ratioPCVControllerV2',

--- a/protocol-configuration/permissions.ts
+++ b/protocol-configuration/permissions.ts
@@ -36,6 +36,6 @@ export const permissions = {
   METAGOVERNANCE_GAUGE_ADMIN: ['feiDAOTimelock', 'optimisticTimelock'],
   ROLE_ADMIN: ['feiDAOTimelock', 'tribalCouncilTimelock'],
   POD_METADATA_REGISTER_ROLE: ['tribalCouncilSafe'],
-  POD_VETO_ADMIN: ['tribalCouncilTimelock', 'nopeDAO'],
+  POD_VETO_ADMIN: ['nopeDAO'],
   POD_ADMIN: ['tribalCouncilTimelock', 'podFactory']
 };

--- a/test/integration/tests/fei.ts
+++ b/test/integration/tests/fei.ts
@@ -94,12 +94,12 @@ describe('e2e-fei', function () {
     });
 
     it('hasAnyOfRoles works', async function () {
-      const addresses = await getAddresses();
       const mockCoreRefTestFactory = await ethers.getContractFactory('MockCoreRefTest');
       const mockCoreRefTest = await mockCoreRefTestFactory.deploy(contracts.core.address);
       await contracts.core.grantGuardian(deployAddress);
-      await mockCoreRefTest.connect(await getImpersonatedSigner(deployAddress)).governorOrGuardianTest();
-      expect(mockCoreRefTest.governorOrGuardianTest()).to.be.revertedWith('UNAUTHORIZED');
+      await mockCoreRefTest.connect(deploySigner).governorOrGuardianTest();
+      await contracts.core.revokeGuardian(deployAddress);
+      expect(mockCoreRefTest.connect(deploySigner).governorOrGuardianTest()).to.be.revertedWith('UNAUTHORIZED');
     });
   });
 });

--- a/test/integration/tests/podOperation.ts
+++ b/test/integration/tests/podOperation.ts
@@ -101,7 +101,7 @@ describe('Pod operation and veto', function () {
     // and the pod is calling to register a proposal on the `GovernanceMetadataRegistry.sol`
 
     // 1. Deploy a pod through which a proposal will be executed
-    await podFactory.connect(tribalCouncilTimelockSigner).createChildOptimisticPod(podConfig);
+    await podFactory.connect(tribalCouncilTimelockSigner).createOptimisticPod(podConfig);
     podId = await podFactory.latestPodId();
     const safeAddress = await podFactory.getPodSafe(podId);
     timelockAddress = await podFactory.getPodTimelock(podId);

--- a/test/integration/tests/podOperation.ts
+++ b/test/integration/tests/podOperation.ts
@@ -183,9 +183,7 @@ describe('Pod operation and veto', function () {
     // User proposes on NopeDAO
     const nopeDAO = contracts.nopeDAO;
     const description = 'Veto proposal';
-    const calldatas = [
-      contracts.podAdminGateway.interface.encodeFunctionData('veto', [podId, podTimelock.address, timelockProposalId])
-    ];
+    const calldatas = [contracts.podAdminGateway.interface.encodeFunctionData('veto', [podId, timelockProposalId])];
     const targets = [contractAddresses.podAdminGateway];
     const values = [0];
 

--- a/test/integration/tests/tribalCouncil.ts
+++ b/test/integration/tests/tribalCouncil.ts
@@ -122,8 +122,9 @@ describe('Tribal Council', function () {
 
   ///////////    TribalCouncil management of other pods  /////////////
   it('can create a child pod', async () => {
-    await podFactory.connect(tribalCouncilTimelockSigner).createOptimisticPod(podConfig);
-    const podId = await podFactory.latestPodId();
+    const deployTx = await podFactory.connect(tribalCouncilTimelockSigner).createOptimisticPod(podConfig);
+    const { args } = (await deployTx.wait()).events.find((elem) => elem.event === 'CreatePod');
+    const podId = args.podId;
     const numPodMembers = await podFactory.getNumMembers(podId);
     expect(numPodMembers).to.equal(4);
   });

--- a/test/integration/tests/tribalCouncil.ts
+++ b/test/integration/tests/tribalCouncil.ts
@@ -10,7 +10,7 @@ import proposals from '@test/integration/proposals_config';
 import { forceEth } from '@test/integration/setup/utils';
 import { TestEndtoEndCoordinator } from '../setup';
 import { BigNumber } from 'ethers';
-import { tribalCouncilMembers } from '@protocol/optimisticGovernance';
+import { tribalCouncilMembers, MIN_TIMELOCK_DELAY } from '@protocol/optimisticGovernance';
 
 const toBN = ethers.BigNumber.from;
 
@@ -81,7 +81,7 @@ describe('Tribal Council', function () {
       label: '0x54726962616c436f726e63696c00000000000000000000000000000000000000', // TribalCouncil
       ensString: 'testPod.eth',
       imageUrl: 'testPod.com',
-      minDelay: 2,
+      minDelay: MIN_TIMELOCK_DELAY,
       numMembers: 4,
       admin: podAdminGateway.address
     };
@@ -131,7 +131,7 @@ describe('Tribal Council', function () {
   it('can create a new role via the Role Bastion', async () => {
     await roleBastion.connect(tribalCouncilTimelockSigner).createRole(dummyRole);
 
-    // Validate that the role was created ROLE_ADMIN role
+    // Validate that the role was created with the admin set to ROLE_ADMIN
     const roleAdmin = await core.getRoleAdmin(dummyRole);
     expect(roleAdmin).to.equal(ethers.utils.id('ROLE_ADMIN'));
   });

--- a/test/integration/tests/tribalCouncil.ts
+++ b/test/integration/tests/tribalCouncil.ts
@@ -17,7 +17,6 @@ const toBN = ethers.BigNumber.from;
 describe('Tribal Council', function () {
   let contracts: NamedContracts;
   let contractAddresses: NamedAddresses;
-  let deployAddress: SignerWithAddress;
   let e2eCoord: TestEndtoEndCoordinator;
   let doLogging: boolean;
   let podFactory: PodFactory;
@@ -40,14 +39,14 @@ describe('Tribal Council', function () {
   before(async function () {
     // Setup test environment and get contracts
     const version = 1;
-    deployAddress = (await ethers.getSigners())[0];
-    if (!deployAddress) throw new Error(`No deploy address!`);
+    // Set deploy address to Tom's address. This has Orca SHIP
+    const deployAddress = '0x64c4Bffb220818F0f2ee6DAe7A2F17D92b359c5d';
 
     doLogging = Boolean(process.env.LOGGING);
 
     const config = {
       logging: doLogging,
-      deployAddress: deployAddress.address,
+      deployAddress,
       version: version
     };
 

--- a/test/integration/tests/tribalCouncil.ts
+++ b/test/integration/tests/tribalCouncil.ts
@@ -122,7 +122,7 @@ describe('Tribal Council', function () {
 
   ///////////    TribalCouncil management of other pods  /////////////
   it('can create a child pod', async () => {
-    await podFactory.connect(tribalCouncilTimelockSigner).createChildOptimisticPod(podConfig);
+    await podFactory.connect(tribalCouncilTimelockSigner).createOptimisticPod(podConfig);
     const podId = await podFactory.latestPodId();
     const numPodMembers = await podFactory.getNumMembers(podId);
     expect(numPodMembers).to.equal(4);


### PR DESCRIPTION
# Summary
Implements governance upgrade todos:

**Main points**
- `admin` of a pod is set on a per pod basis via the `PodConfig` that is passed to `factory.createOptimisticPod()`. This is done for two reasons:
    - Allow the `PodFactory` to be be passed to `PodAdminGateway`, so that in `veto()` we can validate that `podId` corresponds to the passed `timelock` (there won't be a cyclical dependency)
    - Allow us to more easily upgrade the admin contract. An individual pod/safe can migrate itself, and then we will create all new pods in the future by passing a new admin. Rather than requiring to redeploy the factory
- Consolidated specific pod admin roles into: `admin` and `guardian`. Map onto existing global role abilities
- DAO vote will not be bricked by additional Orca pod deploys. We deploy the TribalCouncil first and get a unique podId. The DAO vote script will need updating with our TribalCouncil Id 
- Replaced used of `OptimisticTimelock.sol` with `TimelockController.sol`
- Removed some unnecessary global roles and consolidated
- Have a simplified `deployGenesisPod()` function to deploy the first pod. It is used to deploy the TribalCouncil before the DAO vote FIP. This means we have the podId. It is not placed in the constructor of the factory as it relies on args passed to the constructor which I want to be immutable for future deploys