### PR TITLE
Accounting Update

### DIFF
--- a/contracts/oracle/BalancerWeightedPoolOracle.sol
+++ b/contracts/oracle/BalancerWeightedPoolOracle.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+import "./IOracle.sol";
+import "../Constants.sol";
+import "../external/Decimal.sol";
+import "../external/gyro/ExtendedMath.sol";
+import "../external/gyro/abdk/ABDKMath64x64.sol";
+import "../pcv/balancer/IVault.sol";
+import "../pcv/balancer/IWeightedPool.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title BalancerWeightedPoolOracle
+/// @author eswak
+/// @notice a contract to report the USD value of a Balancer Pool Tokens (LP tokens).
+contract BalancerWeightedPoolOracle is IOracle {
+    using ExtendedMath for *;
+    using ABDKMath64x64 for *;
+    using SafeMath for *;
+    using Decimal for Decimal.D256;
+
+    /// @notice the Balancer V2 Vault
+    IVault public immutable balancerVault;
+
+    /// @notice the Balancer pool to look at
+    IWeightedPool public immutable balancerPool;
+    bytes32 public immutable balancerPoolId;
+
+    /// @notice the pool tokens (in order)
+    IERC20[] public tokens;
+    /// @notice the oracle for pool tokens (in order)
+    IOracle[] public oracles;
+
+    constructor(IWeightedPool _pool, IOracle[] memory _oracles) {
+        balancerPool = _pool;
+        oracles = _oracles;
+
+        balancerVault = _pool.getVault();
+        balancerPoolId = _pool.getPoolId();
+        (tokens, , ) = balancerVault.getPoolTokens(balancerPoolId);
+    }
+
+    /// @notice update underlying token oracles
+    function update() external override {
+        for (uint256 i = 0; i < oracles.length; i++) {
+            oracles[i].update();
+        }
+    }
+
+    /// @notice returns true if one of the underlying oracles are outdated
+    function isOutdated() external view override returns (bool outdated) {
+        for (uint256 i = 0; i < oracles.length; i++) {
+            if (oracles[i].isOutdated()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function read() public view override returns (Decimal.D256 memory, bool) {
+        return (_getBPTPrice(), true);
+    }
+
+    /**
+     * Calculates the value of Balancer pool tokens using the logic described here:
+     * https://docs.gyro.finance/learn/oracles/bpt-oracle
+     * This is robust to price manipulations within the Balancer pool.
+     * Courtesy of Gyroscope protocol, used with permission. See the original file here :
+     * https://github.com/gyrostable/core/blob/master/contracts/GyroPriceOracle.sol#L109-L167
+     * @return bptPrice the price of balancer pool tokens, in USD.
+     */
+    function _getBPTPrice() internal view returns (Decimal.D256 memory bptPrice) {
+        uint256 _bptSupply = balancerPool.totalSupply();
+        uint256[] memory _weights = balancerPool.getNormalizedWeights();
+        (, uint256[] memory _balances, ) = balancerVault.getPoolTokens(balancerPoolId);
+
+        uint256 _k = uint256(1e18);
+        uint256 _weightedProd = uint256(1e18);
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            uint256 _tokenBalance = _balances[i];
+            uint256 _decimals = ERC20(address(tokens[i])).decimals();
+            require(_decimals <= 18, "BalancerWeightedPoolOracle: invalid decimals"); // should never happen
+            if (_decimals < 18) {
+                _tokenBalance = _tokenBalance.mul(10**(18 - _decimals));
+            }
+
+            // if one of the tokens in the pool has zero balance, there is a problem
+            // in the pool, so we return zero
+            if (_tokenBalance == 0) {
+                return Decimal.zero();
+            }
+
+            _k = _k.mulPow(_tokenBalance, _weights[i], 18);
+
+            // read oracle
+            (Decimal.D256 memory oracleValue, bool oracleValid) = oracles[i].read();
+            require(oracleValid, "BPTOracle: invalid oracle");
+            uint256 underlyingPrice = oracleValue.mul(1e18).asUint256();
+            if (_decimals < 18) {
+                underlyingPrice = underlyingPrice * 10**(18 - _decimals);
+            }
+
+            _weightedProd = _weightedProd.mulPow(underlyingPrice.scaledDiv(_weights[i], 18), _weights[i], 18);
+        }
+
+        uint256 result = _k.scaledMul(_weightedProd).scaledDiv(_bptSupply);
+        return Decimal.from(result).div(1e18);
+    }
+}

--- a/contracts/oracle/CurvePoolOracle.sol
+++ b/contracts/oracle/CurvePoolOracle.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+import "./IOracle.sol";
+import "../external/Decimal.sol";
+import "../pcv/curve/ICurveStableSwap3.sol";
+
+/// @title CurvePoolOracle
+/// @author eswak
+/// @notice a contract to report the USD value of a Curve Plain Pool's tokens (LP tokens).
+/// @dev Do not deploy this oracle for pools where ETH or an ERC777/ERC677/ERC223 token
+/// is used and is not the last asset, as there could be an oracle manipulation on the
+/// call to get_virtual_price().
+contract CurvePoolOracle is IOracle {
+    using Decimal for Decimal.D256;
+
+    /// @notice the Curve pool to look at
+    ICurveStableSwap3 public immutable curvePool;
+
+    /// @notice the oracle for pool tokens (it's a stableswap, all tokens have the same value)
+    IOracle public oracle;
+
+    constructor(ICurveStableSwap3 _pool, IOracle _oracle) {
+        curvePool = _pool;
+        oracle = _oracle;
+    }
+
+    /// @notice update underlying token oracle
+    function update() external override {
+        oracle.update();
+    }
+
+    /// @notice returns true if the underlying oracle is outdated
+    function isOutdated() external view override returns (bool outdated) {
+        return oracle.isOutdated();
+    }
+
+    function read() public view override returns (Decimal.D256 memory, bool) {
+        (Decimal.D256 memory oracleValue, bool oracleValid) = oracle.read();
+        uint256 virtualPrice = curvePool.get_virtual_price();
+        return (oracleValue.mul(virtualPrice).div(1e18), oracleValid);
+    }
+}

--- a/proposals/dao/accounting.ts
+++ b/proposals/dao/accounting.ts
@@ -1,0 +1,148 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import {
+  DeployUpgradeFunc,
+  NamedAddresses,
+  NamedContracts,
+  SetupUpgradeFunc,
+  TeardownUpgradeFunc,
+  ValidateUpgradeFunc
+} from '@custom-types/types';
+import { Contract } from 'ethers';
+import { ZERO_ADDRESS, overwriteChainlinkAggregator } from '@test/helpers';
+
+const fipNumber = 'accounting';
+let pcvStatsBefore;
+
+// Do any deployments
+// This should exclusively include new contract deployments
+const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: NamedAddresses, logging: boolean) => {
+  const balancerWeightedPoolOracleFactory = await ethers.getContractFactory('BalancerWeightedPoolOracle');
+  const balancerWeightedPoolOracleFeiWeth = await balancerWeightedPoolOracleFactory.deploy(
+    addresses.balancerFeiWethPool,
+    [
+      addresses.oneConstantOracle, // FEI oracle
+      addresses.chainlinkEthUsdOracleWrapper // WETH oracle
+    ]
+  );
+  logging && console.log('balancerWeightedPoolOracleFeiWeth: ', balancerWeightedPoolOracleFeiWeth.address);
+
+  const curvePoolOracleFactory = await ethers.getContractFactory('CurvePoolOracle');
+  const curvePoolOracleD3 = await curvePoolOracleFactory.deploy(
+    addresses.curveD3pool, // pool to get virtual price from
+    addresses.oneConstantOracle // oracle price for USD stablecoins
+  );
+  logging && console.log('curvePoolOracleD3: ', curvePoolOracleD3.address);
+
+  const convexPCVDepositFactory = await ethers.getContractFactory('ConvexPCVDeposit');
+  const convexPCVDepositD3 = await convexPCVDepositFactory.deploy(
+    addresses.core,
+    addresses.curveD3pool,
+    addresses.convexBooster,
+    addresses.convexD3poolRewards
+  );
+  logging && console.log('convexPCVDepositD3: ', convexPCVDepositD3.address);
+
+  const curvePCVDepositPlainPoolFactory = await ethers.getContractFactory('CurvePCVDepositPlainPool');
+  const curvePCVDepositPlainPoolD3 = await curvePCVDepositPlainPoolFactory.deploy(
+    addresses.core,
+    addresses.curveD3pool,
+    '50' // max 0.5% slippage
+  );
+  logging && console.log('curvePCVDepositPlainPoolD3: ', curvePCVDepositPlainPoolD3.address);
+
+  return {
+    balancerWeightedPoolOracleFeiWeth,
+    curvePoolOracleD3,
+    curvePCVDepositPlainPoolD3,
+    convexPCVDepositD3
+  };
+};
+
+// Do any setup necessary for running the test.
+// This could include setting up Hardhat to impersonate accounts,
+// ensuring contracts have a specific state, etc.
+const setup: SetupUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  console.log(`Setup of ${fipNumber} : reading CR oracle...`);
+
+  // make sure ETH oracle is fresh (for B.AMM not to revert, etc)
+  // Read Chainlink ETHUSD price & override chainlink storage to make it a fresh value
+  const ethPrice = (await contracts.chainlinkEthUsdOracleWrapper.read())[0].toString() / 1e10;
+  await overwriteChainlinkAggregator(addresses.chainlinkEthUsdOracle, Math.round(ethPrice), '8');
+
+  // read pcvStats
+  pcvStatsBefore = await contracts.collateralizationOracle.pcvStats();
+};
+
+// Tears down any changes made in setup() that need to be
+// cleaned up before doing any validation checks.
+const teardown: TeardownUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  console.log(`No actions to complete in teardown for fip${fipNumber}`);
+};
+
+// Run any validations required on the fip using mocha or console logging
+// IE check balances, check state of contracts, etc.
+const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  // assert removals from CR oracle
+  expect(await contracts.collateralizationOracle.depositToToken(addresses.balancerLensBpt30Fei70Weth)).to.be.equal(
+    ZERO_ADDRESS
+  );
+  expect(await contracts.collateralizationOracle.depositToToken(addresses.d3poolConvexPCVDeposit)).to.be.equal(
+    ZERO_ADDRESS
+  );
+  expect(await contracts.collateralizationOracle.depositToToken(addresses.d3poolCurvePCVDeposit)).to.be.equal(
+    ZERO_ADDRESS
+  );
+
+  // assert additions in CR oracle
+  expect(await contracts.collateralizationOracle.depositToToken(addresses.gaugeLensBpt30Fei70WethGauge)).to.be.equal(
+    addresses.balancerFeiWethPool
+  );
+  expect(await contracts.collateralizationOracle.depositToToken(addresses.curvePCVDepositPlainPoolD3)).to.be.equal(
+    addresses.curveD3pool
+  );
+  expect(await contracts.collateralizationOracle.depositToToken(addresses.convexPCVDepositD3)).to.be.equal(
+    addresses.curveD3pool
+  );
+
+  // read FEI/WETH BPT Oracle
+  console.log('----------------------------------------------------');
+  const feiWethOracleRead = await contracts.balancerWeightedPoolOracleFeiWeth.read();
+  console.log('balancerWeightedPoolOracleFeiWeth.read()[0]/1e18', feiWethOracleRead[0] / 1e18);
+  console.log('balancerWeightedPoolOracleFeiWeth.read()[1]', feiWethOracleRead[1]);
+
+  // read D3 Oracle
+  console.log('----------------------------------------------------');
+  const d3OracleRead = await contracts.curvePoolOracleD3.read();
+  console.log('d3OracleRead.read()[0]/1e18', d3OracleRead[0] / 1e18);
+  console.log('d3OracleRead.read()[1]', d3OracleRead[1]);
+
+  // read D3 deposit balances
+  console.log('----------------------------------------------------');
+  console.log(
+    'curvePCVDepositPlainPoolD3.balance()/1e18',
+    (await contracts.curvePCVDepositPlainPoolD3.balance()) / 1e18
+  );
+  console.log('convexPCVDepositD3.balance()/1e18', (await contracts.convexPCVDepositD3.balance()) / 1e18);
+
+  // display pcvStats
+  console.log('----------------------------------------------------');
+  console.log(' pcvStatsBefore.protocolControlledValue [M]e18 ', pcvStatsBefore.protocolControlledValue / 1e24);
+  console.log(' pcvStatsBefore.userCirculatingFei      [M]e18 ', pcvStatsBefore.userCirculatingFei / 1e24);
+  console.log(' pcvStatsBefore.protocolEquity          [M]e18 ', pcvStatsBefore.protocolEquity / 1e24);
+  const pcvStatsAfter = await contracts.collateralizationOracle.pcvStats();
+  console.log('----------------------------------------------------');
+  console.log(' pcvStatsAfter.protocolControlledValue  [M]e18 ', pcvStatsAfter.protocolControlledValue / 1e24);
+  console.log(' pcvStatsAfter.userCirculatingFei       [M]e18 ', pcvStatsAfter.userCirculatingFei / 1e24);
+  console.log(' pcvStatsAfter.protocolEquity           [M]e18 ', pcvStatsAfter.protocolEquity / 1e24);
+  console.log('----------------------------------------------------');
+  const pcvDiff = pcvStatsAfter.protocolControlledValue.sub(pcvStatsBefore.protocolControlledValue);
+  const cFeiDiff = pcvStatsAfter.userCirculatingFei.sub(pcvStatsBefore.userCirculatingFei);
+  const eqDiff = pcvStatsAfter.protocolEquity.sub(pcvStatsBefore.protocolEquity);
+  console.log(' PCV diff                               [M]e18 ', pcvDiff / 1e24);
+  console.log(' Circ FEI diff                          [M]e18 ', cFeiDiff / 1e24);
+  console.log(' Equity diff                            [M]e18 ', eqDiff / 1e24);
+  console.log('----------------------------------------------------');
+};
+
+export { deploy, setup, teardown, validate };

