### PR TITLE
Generate pod executor calldata

### DIFF
--- a/scripts/utils/constructProposalCalldata.ts
+++ b/scripts/utils/constructProposalCalldata.ts
@@ -94,7 +94,7 @@ function getTimelockCalldata(
 
   // Pod execute calldata
   const podExecutorFunctionFragment = new Interface([
-    'function executeBatch(address timelock,address[] calldata targets,uint256[] calldata values,bytes[] calldata payloads,bytes32 predecessor,bytes32 salt)'
+    'function executeBatch(address timelock,address[] calldata targets,uint256[] calldata values,bytes[] calldata payloads,bytes32 predecessor,bytes32 salt) public'
   ]);
 
   const podExecuteCalldata = podExecutorFunctionFragment.encodeFunctionData('executeBatch', [

--- a/test/integration/setup/index.ts
+++ b/test/integration/setup/index.ts
@@ -175,16 +175,6 @@ export class TestEndtoEndCoordinator implements TestCoordinator {
       );
     }
 
-    if (config.category === ProposalCategory.OA) {
-      this.config.logging && console.log(`Simulating OA proposal...`);
-      await simulateOAProposal(
-        config.proposal,
-        contracts as unknown as MainnetContracts,
-        contractAddresses,
-        this.config.logging
-      );
-    }
-
     if (config.category === ProposalCategory.DEBUG) {
       console.log('Simulating DAO proposal in DEBUG mode (step by step)...');
       console.log('  Title: ', config.proposal.title);

--- a/types/types.ts
+++ b/types/types.ts
@@ -64,7 +64,6 @@ export type DependencyMap = { [key: string]: Dependency };
 export enum ProposalCategory {
   DAO,
   DEBUG,
-  OA,
   TC, // Tribal Council
   DEBUG_TC,
   None


### PR DESCRIPTION
# Summary
Generates pod executor calldata for TC proposals. To generate run:

`DEPLOY_FILE=fip_x npm run calldata`

it will be logged under `Pod Executor Calldata:`

Then send an advanced custom transaction to the `PodExecutorV2: 0xC72e814314e79114354F1682111e07015826080D` with the transaction payload being that calldata. It should execute the relevant transaction

### PR Checklist - Feature (Proposal)

- [ ] All Tests Passing
- [ ] Proposal Added to ProposalsConfig
- [ ] Fork Block Correct
- [ ] Remove Any .only's on Tests
- [ ] Update Documentation If Needed
- [ ] Update Roles Config
- [ ] Proposal Submitted

### PR Checklist - Feature (Non-Proposal) | Bug

- [ ] All Tests Passing
- [ ] Remove Any .only's on Tests

### PR Checklist - Release

- [ ] All Tests Passing
- [ ] Clean/Empty Proposals Config
- [ ] Update Fork Block
- [ ] Update Docs If Needed
