### PR TITLE
Deprecate ethPSMRouter (the only PSMRouter)

### DIFF
--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -275,7 +275,7 @@ const MainnetContractsConfig: MainnetContractsConfig = {
   ethPSMRouter: {
     artifactName: 'PSMRouter',
     address: '0xFA6a07f3551bF0ceE88D494780ce793AF452Cbca',
-    category: AddressCategory.Peg
+    category: AddressCategory.Deprecated
   },
   tribeReserveStabilizer: {
     artifactName: 'TribeReserveStabilizer',

--- a/test/unit/peg/PSMRouter.test.ts
+++ b/test/unit/peg/PSMRouter.test.ts
@@ -14,7 +14,7 @@ import hre, { ethers } from 'hardhat';
 
 const toBN = ethers.BigNumber.from;
 
-describe('PSM Router', function () {
+describe.skip('PSM Router', function () {
   let userAddress: string;
   let minterAddress: string;
   let psmAdminAddress;


### PR DESCRIPTION
Following the deprecation of the `ethPSM` in TIP-118 (#922), the `ethPSMRouter` can also be deprecated.

The `ethPSMRouter` was the only instance of `PSMRouter` contract deployed, so I also deprecated its hardhat test suite.