--- a/proposals/description/accounting.ts
+++ b/proposals/description/accounting.ts
@@ -1,0 +1,89 @@
+import { ProposalDescription } from '@custom-types/types';
+
+const accounting: ProposalDescription = {
+  title: 'FIP-82b: Authorise the TribalCouncil with necessary roles',
+  commands: [
+    {
+      target: 'collateralizationOracle',
+      values: '0',
+      method: 'removeDeposits(address[])',
+      arguments: [
+        [
+          '{balancerLensBpt30Fei70Weth}', // old FEI/WETH lens that reports WETH and pFEI
+          '{d3poolConvexPCVDeposit}', // old Convex D3pool that reports "USD" and 1/3rd of FEI
+          '{d3poolCurvePCVDeposit}' // old Curve D3pool that reports "USD" and 1/3rd of FEI
+        ]
+      ],
+      description: 'Remove deprecated Lenses and PCV Deposits'
+    },
+    {
+      target: 'collateralizationOracle',
+      values: '0',
+      method: 'setOracle(address,address)',
+      arguments: [
+        '{balancerFeiWethPool}', // _token
+        '{balancerWeightedPoolOracleFeiWeth}' // _newOracle
+      ],
+      description: 'Set B-70WETH-30FEI Oracle'
+    },
+    {
+      target: 'collateralizationOracle',
+      values: '0',
+      method: 'setOracle(address,address)',
+      arguments: [
+        '{curveD3pool}', // _token
+        '{curvePoolOracleD3}' // _newOracle
+      ],
+      description: 'Set Curve d3pool Oracle'
+    },
+    {
+      target: 'collateralizationOracle',
+      values: '0',
+      method: 'addDeposits(address[])',
+      arguments: [
+        [
+          '{gaugeLensBpt30Fei70WethGauge}', // directly add B-70WETH-30FEI gauge lens
+          '{convexPCVDepositD3}', // updated D3pool Convex PCVDeposit
+          '{curvePCVDepositPlainPoolD3}' // updated D3pool Curve PCVDeposit
+        ]
+      ],
+      description: 'Add new Lenses and PCV Deposits'
+    },
+    {
+      target: 'd3poolConvexPCVDeposit',
+      values: '0',
+      method: 'withdraw(address,uint256)',
+      arguments: [
+        '{convexPCVDepositD3}', // _to
+        '49817687278780155379999541' // 100%
+      ],
+      description: 'Move all D3pool LP tokens to the new Convex PCVDeposit'
+    },
+    {
+      target: 'convexPCVDepositD3',
+      values: '0',
+      method: 'deposit()',
+      arguments: [],
+      description: 'Deposit all D3pool LP tokens in the new Convex PCVDeposit'
+    } /*,
+    {
+      target: 'collateralizationOracle',
+      values: '0',
+      method: 'setOracle(address,address)',
+      arguments: [
+        '{fei}', // _token
+        '{oneConstantOracle}' // _newOracle
+      ],
+      description: 'Set FEI Oracle price to 1$ in COracle'
+    }*/
+  ],
+  description: `
+    Accounting changes :
+
+    - All FEI counts as a liability
+    - FEI in lending markets and AMMs counts as 1$ of PCV
+    - Protocol-owned FEI is only used for PSMs and similar protocol contracts
+  `
+};
+
+export default accounting;

