### PR TITLE
Controller upgrade path

### DIFF
--- a/contracts/pods/PodAdminGateway.sol
+++ b/contracts/pods/PodAdminGateway.sol
@@ -23,20 +23,15 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
     /// @notice Orca membership token for the pods. Handles permissioning pod members
     MemberToken private immutable memberToken;
 
-    /// @notice Pod controller for the pods
-    ControllerV1 public immutable podController;
-
     /// @notice Pod factory which creates optimistic pods and acts as a source of information
     IPodFactory public immutable podFactory;
 
     constructor(
         address _core,
         address _memberToken,
-        address _podController,
         address _podFactory
     ) CoreRef(_core) {
         memberToken = MemberToken(_memberToken);
-        podController = ControllerV1(_podController);
         podFactory = IPodFactory(_podFactory);
     }
 
@@ -183,6 +178,9 @@ contract PodAdminGateway is CoreRef, IPodAdminGateway {
 
     /// @notice Internal method to toggle a pod membership transfer lock
     function _setMembershipTransferLock(uint256 _podId, bool _lock) internal {
+        ControllerV1 podController = ControllerV1(
+            memberToken.memberController(_podId)
+        );
         podController.setPodTransferLock(_podId, _lock);
         emit PodMembershipTransferLock(_podId, _lock);
     }

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -26,7 +26,7 @@ contract PodFactory is CoreRef, IPodFactory {
     /// @notice Public contract that will be granted to execute all timelocks created
     PodExecutor public immutable podExecutor;
 
-    /// @notice Constant podController used to create pods
+    /// @notice Default podController used to create pods
     ControllerV1 public override defaultPodController;
 
     /// @notice Mapping between podId and it's timelock
@@ -46,6 +46,7 @@ contract PodFactory is CoreRef, IPodFactory {
 
     /// @param _core Fei core address
     /// @param _memberToken Membership token that manages the Orca pod membership
+    /// @param _defaultPodController Default pod controller that will be used to create pods initially
     /// @param _podExecutor Public contract that will be granted to execute all timelocks created
     constructor(
         address _core,

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -27,7 +27,7 @@ contract PodFactory is CoreRef, IPodFactory {
     PodExecutor public immutable podExecutor;
 
     /// @notice Constant podController used to create pods
-    ControllerV1 public immutable defaultPodController;
+    ControllerV1 public override defaultPodController;
 
     /// @notice Mapping between podId and it's timelock
     mapping(uint256 => address) public override getPodTimelock;
@@ -87,10 +87,7 @@ contract PodFactory is CoreRef, IPodFactory {
         override
         returns (ControllerV1)
     {
-        ControllerV1 podController = ControllerV1(
-            memberToken.memberController(podId)
-        );
-        return podController;
+        return ControllerV1(memberToken.memberController(podId));
     }
 
     /// @notice Get the address of the Gnosis safe that represents a pod
@@ -213,6 +210,19 @@ contract PodFactory is CoreRef, IPodFactory {
         // Disable membership transfers by default
         PodAdminGateway(_config.admin).lockMembershipTransfers(podId);
         return (podId, timelock, safe);
+    }
+
+    /// @notice Update the default pod controller
+    function updateDefaultPodController(address _newDefaultController)
+        external
+        override
+        hasAnyOfTwoRoles(TribeRoles.GOVERNOR, TribeRoles.POD_ADMIN)
+    {
+        emit UpdateDefaultPodController(
+            address(defaultPodController),
+            _newDefaultController
+        );
+        defaultPodController = ControllerV1(_newDefaultController);
     }
 
     ////////////////////////     INTERNAL          ////////////////////////////

--- a/contracts/pods/PodFactory.sol
+++ b/contracts/pods/PodFactory.sol
@@ -20,14 +20,14 @@ import {PodExecutor} from "./PodExecutor.sol";
 /// The timelock and Orca pod are then linked up so that the Orca pod is
 /// the only proposer and executor.
 contract PodFactory is CoreRef, IPodFactory {
-    /// @notice Orca controller for Pod
-    ControllerV1 public immutable override podController;
-
     /// @notice Orca membership token for the pods. Handles permissioning pod members
     MemberToken public immutable memberToken;
 
     /// @notice Public contract that will be granted to execute all timelocks created
     PodExecutor public immutable podExecutor;
+
+    /// @notice Constant podController used to create pods
+    ControllerV1 public immutable defaultPodController;
 
     /// @notice Mapping between podId and it's timelock
     mapping(uint256 => address) public override getPodTimelock;
@@ -45,17 +45,16 @@ contract PodFactory is CoreRef, IPodFactory {
     uint256 public constant MIN_TIMELOCK_DELAY = 1 days;
 
     /// @param _core Fei core address
-    /// @param _podController Orca pod controller
     /// @param _memberToken Membership token that manages the Orca pod membership
     /// @param _podExecutor Public contract that will be granted to execute all timelocks created
     constructor(
         address _core,
-        address _podController,
         address _memberToken,
+        address _defaultPodController,
         address _podExecutor
     ) CoreRef(_core) {
         podExecutor = PodExecutor(_podExecutor);
-        podController = ControllerV1(_podController);
+        defaultPodController = ControllerV1(_defaultPodController);
         memberToken = MemberToken(_memberToken);
     }
 
@@ -81,9 +80,25 @@ contract PodFactory is CoreRef, IPodFactory {
         return memberToken;
     }
 
+    /// @notice Get the pod controller for a podId
+    function getPodController(uint256 podId)
+        external
+        view
+        override
+        returns (ControllerV1)
+    {
+        ControllerV1 podController = ControllerV1(
+            memberToken.memberController(podId)
+        );
+        return podController;
+    }
+
     /// @notice Get the address of the Gnosis safe that represents a pod
     /// @param podId Unique id for the orca pod
     function getPodSafe(uint256 podId) public view override returns (address) {
+        ControllerV1 podController = ControllerV1(
+            memberToken.memberController(podId)
+        );
         return podController.podIdToSafe(podId);
     }
 
@@ -108,6 +123,9 @@ contract PodFactory is CoreRef, IPodFactory {
         override
         returns (address[] memory)
     {
+        ControllerV1 podController = ControllerV1(
+            memberToken.memberController(podId)
+        );
         address safeAddress = podController.podIdToSafe(podId);
         return IGnosisSafe(safeAddress).getOwners();
     }
@@ -139,6 +157,9 @@ contract PodFactory is CoreRef, IPodFactory {
         override
         returns (address)
     {
+        ControllerV1 podController = ControllerV1(
+            memberToken.memberController(podId)
+        );
         return podController.podAdmin(podId);
     }
 
@@ -149,6 +170,9 @@ contract PodFactory is CoreRef, IPodFactory {
         override
         returns (bool)
     {
+        ControllerV1 podController = ControllerV1(
+            memberToken.memberController(podId)
+        );
         return podController.isTransferLocked(podId);
     }
 
@@ -250,7 +274,7 @@ contract PodFactory is CoreRef, IPodFactory {
         address _admin,
         uint256 podId
     ) internal returns (address) {
-        podController.createPod(
+        defaultPodController.createPod(
             _members,
             _threshold,
             _admin,
@@ -259,7 +283,7 @@ contract PodFactory is CoreRef, IPodFactory {
             podId,
             _imageUrl
         );
-        return podController.podIdToSafe(podId);
+        return defaultPodController.podIdToSafe(podId);
     }
 
     /// @notice Create a timelock, linking to an Orca pod

--- a/contracts/pods/interfaces/IPodFactory.sol
+++ b/contracts/pods/interfaces/IPodFactory.sol
@@ -33,6 +33,11 @@ interface IPodFactory {
         address indexed newController
     );
 
+    event UpdateDefaultPodController(
+        address indexed oldController,
+        address indexed newController
+    );
+
     function deployCouncilPod(PodConfig calldata _config)
         external
         returns (
@@ -40,6 +45,8 @@ interface IPodFactory {
             address,
             address
         );
+
+    function defaultPodController() external view returns (ControllerV1);
 
     function getMemberToken() external view returns (MemberToken);
 
@@ -81,4 +88,6 @@ interface IPodFactory {
             address,
             address
         );
+
+    function updateDefaultPodController(address _newDefaultController) external;
 }

--- a/contracts/pods/interfaces/IPodFactory.sol
+++ b/contracts/pods/interfaces/IPodFactory.sol
@@ -47,7 +47,10 @@ interface IPodFactory {
 
     function getNumberOfPods() external view returns (uint256);
 
-    function podController() external view returns (ControllerV1);
+    function getPodController(uint256 podId)
+        external
+        view
+        returns (ControllerV1);
 
     function getPodSafe(uint256 podId) external view returns (address);
 

--- a/contracts/test/integration/fixtures/MainnetAddresses.sol
+++ b/contracts/test/integration/fixtures/MainnetAddresses.sol
@@ -8,6 +8,8 @@ library MainnetAddresses {
     address public constant TRIBE = 0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B;
     address public constant MEMBER_TOKEN =
         0x0762aA185b6ed2dCA77945Ebe92De705e0C37AE3;
-    address public constant POD_CONTROLLER =
+    address public constant ORCA_POD_CONTROLLER_V1 =
+        0xD89AAd5348A34E440E72f5F596De4fA7e291A3e8;
+    address public constant ORCA_POD_CONTROLLER_V1_2 =
         0x17FDC2Eaf2bd46f3e1052CCbccD9e6AD0296C42c;
 }

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -151,8 +151,8 @@ function deployPodWithSystem(
     // 1. Deploy PodFactory
     PodFactory factory = new PodFactory(
         core,
-        podController,
         memberToken,
+        podController,
         podExecutor
     );
     mintOrcaTokens(address(factory), 2, vm);
@@ -161,7 +161,6 @@ function deployPodWithSystem(
     PodAdminGateway podAdminGateway = new PodAdminGateway(
         MainnetAddresses.CORE,
         memberToken,
-        podController,
         address(factory)
     );
     IPodFactory.PodConfig memory podConfig = getPodParamsWithTimelock(

--- a/contracts/test/integration/governance/NopeDAO.t.sol
+++ b/contracts/test/integration/governance/NopeDAO.t.sol
@@ -62,7 +62,7 @@ contract NopeDAOIntegrationTest is DSTest {
             podConfig
         ) = deployPodWithSystem(
             MainnetAddresses.CORE,
-            MainnetAddresses.POD_CONTROLLER,
+            MainnetAddresses.ORCA_POD_CONTROLLER_V1_2,
             MainnetAddresses.MEMBER_TOKEN,
             podExecutor,
             MainnetAddresses.FEI_DAO_TIMELOCK,

--- a/contracts/test/integration/governance/OptimisticPodTest.t.sol
+++ b/contracts/test/integration/governance/OptimisticPodTest.t.sol
@@ -22,7 +22,8 @@ contract OptimisticPodIntegrationTest is DSTest {
 
     MemberToken memberToken = MemberToken(MainnetAddresses.MEMBER_TOKEN);
 
-    ControllerV1 controller = ControllerV1(MainnetAddresses.POD_CONTROLLER);
+    ControllerV1 controller =
+        ControllerV1(MainnetAddresses.ORCA_POD_CONTROLLER_V1_2);
 
     address proposer = address(0x1);
     address executor = address(0x2);

--- a/contracts/test/integration/governance/PodAdminGateway.t.sol
+++ b/contracts/test/integration/governance/PodAdminGateway.t.sol
@@ -29,7 +29,7 @@ contract PodAdminGatewayIntegrationTest is DSTest {
 
     address core = MainnetAddresses.CORE;
     address memberToken = MainnetAddresses.MEMBER_TOKEN;
-    address podController = MainnetAddresses.POD_CONTROLLER;
+    address podController = MainnetAddresses.ORCA_POD_CONTROLLER_V1_2;
     address feiDAOTimelock = MainnetAddresses.FEI_DAO_TIMELOCK;
 
     function setUp() public {

--- a/contracts/test/integration/governance/PodAdminGateway.t.sol
+++ b/contracts/test/integration/governance/PodAdminGateway.t.sol
@@ -34,13 +34,12 @@ contract PodAdminGatewayIntegrationTest is DSTest {
 
     function setUp() public {
         // 1. Deploy pod factory
-        factory = new PodFactory(core, podController, memberToken, podExecutor);
+        factory = new PodFactory(core, memberToken, podController, podExecutor);
 
         // 2. Deploy pod admin gateway, to expose pod admin functionality
         podAdminGateway = new PodAdminGateway(
             core,
             memberToken,
-            podController,
             address(factory)
         );
 

--- a/contracts/test/integration/governance/PodFactory.t.sol
+++ b/contracts/test/integration/governance/PodFactory.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {ControllerV1} from "@orcaprotocol/contracts/contracts/ControllerV1.sol";
+import {MemberToken} from "@orcaprotocol/contracts/contracts/MemberToken.sol";
 import {IGnosisSafe} from "../../../pods/interfaces/IGnosisSafe.sol";
 import {PodFactory} from "../../../pods/PodFactory.sol";
 import {PodExecutor} from "../../../pods/PodExecutor.sol";
@@ -31,7 +32,7 @@ contract PodFactoryIntegrationTest is DSTest {
 
     address core = MainnetAddresses.CORE;
     address memberToken = MainnetAddresses.MEMBER_TOKEN;
-    address podController = MainnetAddresses.POD_CONTROLLER;
+    address podController = MainnetAddresses.ORCA_POD_CONTROLLER_V1_2;
     address feiDAOTimelock = MainnetAddresses.FEI_DAO_TIMELOCK;
 
     function setUp() public {
@@ -69,6 +70,7 @@ contract PodFactoryIntegrationTest is DSTest {
         assertEq(address(factory.podExecutor()), address(podExecutor));
         assertEq(address(factory.getMemberToken()), memberToken);
         assertEq(factory.MIN_TIMELOCK_DELAY(), 1 days);
+        assertEq(address(factory.defaultPodController()), podController);
 
         address[] memory podSafeAddresses = factory.getPodSafeAddresses();
         assertEq(podSafeAddresses.length, 0);
@@ -405,5 +407,64 @@ contract PodFactoryIntegrationTest is DSTest {
 
         assertTrue(timelockContract.isOperationDone(txHash));
         assertEq(dummyContract.getVariable(), newDummyContractVar);
+    }
+
+    /// @notice Validate that the default pod controller can be updated
+    function testUpdateDefaultPodController() public {
+        address newDefaultPodController = address(0x123);
+        vm.prank(feiDAOTimelock);
+        factory.updateDefaultPodController(newDefaultPodController);
+        assertEq(
+            address(factory.defaultPodController()),
+            newDefaultPodController
+        );
+    }
+
+    /// @notice Validate that a pod controller can be updated and that will be reflected
+    ///         on the pod factory
+    function testPodControllerUpdate() public {
+        IPodFactory.PodConfig memory podConfig = getPodParamsWithTimelock(
+            podAdmin
+        );
+
+        // Set default to old version, to create pod with old controller
+        vm.prank(feiDAOTimelock);
+        factory.updateDefaultPodController(
+            MainnetAddresses.ORCA_POD_CONTROLLER_V1
+        );
+        assertEq(
+            address(factory.defaultPodController()),
+            MainnetAddresses.ORCA_POD_CONTROLLER_V1
+        );
+
+        vm.prank(feiDAOTimelock);
+        (uint256 podId, address timelock, address safe) = factory
+            .deployCouncilPod(podConfig);
+
+        // 1. Get pod controller
+        address defaultPodController = address(factory.defaultPodController());
+        address initialPodController = address(factory.getPodController(podId));
+        assertEq(defaultPodController, initialPodController);
+
+        // 2. Pod migrates it's own pod controller to another minor version
+        vm.prank(safe);
+        ControllerV1(initialPodController).migratePodController(
+            podId,
+            MainnetAddresses.ORCA_POD_CONTROLLER_V1_2,
+            MainnetAddresses.ORCA_POD_CONTROLLER_V1_2
+        );
+
+        // 3. Verify pod's controller was updated on the memberToken and factory
+        address newPodControllerOnFactory = address(
+            factory.getPodController(podId)
+        );
+        address expectedNewPodController = MemberToken(memberToken)
+            .memberController(podId);
+
+        assertEq(expectedNewPodController, newPodControllerOnFactory);
+        assertEq(
+            newPodControllerOnFactory,
+            MainnetAddresses.ORCA_POD_CONTROLLER_V1_2
+        );
     }
 }

--- a/contracts/test/integration/governance/PodFactory.t.sol
+++ b/contracts/test/integration/governance/PodFactory.t.sol
@@ -41,8 +41,8 @@ contract PodFactoryIntegrationTest is DSTest {
         // 1. Deploy pod factory
         factory = new PodFactory(
             core,
-            podController,
             memberToken,
+            podController,
             address(podExecutor)
         );
 
@@ -50,7 +50,6 @@ contract PodFactoryIntegrationTest is DSTest {
         PodAdminGateway podAdminGateway = new PodAdminGateway(
             core,
             memberToken,
-            podController,
             address(factory)
         );
         podAdmin = address(podAdminGateway);
@@ -66,7 +65,6 @@ contract PodFactoryIntegrationTest is DSTest {
 
     /// @notice Validate initial factory state
     function testInitialState() public {
-        assertEq(address(factory.podController()), podController);
         assertEq(factory.getNumberOfPods(), 0);
         assertEq(address(factory.podExecutor()), address(podExecutor));
         assertEq(address(factory.getMemberToken()), memberToken);
@@ -111,6 +109,11 @@ contract PodFactoryIntegrationTest is DSTest {
         address[] memory podSafeAddresses = factory.getPodSafeAddresses();
         assertEq(podSafeAddresses.length, 1);
         assertEq(podSafeAddresses[0], councilSafe);
+
+        assertEq(
+            address(factory.getPodController(councilPodId)),
+            podController
+        );
     }
 
     function testCanOnlyDeployGenesisOnce() public {

--- a/proposals/dao/fip_82.ts
+++ b/proposals/dao/fip_82.ts
@@ -53,8 +53,8 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
   const podFactoryEthersFactory = await ethers.getContractFactory('PodFactory');
   const podFactory = await podFactoryEthersFactory.deploy(
     addresses.core, // core
-    addresses.orcaPodController, // podController
     addresses.orcaMemberToken, // podMembershipToken
+    addresses.orcaPodController, // podController
     podExecutor.address // Public pod executor
   );
   await podFactory.deployTransaction.wait();
@@ -64,7 +64,6 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
   const podAdminGateway = await podAdminGatewayFactory.deploy(
     addresses.core,
     addresses.orcaMemberToken,
-    addresses.orcaPodController,
     podFactory.address
   );
   await podAdminGateway.deployTransaction.wait();


### PR DESCRIPTION
# Summary
Adds support for allowing pods to upgrade their own controller versions. 

In the Orca protocol, pods are able to upgrade their own controller. Currently we would not fully support this as the factory is based on a hard coded initial pod controller set at deploy time. 

This PR updates the factory to instead get the relevant pod's controller at run time, by using the member token as the source of truth (this never changes). It means that we now support pods being able to upgrade to a newer pod version to take account of upgrade features. 

We still do not support any new admin features, as the pod admins are set immutably to a `PodAdminGateway` contract. This is okay for our purposes as we have all admin functionality we require already - add member, remove member, lock and unlock.