### PR TITLE
Remove var names from FIP script function calls

### DIFF
--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -182,15 +182,15 @@ const fip_82: ProposalDescription = {
   The Ethereum addresses of the 9 elected members are:
   
   [
-    '0xc8eefb8b3d50ca87Da7F99a661720148acf97EfA',
-    '0x72b7448f470D07222Dbf038407cD69CC380683F3',
-    '0xA6D08774604d6Da7C96684ca6c4f61f89c4e5b96',
-    '0xe0ac4559739bD36f0913FB0A3f5bFC19BCBaCD52',
-    '0xC2138f77E97A9Ac0A4bC26F42D80D29D1a091866',
-    '0x9f5e6F58CC8823D3c022AeBE3942EeF689E9AcD9',
-    '0xaB339ae6eab3C3CF4f5885E56F7B49391a01DDA6',
-    '0xd90E9181B20D8D1B5034d9f5737804Da182039F6',
-    '0x7671f0615B1764fb4bf4b8dF06B7338843f99678'
+    '0xc8eefb8b3d50ca87Da7F99a661720148acf97EfA', - Brianna Montgomery
+    '0x72b7448f470D07222Dbf038407cD69CC380683F3', - Fishy
+    '0xA6D08774604d6Da7C96684ca6c4f61f89c4e5b96', - Bruno Rodrigues
+    '0xe0ac4559739bD36f0913FB0A3f5bFC19BCBaCD52', - Joey Santoro
+    '0xC2138f77E97A9Ac0A4bC26F42D80D29D1a091866', - Jack Lipstone
+    '0x9f5e6F58CC8823D3c022AeBE3942EeF689E9AcD9', - Jack Longarzo
+    '0xaB339ae6eab3C3CF4f5885E56F7B49391a01DDA6', - State
+    '0xd90E9181B20D8D1B5034d9f5737804Da182039F6', - OneTrueKirk
+    '0x7671f0615B1764fb4bf4b8dF06B7338843f99678'  - Freddie Farmer
   ]
 
   There will be a second DAO vote to transfer various protocol roles to the TribalCouncil pod and to make it the admin of various roles - to allow it to 

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -128,7 +128,7 @@ const fip_82: ProposalDescription = {
     {
       target: 'podAdminGateway',
       values: '0',
-      method: 'batchAddPodMember(uint256 _podId,address[] memory _members)',
+      method: 'batchAddPodMember(uint256,address[])',
       arguments: [
         '25',
         [
@@ -148,7 +148,7 @@ const fip_82: ProposalDescription = {
     {
       target: 'podAdminGateway',
       values: '0',
-      method: 'batchRemovePodMember(uint256 _podId, address[] memory)',
+      method: 'batchRemovePodMember(uint256,address[])',
       arguments: [
         '25',
         [
@@ -168,24 +168,22 @@ const fip_82: ProposalDescription = {
     {
       target: 'podAdminGateway',
       values: '0',
-      method: 'lockMembershipTransfers(uint256 _podId)',
+      method: 'lockMembershipTransfers(uint256)',
       arguments: ['25'],
       description: 'Lock TribalCouncil membership transfers'
     }
   ],
   description: `
-  FIP-82 enacts the governance upgrade to the TRIBE DAO and deploys the TribalCouncil pod. Specifically, this FIP will:
-  1. Deploy the relevant contracts for the Governance upgrade: PodFactory.sol, GovernanceMetadataRegistry.sol, PodAdminGateway.sol,
-  RoleBastion.sol, NopeDAO.sol, PodExecutor.sol
-  2. Create and grant the relevant new roles for the pod system
-  3. Initialise the membership of the Tribal Council, as accordig to the members who were elected in the Snapshot vote:
+  FIP-82 enacts the first stage of the governance upgrade to the TRIBE DAO and configures the TribalCouncil pod. Specifically, this FIP will:
+  1. Create and grant the relevant new roles for the TribalCouncil and pod based governance system
+  2. Install the 9 members of the TribalCouncil who were previously elected by the community in the Snapshot vote:
   https://snapshot.fei.money/#/proposal/0x003adc2cb0f13784645e31440d24d0364817085aa1994e1ad72944d11bedb528 
-
-  Forum post for the Governance upgrade: https://tribe.fei.money/t/fip-82-governance-enhancements/3945
-  Snapshot vote authorising the upgrade: https://snapshot.fei.money/#/proposal/0x463fd1be98d9e86c83eb845ca7e2a5555387e3c86ca0b756aada17a11df87f2b
 
   There will be a second DAO vote to transfer various protocol roles to the TribalCouncil pod and to make it the admin of various roles - to allow it to 
   operate the protocol.
+
+  Forum post for the Governance upgrade: https://tribe.fei.money/t/fip-82-governance-enhancements/3945
+  Snapshot vote authorising the upgrade: https://snapshot.fei.money/#/proposal/0x463fd1be98d9e86c83eb845ca7e2a5555387e3c86ca0b756aada17a11df87f2b
   `
 };
 

--- a/proposals/description/fip_82.ts
+++ b/proposals/description/fip_82.ts
@@ -179,6 +179,20 @@ const fip_82: ProposalDescription = {
   2. Install the 9 members of the TribalCouncil who were previously elected by the community in the Snapshot vote:
   https://snapshot.fei.money/#/proposal/0x003adc2cb0f13784645e31440d24d0364817085aa1994e1ad72944d11bedb528 
 
+  The Ethereum addresses of the 9 elected members are:
+  
+  [
+    '0xc8eefb8b3d50ca87Da7F99a661720148acf97EfA',
+    '0x72b7448f470D07222Dbf038407cD69CC380683F3',
+    '0xA6D08774604d6Da7C96684ca6c4f61f89c4e5b96',
+    '0xe0ac4559739bD36f0913FB0A3f5bFC19BCBaCD52',
+    '0xC2138f77E97A9Ac0A4bC26F42D80D29D1a091866',
+    '0x9f5e6F58CC8823D3c022AeBE3942EeF689E9AcD9',
+    '0xaB339ae6eab3C3CF4f5885E56F7B49391a01DDA6',
+    '0xd90E9181B20D8D1B5034d9f5737804Da182039F6',
+    '0x7671f0615B1764fb4bf4b8dF06B7338843f99678'
+  ]
+
   There will be a second DAO vote to transfer various protocol roles to the TribalCouncil pod and to make it the admin of various roles - to allow it to 
   operate the protocol.
 


### PR DESCRIPTION
# Summary

## Function call names
Removes the variable names from the FIP_82 var function calls. Do not believe this is necessarily needed as the compiler will generate the calldata from the function signature, but I think it's better practice and more in keeping with how other FIP scripts are run. 

The FIP script also fails in debug mode with the var names in.

## FIP description
Updates the FIP description for Tally and adds the names of those elected to the council member addresses being added