### PR TITLE
1) Remove test 10M FEI mint 

### DIFF
--- a/proposals/dao/tip_121c.ts
+++ b/proposals/dao/tip_121c.ts
@@ -18,9 +18,6 @@ const fipNumber = 'tip_121c';
 
 let pcvStatsBefore: PcvStats;
 
-// Amount of FEI sudo() script mints to accounts[0], will be subtracted off
-const AMOUNT_FEI_MINTED_BY_E2E = toBN('10000000000000000000000000'); // 10M
-
 /////////////  Tribe Redeemer config
 // Circulating amount of TRIBE, which is redeemable for underlying PCV assets
 const REDEEM_BASE = ethers.constants.WeiPerEther.mul(458_964_340);
@@ -108,9 +105,7 @@ const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts,
     await contracts.fei.balanceOf(addresses.rariInfraFeiTimelock)
   );
 
-  const userCirculatingFeiSupply = (await contracts.fei.totalSupply())
-    .sub(protocolControlledFei)
-    .sub(AMOUNT_FEI_MINTED_BY_E2E);
+  const userCirculatingFeiSupply = (await contracts.fei.totalSupply()).sub(protocolControlledFei);
   const protocolEquity = pcvStatsAfter.protocolControlledValue.sub(userCirculatingFeiSupply) as any;
   console.log('Fei Total supply: ', (await contracts.fei.totalSupply()) / 1e24, '(millions)');
   console.log('Protocol controlled fei: ', protocolControlledFei / 1e24, '(millions)');

--- a/scripts/utils/sudo.ts
+++ b/scripts/utils/sudo.ts
@@ -44,7 +44,4 @@ export async function sudo(contracts: NamedContracts, logging = false): Promise<
   await core.grantPCVController(accounts[0].address);
   await core.grantMinter(accounts[0].address);
   await core.grantBurner(accounts[0].address);
-
-  logging ? console.log('Minting FEI to accounts[0]') : undefined;
-  await fei.mint(accounts[0].address, '10000000000000000000000000');
 }

--- a/test/integration/tests/fei.ts
+++ b/test/integration/tests/fei.ts
@@ -2,12 +2,13 @@ import { Fei } from '@custom-types/contracts';
 import { NamedContracts } from '@custom-types/types';
 import { Signer } from '@ethersproject/abstract-signer';
 import { ProposalsConfig } from '@protocol/proposalsConfig';
-import { ZERO_ADDRESS } from '@test/helpers';
+import { getImpersonatedSigner, ZERO_ADDRESS } from '@test/helpers';
 import { TestEndtoEndCoordinator } from '@test/integration/setup';
 import chai, { expect } from 'chai';
 import CBN from 'chai-bn';
 import { solidity } from 'ethereum-waffle';
 import { ethers } from 'hardhat';
+import { forceEth } from '../setup/utils';
 const toBN = ethers.BigNumber.from;
 
 describe('e2e-fei', function () {
@@ -64,6 +65,10 @@ describe('e2e-fei', function () {
     });
 
     it('burn works', async function () {
+      const feiWhale = '0x9928e4046d7c6513326cCeA028cD3e7a91c7590A';
+      const feiWhaleSigner = await getImpersonatedSigner(feiWhale);
+      await forceEth(feiWhale);
+      await fei.connect(feiWhaleSigner).transfer(deployAddress, 50);
       const balanceBefore = await fei.balanceOf(deployAddress);
       await fei.connect(deploySigner).burn(10);
       const balanceAfter = await fei.balanceOf(deployAddress);


### PR DESCRIPTION
# Remove test 10M FEI mint 
The sudo script called as part of the e2e setup mints 10M FEI to the accounts[0] account. Firstly, this should only be done in the relevant test where that is needed and not globally, but it also affects the PCV accounting in the tests as totalSupply() will be greater than it should be.

This PR removes that FEI minting