### PR TITLE
Fix (most) forge compilation warnings

### DIFF
--- a/contracts/mock/MockChainlinkOracle.sol
+++ b/contracts/mock/MockChainlinkOracle.sol
@@ -14,9 +14,9 @@ contract MockChainlinkOracle is AggregatorV3Interface {
     uint256 _updatedAt;
     uint80 _answeredInRound;
 
-    constructor(int256 value, uint8 decimals) {
+    constructor(int256 value, uint8 oracleDecimals) {
         _value = value;
-        _decimals = decimals;
+        _decimals = oracleDecimals;
         _roundId = 42;
         _startedAt = 1620651856;
         _updatedAt = 1620651856;

--- a/contracts/mock/MockConvexBaseRewardPool.sol
+++ b/contracts/mock/MockConvexBaseRewardPool.sol
@@ -31,7 +31,10 @@ contract MockConvexBaseRewardPool is MockERC20 {
         getReward(msg.sender, claim);
     }
 
-    function getReward(address who, bool claim) public returns (bool) {
+    function getReward(
+        address who,
+        bool /* claim*/
+    ) public returns (bool) {
         if (rewardAmountPerClaim > 0) {
             rewardToken.mint(who, rewardAmountPerClaim);
         }
@@ -40,6 +43,7 @@ contract MockConvexBaseRewardPool is MockERC20 {
 
     function stakeFor(address who, uint256 amount) public returns (bool) {
         _balances[who] = amount;
+        return true;
     }
 
     function balanceOf(address who) public view override returns (uint256) {

--- a/contracts/mock/MockConvexBooster.sol
+++ b/contracts/mock/MockConvexBooster.sol
@@ -14,7 +14,7 @@ contract MockConvexBooster is MockERC20 {
     }
 
     function deposit(
-        uint256 poolId,
+        uint256, /* poolId*/
         uint256 lpTokens,
         bool stake
     ) public returns (bool) {

--- a/contracts/mock/MockCurve3pool.sol
+++ b/contracts/mock/MockCurve3pool.sol
@@ -21,7 +21,10 @@ contract MockCurve3pool is MockERC20 {
         slippage = _slippage;
     }
 
-    function add_liquidity(uint256[3] memory amounts, uint256 min_mint_amount) public {
+    function add_liquidity(
+        uint256[3] memory amounts,
+        uint256 /* min_mint_amount*/
+    ) public {
         IERC20(coins[0]).transferFrom(msg.sender, address(this), amounts[0]);
         IERC20(coins[1]).transferFrom(msg.sender, address(this), amounts[1]);
         IERC20(coins[2]).transferFrom(msg.sender, address(this), amounts[2]);
@@ -33,7 +36,10 @@ contract MockCurve3pool is MockERC20 {
         return IERC20(coins[i]).balanceOf(address(this));
     }
 
-    function remove_liquidity(uint256 _amount, uint256[3] memory min_amounts) public {
+    function remove_liquidity(
+        uint256 _amount,
+        uint256[3] memory /* min_amounts*/
+    ) public {
         uint256[3] memory amounts;
         amounts[0] = _amount / 3;
         amounts[1] = _amount / 3;
@@ -47,7 +53,7 @@ contract MockCurve3pool is MockERC20 {
     function remove_liquidity_one_coin(
         uint256 _amount,
         int128 i,
-        uint256 min_amount
+        uint256 /* min_amount*/
     ) public {
         uint256 _amountOut = (_amount * (10000 - slippage)) / 10000;
         _amountOut = (_amountOut * 100000) / 100015; // 0.015% fee
@@ -59,7 +65,10 @@ contract MockCurve3pool is MockERC20 {
         return 1000000000000000000;
     }
 
-    function calc_withdraw_one_coin(uint256 _token_amount, int128 i) public view returns (uint256) {
+    function calc_withdraw_one_coin(
+        uint256 _token_amount,
+        int128 /* i*/
+    ) public view returns (uint256) {
         uint256 _amountOut = (_token_amount * (10000 - slippage)) / 10000;
         _amountOut = (_amountOut * 100000) / 100015; // 0.015% fee
         return _amountOut;

--- a/contracts/mock/MockCurveMetapool.sol
+++ b/contracts/mock/MockCurveMetapool.sol
@@ -16,7 +16,10 @@ contract MockCurveMetapool is MockERC20 {
         slippage = _slippage;
     }
 
-    function add_liquidity(uint256[2] memory amounts, uint256 min_mint_amount) public {
+    function add_liquidity(
+        uint256[2] memory amounts,
+        uint256 /* min_mint_amount*/
+    ) public {
         IERC20(coins[0]).transferFrom(msg.sender, address(this), amounts[0]);
         IERC20(coins[1]).transferFrom(msg.sender, address(this), amounts[1]);
         uint256 totalTokens = ((amounts[0] + amounts[1]) * (10000 - slippage)) / 10000;
@@ -27,7 +30,10 @@ contract MockCurveMetapool is MockERC20 {
         return IERC20(coins[i]).balanceOf(address(this));
     }
 
-    function remove_liquidity(uint256 _amount, uint256[2] memory min_amounts) public {
+    function remove_liquidity(
+        uint256 _amount,
+        uint256[2] memory /* min_amounts*/
+    ) public {
         uint256[2] memory amounts;
         amounts[0] = _amount / 2;
         amounts[1] = _amount / 2;
@@ -39,7 +45,7 @@ contract MockCurveMetapool is MockERC20 {
     function remove_liquidity_one_coin(
         uint256 _amount,
         int128 i,
-        uint256 min_amount
+        uint256 /* min_amount*/
     ) public {
         uint256 _amountOut = (_amount * (10000 - slippage)) / 10000;
         _amountOut = (_amountOut * 10000) / 10002; // 0.02% fee
@@ -51,7 +57,10 @@ contract MockCurveMetapool is MockERC20 {
         return 1000000000000000000;
     }
 
-    function calc_withdraw_one_coin(uint256 _token_amount, int128 i) public view returns (uint256) {
+    function calc_withdraw_one_coin(
+        uint256 _token_amount,
+        int128 /* i*/
+    ) public view returns (uint256) {
         uint256 _amountOut = (_token_amount * (10000 - slippage)) / 10000;
         _amountOut = (_amountOut * 10000) / 10002; // 0.02% fee
         return _amountOut;

--- a/contracts/mock/MockERC20PCVDeposit.sol
+++ b/contracts/mock/MockERC20PCVDeposit.sol
@@ -26,12 +26,12 @@ contract MockERC20PCVDeposit is IPCVDeposit {
     }
 
     function withdrawERC20(
-        address token,
+        address _token,
         address to,
         uint256 amount
     ) public override {
-        SafeERC20.safeTransfer(IERC20(token), to, amount);
-        emit WithdrawERC20(msg.sender, to, token, amount);
+        SafeERC20.safeTransfer(IERC20(_token), to, amount);
+        emit WithdrawERC20(msg.sender, to, _token, amount);
     }
 
     function withdrawETH(address payable to, uint256 amountOut) external virtual override {

--- a/contracts/mock/MockERC20UniswapPCVDeposit.sol
+++ b/contracts/mock/MockERC20UniswapPCVDeposit.sol
@@ -19,12 +19,12 @@ contract MockERC20UniswapPCVDeposit is IPCVDeposit {
     }
 
     function withdrawERC20(
-        address token,
+        address _token,
         address to,
         uint256 amount
     ) public override {
-        SafeERC20.safeTransfer(IERC20(token), to, amount);
-        emit WithdrawERC20(msg.sender, to, token, amount);
+        SafeERC20.safeTransfer(IERC20(_token), to, amount);
+        emit WithdrawERC20(msg.sender, to, _token, amount);
     }
 
     function withdrawETH(address payable to, uint256 amountOut) external virtual override {

--- a/contracts/mock/MockEthPCVDeposit.sol
+++ b/contracts/mock/MockEthPCVDeposit.sol
@@ -51,7 +51,7 @@ contract MockEthPCVDeposit is IPCVDeposit {
     }
 
     /// @notice display the related token of the balance reported
-    function balanceReportedIn() public view override returns (address) {
+    function balanceReportedIn() public pure override returns (address) {
         return address(0);
     }
 

--- a/contracts/mock/MockLendingPool.sol
+++ b/contracts/mock/MockLendingPool.sol
@@ -16,7 +16,7 @@ contract MockLendingPool {
         address asset,
         uint256 amount,
         address onBehalfOf,
-        uint16 referralCode
+        uint16 /* referralCode*/
     ) external {
         IERC20(asset).transferFrom(msg.sender, address(this), amount);
         aToken.mint(onBehalfOf, amount);

--- a/contracts/mock/MockMerkleOrchard.sol
+++ b/contracts/mock/MockMerkleOrchard.sol
@@ -15,7 +15,7 @@ contract MockMerkleOrchard is IMerkleOrchard {
     function claimDistributions(
         address claimer,
         Claim[] memory claims,
-        IERC20[] memory tokens
+        IERC20[] memory /* tokens*/
     ) external override {
         balToken.mint(claimer, claims[0].balance);
     }

--- a/contracts/mock/MockRewardsDistributor.sol
+++ b/contracts/mock/MockRewardsDistributor.sol
@@ -70,18 +70,22 @@ contract MockRewardsDistributor is IRewardsDistributorAdmin, Ownable {
 
     /**
      * @notice Set COMP speed for a single market
-     * @param cToken The market whose COMP speed to update
      */
-    function _setCompSupplySpeed(address cToken, uint256 compSpeed) external override onlyOwner {
+    function _setCompSupplySpeed(
+        address, /* cToken*/
+        uint256 compSpeed
+    ) external override onlyOwner {
         compSupplySpeed = compSpeed;
         emit successSetCompSupplySpeed();
     }
 
     /**
      * @notice Set COMP speed for a single market
-     * @param cToken The market whose COMP speed to update
      */
-    function _setCompBorrowSpeed(address cToken, uint256 compSpeed) external override onlyOwner {
+    function _setCompBorrowSpeed(
+        address, /* cToken*/
+        uint256 compSpeed
+    ) external override onlyOwner {
         compBorrowSpeed = compSpeed;
         emit successSetCompBorrowSpeed();
     }
@@ -108,17 +112,19 @@ contract MockRewardsDistributor is IRewardsDistributorAdmin, Ownable {
 
     /**
      * @notice view function to get the comp supply speeds from the rewards distributor contract
-     * @param cToken The market to view
      */
-    function compSupplySpeeds(address cToken) external view override returns (uint256) {
+    function compSupplySpeeds(
+        address /* cToken*/
+    ) external view override returns (uint256) {
         return compSupplySpeed;
     }
 
     /**
      * @notice view function to get the comp borrow speeds from the rewards distributor contract
-     * @param cToken The market to view
      */
-    function compBorrowSpeeds(address cToken) external view override returns (uint256) {
+    function compBorrowSpeeds(
+        address /* cToken*/
+    ) external view override returns (uint256) {
         return compBorrowSpeed;
     }
 

--- a/contracts/mock/MockStEthStableSwap.sol
+++ b/contracts/mock/MockStEthStableSwap.sol
@@ -11,7 +11,7 @@ contract MockStEthStableSwap {
 
     IERC20 public token;
 
-    constructor(address _token1) public {
+    constructor(address _token1) {
         token = IERC20(_token1);
     }
 
@@ -27,7 +27,7 @@ contract MockStEthStableSwap {
 
     function exchange(
         int128 i,
-        int128 j,
+        int128, /* j*/
         uint256 input,
         uint256 min_out
     ) public payable returns (uint256 output) {
@@ -42,8 +42,8 @@ contract MockStEthStableSwap {
     }
 
     function get_dy(
-        int128 i,
-        int128 j,
+        int128, /* i*/
+        int128, /* j*/
         uint256 input
     ) public view returns (uint256 output) {
         output = anti ? (input * (10000 + slippage)) / 10000 : (input * (10000 - slippage)) / 10000;

--- a/contracts/mock/MockStEthToken.sol
+++ b/contracts/mock/MockStEthToken.sol
@@ -8,13 +8,15 @@ contract MockStEthToken is MockERC20 {
     uint256 public totalShares;
     mapping(address => uint256) public shares;
 
-    constructor() public {
+    constructor() {
         pooledEth = 1_000_000e18;
         totalShares = 999_999e18;
         shares[address(msg.sender)] = totalShares;
     }
 
-    function submit(address _referral) external payable returns (uint256 amount_) {
+    function submit(
+        address /* _referral*/
+    ) external payable returns (uint256 amount_) {
         amount_ = msg.value;
 
         uint256 _shares = getSharesByPooledEth(amount_);
@@ -82,7 +84,7 @@ contract MockStEthToken is MockERC20 {
         totalEther_ = pooledEth;
     }
 
-    function getTotalShares() public returns (uint256 totalShares_) {
+    function getTotalShares() public view returns (uint256 totalShares_) {
         totalShares_ = totalShares;
     }
 

--- a/contracts/mock/MockTokemakEthPool.sol
+++ b/contracts/mock/MockTokemakEthPool.sol
@@ -28,7 +28,10 @@ contract MockTokemakEthPool is MockERC20 {
         weth.deposit{value: msg.value}();
     }
 
-    function withdraw(uint256 requestedAmount, bool asEth) external {
+    function withdraw(
+        uint256 requestedAmount,
+        bool /* asEth*/
+    ) external {
         require(requestedWithdrawal[msg.sender] >= requestedAmount, "WITHDRAW_INSUFFICIENT_BALANCE");
         require(weth.balanceOf(address(this)) >= requestedAmount, "INSUFFICIENT_POOL_BALANCE");
         requestedWithdrawal[msg.sender] -= requestedAmount;

--- a/contracts/mock/MockTokemakRewards.sol
+++ b/contracts/mock/MockTokemakRewards.sol
@@ -20,9 +20,9 @@ contract MockTokemakRewards is MockERC20 {
 
     function claim(
         Recipient calldata recipient,
-        uint8 v,
-        bytes32 r,
-        bytes32 s // bytes calldata signature
+        uint8, /* v*/
+        bytes32, /* r*/
+        bytes32 /* s*/ // bytes calldata signature
     ) external {
         rewardsToken.mint(recipient.wallet, recipient.amount);
     }

--- a/contracts/mock/MockTribalChief.sol
+++ b/contracts/mock/MockTribalChief.sol
@@ -20,7 +20,9 @@ contract MockTribalChief {
         totalAllocPoint = _totalAllocPoint;
     }
 
-    function poolInfo(uint256 _index)
+    function poolInfo(
+        uint256 /* _index*/
+    )
         external
         view
         returns (

--- a/contracts/mock/MockVault.sol
+++ b/contracts/mock/MockVault.sol
@@ -37,12 +37,16 @@ contract MockVault {
         TWO_TOKEN
     }
 
-    function getPool(bytes32 poolId) external view returns (address poolAddress, PoolSpecialization poolSpec) {
+    function getPool(
+        bytes32 /* poolId*/
+    ) external view returns (address poolAddress, PoolSpecialization poolSpec) {
         poolAddress = address(_pool);
         poolSpec = PoolSpecialization.TWO_TOKEN;
     }
 
-    function getPoolTokens(bytes32 poolId)
+    function getPoolTokens(
+        bytes32 /* poolId*/
+    )
         external
         view
         returns (
@@ -68,8 +72,8 @@ contract MockVault {
     }
 
     function joinPool(
-        bytes32 poolId,
-        address sender,
+        bytes32, /* poolId*/
+        address, /* sender*/
         address recipient,
         JoinPoolRequest memory request
     ) external payable {
@@ -89,7 +93,7 @@ contract MockVault {
     }
 
     function exitPool(
-        bytes32 poolId,
+        bytes32, /* poolId*/
         address sender,
         address payable recipient,
         ExitPoolRequest memory request

--- a/contracts/test/integration/fixtures/MainnetAddresses.sol
+++ b/contracts/test/integration/fixtures/MainnetAddresses.sol
@@ -36,4 +36,5 @@ library MainnetAddresses {
     address public constant AGEUR = 0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8;
     address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address public constant DAI_FIXED_PRICE_PSM = 0x2A188F9EB761F70ECEa083bA6c2A40145078dfc2;
+    address public constant LUSD_HOLDING_PCV_DEPOSIT = 0x4378De2F2991Fbed6616b34AC7727E7653713712;
 }

--- a/contracts/test/integration/fixtures/Orca.sol
+++ b/contracts/test/integration/fixtures/Orca.sol
@@ -35,7 +35,7 @@ function createPod(
 function setupTimelock(
     address proposer,
     address executor,
-    address core
+    address /* core*/
 ) returns (TimelockController) {
     address[] memory proposers = new address[](1);
     proposers[0] = proposer;

--- a/contracts/test/integration/governance/PodFactory.t.sol
+++ b/contracts/test/integration/governance/PodFactory.t.sol
@@ -72,7 +72,11 @@ contract PodFactoryIntegrationTest is DSTest {
 
     function testDeployGenesisPod() public {
         IPodFactory.PodConfig memory councilConfig = getCouncilPodParams(podAdmin);
-        (uint256 councilPodId, address councilTimelock, address councilSafe) = factory.deployCouncilPod(councilConfig);
+        (
+            uint256 councilPodId, /*address councilTimelock*/
+            ,
+            address councilSafe
+        ) = factory.deployCouncilPod(councilConfig);
 
         uint256 numMembers = factory.getNumMembers(councilPodId);
         assertEq(numMembers, councilConfig.members.length);
@@ -95,7 +99,7 @@ contract PodFactoryIntegrationTest is DSTest {
 
     function testCanOnlyDeployGenesisOnce() public {
         IPodFactory.PodConfig memory councilConfig = getCouncilPodParams(podAdmin);
-        (uint256 councilPodId, address councilTimelock, address genesisSafe) = factory.deployCouncilPod(councilConfig);
+        factory.deployCouncilPod(councilConfig);
 
         IPodFactory.PodConfig memory config = getPodParamsWithTimelock(podAdmin);
         vm.expectRevert(bytes("Genesis pod already deployed"));
@@ -294,7 +298,11 @@ contract PodFactoryIntegrationTest is DSTest {
         assertEq(address(factory.defaultPodController()), MainnetAddresses.ORCA_POD_CONTROLLER_V1);
 
         vm.prank(feiDAOTimelock);
-        (uint256 podId, address timelock, address safe) = factory.deployCouncilPod(podConfig);
+        (
+            uint256 podId, /*address timelock*/
+            ,
+            address safe
+        ) = factory.deployCouncilPod(podConfig);
 
         // 1. Get pod controller
         address defaultPodController = address(factory.defaultPodController());

--- a/contracts/test/integration/pcv/ERC20HoldingPCVDeposit.t.sol
+++ b/contracts/test/integration/pcv/ERC20HoldingPCVDeposit.t.sol
@@ -69,6 +69,6 @@ contract ERC20HoldingPCVDepositIntegrationTest is DSTest {
     /// @notice Validate can not deploy for FEI
     function testCanNotDeployForFei() public {
         vm.expectRevert(bytes("FEI not supported"));
-        ERC20HoldingPCVDeposit feiDeposit = new ERC20HoldingPCVDeposit(address(core), fei);
+        new ERC20HoldingPCVDeposit(address(core), fei);
     }
 }

--- a/contracts/test/integration/sentinel/FuseWithdrawalGuard.t.sol
+++ b/contracts/test/integration/sentinel/FuseWithdrawalGuard.t.sol
@@ -36,7 +36,7 @@ contract FuseWithdrawalGuardIntegrationTest is DSTest, StdLib {
         underlyings[1] = MainnetAddresses.LUSD;
 
         destinations[0] = MainnetAddresses.DAI_PSM;
-        destinations[1] = MainnetAddresses.LUSD_PSM;
+        destinations[1] = MainnetAddresses.LUSD_HOLDING_PCV_DEPOSIT;
 
         liquidityToLeaveList[0] = 100_000e18;
         // make liquidity to leave higher than liquidity in contract
@@ -76,7 +76,7 @@ contract FuseWithdrawalGuardIntegrationTest is DSTest, StdLib {
         guard.setWithdrawInfo(
             MainnetAddresses.RARI_POOL_8_LUSD_PCV_DEPOSIT,
             FuseWithdrawalGuard.WithdrawInfo({
-                destination: MainnetAddresses.LUSD_PSM,
+                destination: MainnetAddresses.LUSD_HOLDING_PCV_DEPOSIT,
                 underlying: MainnetAddresses.LUSD,
                 liquidityToLeave: 0
             })
@@ -84,7 +84,7 @@ contract FuseWithdrawalGuardIntegrationTest is DSTest, StdLib {
         // 4. Check preconditions of LUSD pool 8 withdraw
         assertTrue(guard.check());
         uint256 lusdCTokenBalanceBefore = lusd.balanceOf(MainnetAddresses.RARI_POOL_8_LUSD);
-        uint256 lusdPSMBalanceBefore = lusd.balanceOf(MainnetAddresses.LUSD_PSM);
+        uint256 lusdPSMBalanceBefore = lusd.balanceOf(MainnetAddresses.LUSD_HOLDING_PCV_DEPOSIT);
         assertEq(
             guard.getAmountToWithdraw(ERC20CompoundPCVDeposit(MainnetAddresses.RARI_POOL_8_LUSD_PCV_DEPOSIT)),
             lusdCTokenBalanceBefore
@@ -93,7 +93,10 @@ contract FuseWithdrawalGuardIntegrationTest is DSTest, StdLib {
         // 5. Withdraw from pool 8 LUSD.
         sentinel.protec(address(guard));
         assertEq(lusd.balanceOf(MainnetAddresses.RARI_POOL_8_LUSD), 0);
-        assertEq(lusd.balanceOf(MainnetAddresses.LUSD_PSM), lusdPSMBalanceBefore + lusdCTokenBalanceBefore);
+        assertEq(
+            lusd.balanceOf(MainnetAddresses.LUSD_HOLDING_PCV_DEPOSIT),
+            lusdPSMBalanceBefore + lusdCTokenBalanceBefore
+        );
 
         // 6. Check no more withdrawals
         assertFalse(guard.check());

--- a/contracts/test/unit/governance/NopeDAO.t.sol
+++ b/contracts/test/unit/governance/NopeDAO.t.sol
@@ -13,6 +13,7 @@ import {TribeRoles} from "../../../core/TribeRoles.sol";
 
 /// @notice Fixture to create a dummy proposal
 function createDummyProposal(address dummyContract, uint256 newVariable)
+    pure
     returns (
         address[] memory,
         uint256[] memory,

--- a/contracts/test/unit/governance/PodExecutor.t.sol
+++ b/contracts/test/unit/governance/PodExecutor.t.sol
@@ -91,6 +91,10 @@ contract PodExecutorTest is DSTest {
 
         // 3. Give timelock some ETH to transfer in proposal
         vm.deal(address(timelock), 10 ether);
+
+        // 4. Initialize time to be >1
+        // TimelockController relies on timestamps being at least _DONE_TIMESTAMP (>1)
+        vm.warp(1000);
     }
 
     /// @notice Validate can pause execution

--- a/contracts/test/unit/governance/PodExecutor.t.sol
+++ b/contracts/test/unit/governance/PodExecutor.t.sol
@@ -11,6 +11,7 @@ import {Core} from "../../../core/Core.sol";
 
 /// @notice Fixture to create a dummy proposal. Sends ETH to an address
 function dummyBatchProposals(address[] memory ethReceivers, uint256[] memory amounts)
+    pure
     returns (
         address[] memory,
         uint256[] memory,
@@ -40,6 +41,7 @@ function dummyBatchProposals(address[] memory ethReceivers, uint256[] memory amo
 
 /// @notice Dummy proposal that transfers ETH to a target
 function dummyProposal(address ethReceiver, uint256 amount)
+    pure
     returns (
         address target,
         uint256 value,

--- a/contracts/test/utils/StdLib.sol
+++ b/contracts/test/utils/StdLib.sol
@@ -29,14 +29,17 @@ abstract contract StdLib {
         vm_std_cheats.prank(who);
     }
 
-    function hoax(address who, address origin) public {
+    function hoax(
+        address who,
+        address /* origin*/
+    ) public {
         vm_std_cheats.deal(who, 1 << 128);
         vm_std_cheats.prank(who, who);
     }
 
     function hoax(
         address who,
-        address origin,
+        address, /* origin*/
         uint256 give
     ) public {
         vm_std_cheats.deal(who, give);


### PR DESCRIPTION
This PR fixes most compilation warnings when running `npm run compile` (forge compilation).

Only .sol changes that won't change the contract's bytecode are included.

Most warnings were in Mock contracts or forge test files.

There are a bunch of warnings left during compilation, detailed below : 

- 12 warnings in `node_modules/@orcaprotocol/contracts/....`, not much we can do about it without copying the Solidity in our own repo, so I did not take this decision. Tom notified Orca about it (but it's not a big deal).

- 5 warnings in `WETH9.sol`, it's using an old version of Solidity and uses `this.balance` instead of `address(this).balance` and does not prefix event emissions with the `emit` keyword, but I didn't change because this contract compiles in Solidity 0.4.18

- 1 warning in `PSMRouter.sol` "This contract has a payable fallback function, but no receive ether function. Consider adding a receive ether function.", I did not fix because it would change the bytecode of the contract. PSMRouter is not used anywhere and the only mainnet deployment is deprecated because it's a wrapper above the ETH PSM that is itself deprecated (I'm doing a separate PR to deprecate the `ethPSMRouter`)

- 2 warnings in `FuseGuardian.sol`, I think these are important warnings because the Solidity code does not have the intended behavior and I think this was missed because of all the "warnings pollution" and nobody reading warnings anymore. The functions `_setBorrowPaused` and `_setMintPausedByUnderlying` return booleans, but they always return false, instead of the result of the internal functions. I don't think there's any harm in it, and I did not fix the warnings because it would introduce bytecode changes, but it's definitely not the intended behavior. Reducing the amounts of warnings will allow us to catch this kind of errors in the future.