--- a/scripts/utils/simulateTimelockProposal.ts
+++ b/scripts/utils/simulateTimelockProposal.ts
@@ -85,7 +85,7 @@ export async function simulateTimelockProposal(
 }
 
 // Recursively interpolate strings in the argument array
-const replaceArgs = (args: any[], contractNames: NamedAddresses) => {
+export function replaceArgs(args: any[], contractNames: NamedAddresses) {
   const result = [];
   for (let i = 0; i < args.length; i++) {
     const element = args[i];
@@ -99,4 +99,4 @@ const replaceArgs = (args: any[], contractNames: NamedAddresses) => {
     }
   }
   return result;
-};
+}

--- a/test/integration/proposals_config.ts
+++ b/test/integration/proposals_config.ts
@@ -1,6 +1,7 @@
 import { ProposalCategory, ProposalsConfigMap } from '@custom-types/types';
 
 // import fip_xx_proposal from '@proposals/description/fip_xx';
+import accounting from '@proposals/description/accounting';
 
 const proposals: ProposalsConfigMap = {
   /*
@@ -14,6 +15,15 @@ const proposals: ProposalsConfigMap = {
       category: ProposalCategory.DAO
     }
     */
+  accounting: {
+    deploy: true, // deploy flag for whether to run deploy action during e2e tests or use mainnet state
+    totalValue: 0, // amount of ETH to send to DAO execution
+    proposal: accounting, // full proposal file, imported from '@proposals/description/fip_xx.ts'
+    proposalId: null,
+    affectedContractSignoff: [],
+    deprecatedContractSignoff: [],
+    category: ProposalCategory.DEBUG
+  }
 };
 
 export default proposals;


