### PR TITLE
Version pcvGuardian, add safe addresses e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
   test:
     working_directory: ~/repo
     executor: nodeimage
-    parallelism: 16
+    parallelism: 17
     steps:
       - attach_workspace:
           at: ./

--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -36,7 +36,7 @@ const MainnetContractsConfig: MainnetContractsConfig = {
     address: '0xC297705Acf50134d256187c754B92FA37826C019',
     category: AddressCategory.Security
   },
-  pcvGuardianV2: {
+  pcvGuardian: {
     artifactName: 'PCVGuardian',
     address: '0x02435948F84d7465FB71dE45ABa6098Fc6eC2993',
     category: AddressCategory.Security

--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -36,7 +36,7 @@ const MainnetContractsConfig: MainnetContractsConfig = {
     address: '0xC297705Acf50134d256187c754B92FA37826C019',
     category: AddressCategory.Security
   },
-  pcvGuardianNew: {
+  pcvGuardianV2: {
     artifactName: 'PCVGuardian',
     address: '0x02435948F84d7465FB71dE45ABa6098Fc6eC2993',
     category: AddressCategory.Security
@@ -1766,7 +1766,7 @@ const MainnetContractsConfig: MainnetContractsConfig = {
     address: '0x1fa69a416bcf8572577d3949b742fbb0a9cd98c7',
     category: AddressCategory.Deprecated
   },
-  pcvGuardian: {
+  pcvGuardianV1: {
     artifactName: 'PCVGuardian',
     address: '0x2D1b1b509B6432A73e3d798572f0648f6453a5D9',
     category: AddressCategory.Deprecated

--- a/protocol-configuration/permissions.ts
+++ b/protocol-configuration/permissions.ts
@@ -5,12 +5,12 @@ export const permissions = {
   PCV_CONTROLLER_ROLE: [
     'feiDAOTimelock',
     'ratioPCVControllerV2',
-    'pcvGuardianNew',
+    'pcvGuardian',
     'daiPCVDripController',
     'ethPSMFeiSkimmer',
     'lusdPSMFeiSkimmer'
   ],
-  GUARDIAN_ROLE: ['guardianMultisig', 'pcvGuardianNew', 'pcvSentinel'],
+  GUARDIAN_ROLE: ['guardianMultisig', 'pcvGuardian', 'pcvSentinel'],
   ORACLE_ADMIN_ROLE: ['tribalCouncilTimelock'],
   SWAP_ADMIN_ROLE: ['pcvEquityMinter', 'tribalCouncilTimelock', 'tribalCouncilSafe'],
   BALANCER_MANAGER_ADMIN_ROLE: [],

--- a/protocol-configuration/safeAddresses.ts
+++ b/protocol-configuration/safeAddresses.ts
@@ -5,7 +5,7 @@ export const safeAddressesConfig: SafeAddressStateConfig = [
   'uniswapPCVDeposit',
   'raiPriceBoundPSM',
   'aaveRaiPCVDeposit',
-  'raiPool9RaiPCVDeposit',
+  'rariPool9RaiPCVDeposit',
   'turboFusePCVDeposit',
   'veBalDelegatorPCVDeposit',
   'balancerDepositFeiWeth',

--- a/protocol-configuration/safeAddresses.ts
+++ b/protocol-configuration/safeAddresses.ts
@@ -1,0 +1,24 @@
+export const safeAddressesConfig: SafeAddressStateConfig = [
+  'ethToDaiLBPSwapper',
+  'balancerGaugeStaker',
+  'dpiToDaiLBPSwapper',
+  'uniswapPCVDeposit',
+  'raiPriceBoundPSM',
+  'aaveRaiPCVDeposit',
+  'raiPool9RaiPCVDeposit',
+  'turboFusePCVDeposit',
+  'veBalDelegatorPCVDeposit',
+  'balancerDepositFeiWeth',
+  'balancerDepositBalWeth',
+  'agEurUniswapPCVDeposit',
+  'd3poolConvexPCVDeposit',
+  'd3poolCurvePCVDeposit',
+  'lusdPSM',
+  'daiFixedPricePSM',
+  'aaveEthPCVDeposit',
+  'ethPSM',
+  'compoundEthPCVDeposit',
+  'feiDAOTimelock'
+];
+
+export type SafeAddressStateConfig = string[];

--- a/test/integration/tests/pcv.ts
+++ b/test/integration/tests/pcv.ts
@@ -81,7 +81,7 @@ describe('e2e-pcv', function () {
 
   describe('PCV Guardian', async () => {
     it('can withdraw PCV and pause', async () => {
-      const pcvGuardian = contracts.pcvGuardianV2;
+      const pcvGuardian = contracts.pcvGuardian;
 
       const amount = await contracts.compoundEthPCVDeposit.balance();
       await pcvGuardian.withdrawToSafeAddress(
@@ -96,7 +96,7 @@ describe('e2e-pcv', function () {
     });
 
     it('can withdraw PCV and pause', async () => {
-      const pcvGuardian = contracts.pcvGuardianV2;
+      const pcvGuardian = contracts.pcvGuardian;
 
       const feiBalanceBefore = await contracts.fei.balanceOf(contractAddresses.feiDAOTimelock);
       await pcvGuardian.withdrawToSafeAddress(

--- a/test/integration/tests/pcv.ts
+++ b/test/integration/tests/pcv.ts
@@ -81,7 +81,7 @@ describe('e2e-pcv', function () {
 
   describe('PCV Guardian', async () => {
     it('can withdraw PCV and pause', async () => {
-      const pcvGuardian = contracts.pcvGuardianNew;
+      const pcvGuardian = contracts.pcvGuardianV2;
 
       const amount = await contracts.compoundEthPCVDeposit.balance();
       await pcvGuardian.withdrawToSafeAddress(
@@ -96,7 +96,7 @@ describe('e2e-pcv', function () {
     });
 
     it('can withdraw PCV and pause', async () => {
-      const pcvGuardian = contracts.pcvGuardianNew;
+      const pcvGuardian = contracts.pcvGuardianV2;
 
       const feiBalanceBefore = await contracts.fei.balanceOf(contractAddresses.feiDAOTimelock);
       await pcvGuardian.withdrawToSafeAddress(

--- a/test/integration/tests/safeAddresses.ts
+++ b/test/integration/tests/safeAddresses.ts
@@ -1,0 +1,62 @@
+import { NamedContracts } from '@custom-types/types';
+import { safeAddressesConfig } from '@protocol/safeAddresses';
+import proposals from '@protocol/proposalsConfig';
+import { TestEndtoEndCoordinator } from '@test/integration/setup';
+import chai, { expect } from 'chai';
+import CBN from 'chai-bn';
+import { solidity } from 'ethereum-waffle';
+import { ethers } from 'hardhat';
+
+describe('e2e-pcv-guardian-safe-addresses', function () {
+  let contracts: NamedContracts;
+  let deployAddress: string;
+  let e2eCoord: TestEndtoEndCoordinator;
+  let doLogging: boolean;
+
+  before(async () => {
+    chai.use(CBN(ethers.BigNumber));
+    chai.use(solidity);
+  });
+
+  before(async function () {
+    // Setup test environment and get contracts
+    const version = 1;
+    deployAddress = (await ethers.getSigners())[0].address;
+    if (!deployAddress) throw new Error(`No deploy address!`);
+
+    doLogging = Boolean(process.env.LOGGING);
+
+    const config = {
+      logging: doLogging,
+      deployAddress: deployAddress,
+      version: version
+    };
+
+    e2eCoord = new TestEndtoEndCoordinator(config, proposals);
+
+    doLogging && console.log(`Loading environment...`);
+    ({ contracts } = await e2eCoord.loadEnvironment());
+    doLogging && console.log(`Environment loaded.`);
+  });
+
+  // If each address in the local config is a safe address and the total number
+  // of safe addresses match up, then by definition safe address state is correct
+  it('should reflect PCV Guardian safe addresses on-chain', async function () {
+    const pcvGuardian = contracts.pcvGuardian;
+    const allAddressesOnChain = await pcvGuardian.getSafeAddresses();
+
+    const numAddressesOnChain = allAddressesOnChain.length;
+    const numAddressesLocally = safeAddressesConfig.length;
+    expect(numAddressesOnChain).to.be.equal(numAddressesLocally, 'Num safe addresses mismatch');
+
+    for (let i = 0; i < safeAddressesConfig.length; i += 1) {
+      const safeAddressContractName = safeAddressesConfig[i];
+
+      // Get the on-chain contract
+      const onChainContract = contracts[safeAddressContractName];
+
+      // Validate is a safe address
+      expect(await pcvGuardian.isSafeAddress(onChainContract.address)).to.be.true;
+    }
+  });
+});

--- a/test/integration/tests/safeAddresses.ts
+++ b/test/integration/tests/safeAddresses.ts
@@ -56,7 +56,10 @@ describe('e2e-pcv-guardian-safe-addresses', function () {
       const onChainContract = contracts[safeAddressContractName];
 
       // Validate is a safe address
-      expect(await pcvGuardian.isSafeAddress(onChainContract.address)).to.be.true;
+      expect(await pcvGuardian.isSafeAddress(onChainContract.address)).to.be.equal(
+        true,
+        'Expected ' + safeAddressContractName + ' to be a safe address'
+      );
     }
   });
 });


### PR DESCRIPTION
# Version pcvGuardian, add safe addresses e2e test

Use a versioning system for the pcvGuardian to avoid mistakes in the future in using the old, deprecated guardian. 

Also add an e2e test and config asserting the state of the safe addresses in the latest active version of the pcvGuardian
