### PR TITLE
cToken number update + solc version update

### DIFF
--- a/contracts/mock/MockRariMerkleRedeemerNoSigs.sol
+++ b/contracts/mock/MockRariMerkleRedeemerNoSigs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.4;
+pragma solidity =0.8.15;
 
 import "../shutdown/fuse/RariMerkleRedeemer.sol";
 

--- a/contracts/shutdown/fuse/MerkleRedeemerDripper.sol
+++ b/contracts/shutdown/fuse/MerkleRedeemerDripper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import {ERC20Dripper} from "../../pcv/utils/ERC20Dripper.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/shutdown/fuse/MultiMerkleRedeemer.sol
+++ b/contracts/shutdown/fuse/MultiMerkleRedeemer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.4;
+pragma solidity =0.8.15;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 

--- a/contracts/shutdown/fuse/RariMerkleRedeemer.sol
+++ b/contracts/shutdown/fuse/RariMerkleRedeemer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "../../refs/CoreRef.sol";
 import "./MultiMerkleRedeemer.sol";

--- a/contracts/shutdown/fuse/RariMerkleRedeemer.sol
+++ b/contracts/shutdown/fuse/RariMerkleRedeemer.sol
@@ -29,9 +29,9 @@ contract RariMerkleRedeemer is MultiMerkleRedeemer, ReentrancyGuard {
     }
 
     /// @param token The token that will be received when exchanging cTokens
-    /// @param cTokens The supported cTokens; must be exactly 27 tokens
-    /// @param rates The exchange rate for each cToken; must be exactly 27 rates
-    /// @param roots The merkle root for each cToken; must be exactly 27 roots
+    /// @param cTokens The supported cTokens; must be exactly 20 tokens
+    /// @param rates The exchange rate for each cToken; must be exactly 20 rates
+    /// @param roots The merkle root for each cToken; must be exactly 20 roots
     constructor(
         address token,
         address[] memory cTokens,
@@ -122,7 +122,7 @@ contract RariMerkleRedeemer is MultiMerkleRedeemer, ReentrancyGuard {
     // The exchange rates provided should represent how much of the base token will be given
     // in exchange for 1e18 cTokens. This increases precision.
     function _configureExchangeRates(address[] memory _cTokens, uint256[] memory _exchangeRates) internal {
-        require(_cTokens.length == 27, "Must provide exactly 27 exchange rates.");
+        require(_cTokens.length == 20, "Must provide exactly 20 exchange rates.");
         require(_cTokens.length == _exchangeRates.length, "Exchange rates must be provided for each cToken");
 
         for (uint256 i = 0; i < _cTokens.length; i++) {
@@ -135,7 +135,7 @@ contract RariMerkleRedeemer is MultiMerkleRedeemer, ReentrancyGuard {
     }
 
     function _configureMerkleRoots(address[] memory _cTokens, bytes32[] memory _roots) internal {
-        require(_cTokens.length == 27, "Must provide exactly 27 merkle roots");
+        require(_cTokens.length == 20, "Must provide exactly 20 merkle roots");
         require(_cTokens.length == _roots.length, "Merkle roots must be provided for each cToken");
 
         for (uint256 i = 0; i < _cTokens.length; i++) {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -107,6 +107,15 @@ export default {
             runs: 200
           }
         }
+      },
+      {
+        version: '0.8.15',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
This PR *does* affect smart contracts.

Two changes.

1) Solidity version: https://github.com/code-423n4/2022-09-tribe-findings/issues/52
2) 27 --> 20 cTokens