### PR DESCRIPTION
This branch updates how accounting is performed in the CR Oracle.

Suggested change (baseline for the work of this PR, can be updates after further forum discussions) :
- "Protocol-owned FEI" is reserved for contracts that can't make the FEI enter circulation dynamically (only FEI that is pre-minted/unburnt for gas reasons should be accounted as protocol-owned). Examples: PSMs, Lens for OA/TC/DAO Timelock holdings, drippers, buyback pool.
- All other FEI is a liability
  - aFEI, cFEI, fFEI-8, etc, count as 1$ assets, and 1 FEI of liability
  - AMM positions (uniswap LP tokens, BPTs, Curve LP tokens, etc) count at their full value as assets (no protocol-owned FEI reported) and the FEI contained in them is counted as a liability
- No on-chain computation of the "Stable Backing", different reports have different accounting needs

Tasks : 

- [x] Set FEI price in CR oracle to 1$ instead of 0
- Update AMM deposits to report a number of LP tokens
  - [x] Update Balancer deposits to report a number of LP tokens
    - [ ] Unit/Integration test changes
    - [ ] Redeploy `B-70WETH-30FEI` deposit (`balancerDepositBalWeth`)
    - [ ] Redeploy `B-80BAL-20WETH` deposit (`balancerDepositFeiWeth`)
  - [x] Update Curve/Convex deposits to report a number of LP tokens
    - [ ] Unit/Integration test changes
    - [ ] Redeploy `D3 Curve` deposit (`d3poolCurvePCVDeposit`)
    - [ ] Redeploy `D3 Convex` deposit (`d3poolConvexPCVDeposit`)
  - [ ] Update Uniswap deposits to report a number of LP tokens
    - [ ] Unit/Integration test changes
    - [ ] Redeploy `FEI/ETH` deposit (`uniswapPCVDeposit`)
    - [ ] Redeploy `FEI/agEUR` deposit (`agEurUniswapPCVDeposit`)
