### PR TITLE
Update GovernorAlpha.sol: Some Gas Optimizations

### DIFF
--- a/contracts/dao/governor/GovernorAlpha.sol
+++ b/contracts/dao/governor/GovernorAlpha.sol
@@ -219,7 +219,7 @@ contract GovernorAlpha {
         );
         Proposal storage proposal = proposals[proposalId];
         uint256 eta = add256(block.timestamp, timelock.delay());
-        for (uint256 i = 0; i < proposal.targets.length; i++) {
+        for (uint256 i; i < proposal.targets.length; ++i) {
             _queueOrRevert(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], eta);
         }
         proposal.eta = eta;
@@ -247,7 +247,7 @@ contract GovernorAlpha {
         );
         Proposal storage proposal = proposals[proposalId];
         proposal.executed = true;
-        for (uint256 i = 0; i < proposal.targets.length; i++) {
+        for (uint256 i; i < proposal.targets.length; ++i) {
             timelock.executeTransaction{value: proposal.values[i]}(
                 proposal.targets[i],
                 proposal.values[i],
@@ -274,7 +274,7 @@ contract GovernorAlpha {
         );
 
         proposal.canceled = true;
-        for (uint256 i = 0; i < proposal.targets.length; i++) {
+        for (uint256 i; i < proposal.targets.length; ++i) {
             timelock.cancelTransaction(
                 proposal.targets[i],
                 proposal.values[i],


### PR DESCRIPTION
Two types of changes made:

1st: changed `uint256 i = 0;` to `uint256 i;`
Default values of all unsigned integers is always 0. So, there's no need to waste some extra gas in order to initialize any 'uint' variable to 0

2nd: changed `i++` to `++i`
This change won't be messing with code's logic as far as I am concerned. And `++i` is more gas efficient than `++i`

For more details refer this -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#for-loops-improvement