### PR TITLE
4) Audit feedback, feiPSM: Silence `minAmountOut`, remove requires

### DIFF
--- a/contracts/peg/SimpleFeiDaiPSM.sol
+++ b/contracts/peg/SimpleFeiDaiPSM.sol
@@ -33,7 +33,7 @@ contract SimpleFeiDaiPSM {
     function mint(
         address to,
         uint256 amountIn,
-        uint256 minAmountOut
+        uint256 // minAmountOut
     ) external returns (uint256 amountFeiOut) {
         amountFeiOut = amountIn;
         DAI.safeTransferFrom(msg.sender, address(this), amountIn);
@@ -47,7 +47,7 @@ contract SimpleFeiDaiPSM {
     function redeem(
         address to,
         uint256 amountFeiIn,
-        uint256 minAmountOut
+        uint256 // minAmountOut
     ) external returns (uint256 amountOut) {
         amountOut = amountFeiIn;
         FEI.safeTransferFrom(msg.sender, address(this), amountFeiIn);

--- a/contracts/peg/SimpleFeiDaiPSM.sol
+++ b/contracts/peg/SimpleFeiDaiPSM.sol
@@ -36,7 +36,6 @@ contract SimpleFeiDaiPSM {
         uint256 minAmountOut
     ) external returns (uint256 amountFeiOut) {
         amountFeiOut = amountIn;
-        require(amountFeiOut >= minAmountOut, "SimpleFeiDaiPSM: Mint not enough out");
         DAI.safeTransferFrom(msg.sender, address(this), amountIn);
         FEI.mint(to, amountFeiOut);
         emit Mint(to, amountIn, amountIn);
@@ -51,7 +50,6 @@ contract SimpleFeiDaiPSM {
         uint256 minAmountOut
     ) external returns (uint256 amountOut) {
         amountOut = amountFeiIn;
-        require(amountOut >= minAmountOut, "SimpleFeiDaiPSM: Redeem not enough out");
         FEI.safeTransferFrom(msg.sender, address(this), amountFeiIn);
         DAI.safeTransfer(to, amountOut);
         emit Redeem(to, amountFeiIn, amountFeiIn);


### PR DESCRIPTION
# Audit feedback, feiPSM: Silence `minAmountOut`, remove requires
Mint/redemption is 1:1 and `minAmountOut` is only there for interface reasons. Can remove the require checks and silence the `minAmountOut` parameter