- Update Lending market deposits to not report FEI as protocol-owned
  - [ ] Update Compound deposits to not report FEI as protocol-owned
    - [ ] Unit/Integration test changes
    - [ ] Redeploy `rariPool8FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `turboFusePCVDeposit` + migrate liquidity to new deposit
    - [ ] Redeploy `convexPoolPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `compoundPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool6FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool79FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool8FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool27FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool128FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool18FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool19FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool24FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool90FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool72FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool22FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool31FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
    - [ ] Redeploy `rariPool25FeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
  - [ ] Update Aave deposits to not report FEI as protocol-owned
    - [ ] Unit/Integration test changes
    - [ ] Redeploy `aaveFeiPCVDeposit` + deprecate wrapper + migrate liquidity to new deposit
- Add new oracles to the CR oracle
  - [x] Add Oracle for Balancer Pool Tokens
    - [ ] Unit / Integration tests
    - [ ] Deploy for `B-70WETH-30FEI` and update CR oracle config
    - [ ] Deploy for `B-80BAL-20WETH` and update CR oracle config
    - [ ] Update CR oracle config of how the veBAL read (`balancerLensVeBalBal`, `balancerLensVeBalWeth`, etc)
  - [x] Add Oracle for Curve LP tokens
    - [ ] Unit / Integration tests
    - [ ] Deploy for `D3` and update CR oracle config
  - [ ] Add Oracle for Uniswap LP tokens
    - [ ] Unit / Integration tests
    - [ ] Deploy for `FEI/agEUR` and update CR oracle config
    - [ ] Deploy for `FEI/ETH` and update CR oracle config
    - [ ] Update CR oracle config of how the gauge stake is read (`uniswapLensAgEurUniswapGauge` etc)

This a good occasion to get rid of most of the "deposit wrappers" that are wrapping PCV Deposits that don't implement the V2 interface.

A good chunk of the PCV / Protocol FEI have to migrate to new contracts. I think this is a good occasion to add stuff like ENS metadata / reverse registry, improve events for offchain analysis, etc. Rethink how PCV is managed & accounted in general. It could take a bit more time, but it's probably worth it, because we're talking about redeploying 20-30 contracts, introducing a significant amount of code changes (oracles), and a large configuration change on the CR Oracle.